### PR TITLE
Fix fill paints on Android; remove restrictions from ChartView.Adapter

### DIFF
--- a/chart/src/androidMain/kotlin/ChartView.kt
+++ b/chart/src/androidMain/kotlin/ChartView.kt
@@ -79,7 +79,7 @@ public class ChartView @JvmOverloads constructor(
      * will be canceled and a new one will start. This means the current approach is
      * not particularly animation friendly. In the future I'll see if I can improve this.
      */
-    class Adapter<DATA> where DATA : DataSet<*> {
+    class Adapter<DATA> {
 
         /** The chart renderer. */
         var renderer: Renderer<DATA>? = null

--- a/kanvas/build.gradle.kts
+++ b/kanvas/build.gradle.kts
@@ -45,6 +45,8 @@ kotlin {
         val androidTest by getting {
             dependencies {
                 implementation(kotlin("test-junit"))
+                implementation("androidx.test:core:1.3.0")
+                implementation("org.robolectric:robolectric:4.4")
             }
         }
 

--- a/kanvas/src/androidMain/kotlin/AndroidPaint.kt
+++ b/kanvas/src/androidMain/kotlin/AndroidPaint.kt
@@ -27,7 +27,7 @@ public fun Paint.toAndroid(context: Context): AndroidPaint = when (this) {
 }
 
 private fun androidPaint(source: Paint.Fill) = AndroidPaint().apply {
-    style = AndroidPaint.Style.STROKE
+    style = AndroidPaint.Style.FILL
     isAntiAlias = true
     color = source.color.argb
 }

--- a/kanvas/src/androidMain/kotlin/AndroidPaint.kt
+++ b/kanvas/src/androidMain/kotlin/AndroidPaint.kt
@@ -26,6 +26,12 @@ public fun Paint.toAndroid(context: Context): AndroidPaint = when (this) {
     is Paint.Text -> androidPaint(context, this)
 }
 
+/** Converts a Krayon [Paint] into an [AndroidPaint]. */
+public fun Paint.Fill.toAndroid(): AndroidPaint = androidPaint(this)
+
+/** Converts a Krayon [Paint] into an [AndroidPaint]. */
+public fun Paint.Stroke.toAndroid(): AndroidPaint = androidPaint(this)
+
 private fun androidPaint(source: Paint.Fill) = AndroidPaint().apply {
     style = AndroidPaint.Style.FILL
     isAntiAlias = true

--- a/kanvas/src/androidTest/kotlin/AndroidPaintTests.kt
+++ b/kanvas/src/androidTest/kotlin/AndroidPaintTests.kt
@@ -1,0 +1,35 @@
+package com.juul.krayon.kanvas
+
+import androidx.test.core.app.ApplicationProvider
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import android.graphics.Paint as AndroidPaint
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class AndroidPaintTests {
+
+    @Test
+    fun checkFillPaintStyle() {
+        val source = Paint.Fill(Color.black)
+        val dest = source.toAndroid()
+        assertEquals(dest.style, AndroidPaint.Style.FILL)
+    }
+
+    @Test
+    fun checkStrokePaintStyle() {
+        val source = Paint.Stroke(Color.black, width = 1f)
+        val dest = source.toAndroid()
+        assertEquals(dest.style, AndroidPaint.Style.STROKE)
+    }
+
+    @Test
+    fun checkTextPaintStyle() {
+        val source = Paint.Text(Color.black, size = 12f, Paint.Text.Alignment.Center, Font("Times New Roman"))
+        val dest = source.toAndroid(ApplicationProvider.getApplicationContext())
+        assertEquals(dest.style, AndroidPaint.Style.FILL)
+    }
+}


### PR DESCRIPTION
Just a couple of small issues I ran into now that I'm actually consuming this.