### PR TITLE
Split color into its own module

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Multiplatform drawing library. Provides a multiplatform canvas and chart renderi
 | Module             | Description           |
 |--------------------|-----------------------|
 | [`chart`](chart)   | Multiplatform charts. |
+| [`color`](color)   | Multiplatform colors. |
 | [`kanvas`](kanvas) | Multiplatform canvas. |
 
 # License

--- a/chart/src/commonMain/kotlin/render/Defaults.kt
+++ b/chart/src/commonMain/kotlin/render/Defaults.kt
@@ -3,7 +3,15 @@ package com.juul.krayon.chart.render
 import com.juul.krayon.chart.render.components.AxisRenderer
 import com.juul.krayon.chart.render.components.BarRenderer
 import com.juul.krayon.color.Color
+import com.juul.krayon.color.black
+import com.juul.krayon.color.blue
+import com.juul.krayon.color.cyan
 import com.juul.krayon.color.lerp
+import com.juul.krayon.color.lime
+import com.juul.krayon.color.magenta
+import com.juul.krayon.color.red
+import com.juul.krayon.color.white
+import com.juul.krayon.color.yellow
 import com.juul.krayon.kanvas.Font
 import com.juul.krayon.kanvas.Paint
 
@@ -11,7 +19,7 @@ internal fun defaultAxisStyle(
     orientation: Orientation,
 ): AxisRenderer.Style = AxisRenderer.Style(
     orientation,
-    Paint.Stroke(Color.black, 1f, Paint.Stroke.Cap.Square)
+    Paint.Stroke(black, 1f, Paint.Stroke.Cap.Square)
 )
 
 internal fun defaultBarStyle(
@@ -27,16 +35,16 @@ internal fun defaultFont(): Font = Font("sans-serif")
 internal fun defaultIndexLabelFactory() = IndexLabelFactory { null }
 
 internal fun defaultSeriesColors(): Sequence<Color> = sequenceOf(
-    Color.red.lerp(Color.white, 0.375f),
-    Color.green.lerp(Color.white, 0.375f),
-    Color.blue.lerp(Color.white, 0.375f),
-    Color.cyan.lerp(Color.white, 0.375f),
-    Color.magenta.lerp(Color.white, 0.375f),
-    Color.yellow.lerp(Color.white, 0.375f),
-    Color.red.lerp(Color.white, 0.75f),
-    Color.green.lerp(Color.white, 0.75f),
-    Color.blue.lerp(Color.white, 0.75f),
-    Color.cyan.lerp(Color.white, 0.75f),
-    Color.magenta.lerp(Color.white, 0.75f),
-    Color.yellow.lerp(Color.white, 0.75f)
+    lerp(red, white, 0.375f),
+    lerp(lime, white, 0.375f),
+    lerp(blue, white, 0.375f),
+    lerp(cyan, white, 0.375f),
+    lerp(magenta, white, 0.375f),
+    lerp(yellow, white, 0.375f),
+    lerp(red, white, 0.75f),
+    lerp(lime, white, 0.75f),
+    lerp(blue, white, 0.75f),
+    lerp(cyan, white, 0.75f),
+    lerp(magenta, white, 0.75f),
+    lerp(yellow, white, 0.75f)
 )

--- a/chart/src/commonMain/kotlin/render/Defaults.kt
+++ b/chart/src/commonMain/kotlin/render/Defaults.kt
@@ -2,10 +2,10 @@ package com.juul.krayon.chart.render
 
 import com.juul.krayon.chart.render.components.AxisRenderer
 import com.juul.krayon.chart.render.components.BarRenderer
-import com.juul.krayon.kanvas.Color
+import com.juul.krayon.color.Color
+import com.juul.krayon.color.lerp
 import com.juul.krayon.kanvas.Font
 import com.juul.krayon.kanvas.Paint
-import com.juul.krayon.kanvas.lerp
 
 internal fun defaultAxisStyle(
     orientation: Orientation,

--- a/chart/src/commonMain/kotlin/render/components/BarRenderer.kt
+++ b/chart/src/commonMain/kotlin/render/components/BarRenderer.kt
@@ -4,8 +4,8 @@ import com.juul.krayon.chart.data.ClusteredDataSet
 import com.juul.krayon.chart.data.maxValue
 import com.juul.krayon.chart.render.Orientation
 import com.juul.krayon.chart.render.Renderer
+import com.juul.krayon.color.Color
 import com.juul.krayon.kanvas.Clip
-import com.juul.krayon.kanvas.Color
 import com.juul.krayon.kanvas.Kanvas
 import com.juul.krayon.kanvas.Paint
 import com.juul.krayon.kanvas.withClip

--- a/color/README.md
+++ b/color/README.md
@@ -1,0 +1,69 @@
+![badge-android]
+![badge-jvm]
+
+# Color
+
+Multiplatform color
+
+## Setup
+
+### Gradle
+
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.juul.krayon/color/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.juul.krayon/color)
+
+Charts can be configured via Gradle Kotlin DSL as follows:
+
+#### Multiplatform
+
+```kotlin
+plugins {
+    id("com.android.application") // or id("com.android.library")
+    kotlin("multiplatform")
+}
+
+repositories {
+    mavenCentral()
+}
+
+kotlin {
+    android()
+    jvm()
+
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                implementation("com.juul.krayon:color:$version")
+            }
+        }
+    }
+}
+
+android {
+    // ...
+}
+```
+
+#### Platform-specific
+
+```kotlin
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation("com.juul.krayon:color-$platform:$version")
+}
+```
+
+_Where `$platform` represents (should be replaced with) the desired platform dependency (e.g. `jvm`)._
+
+[badge-android]: http://img.shields.io/badge/platform-android-6EDB8D.svg?style=flat
+[badge-ios]: http://img.shields.io/badge/platform-ios-CDCDCD.svg?style=flat
+[badge-js]: http://img.shields.io/badge/platform-js-F8DB5D.svg?style=flat
+[badge-jvm]: http://img.shields.io/badge/platform-jvm-DB413D.svg?style=flat
+[badge-linux]: http://img.shields.io/badge/platform-linux-2D3F6C.svg?style=flat
+[badge-windows]: http://img.shields.io/badge/platform-windows-4D76CD.svg?style=flat
+[badge-mac]: http://img.shields.io/badge/platform-macos-111111.svg?style=flat
+[badge-watchos]: http://img.shields.io/badge/platform-watchos-C0C0C0.svg?style=flat
+[badge-tvos]: http://img.shields.io/badge/platform-tvos-808080.svg?style=flat
+[badge-wasm]: https://img.shields.io/badge/platform-wasm-624FE8.svg?style=flat

--- a/color/api/color.api
+++ b/color/api/color.api
@@ -1,5 +1,4 @@
 public final class com/juul/krayon/color/Color {
-	public static final field Companion Lcom/juul/krayon/color/Color$Companion;
 	public static final synthetic fun box-impl (I)Lcom/juul/krayon/color/Color;
 	public static fun constructor-impl (FFF)I
 	public static fun constructor-impl (FFFF)I
@@ -24,21 +23,156 @@ public final class com/juul/krayon/color/Color {
 	public final synthetic fun unbox-impl ()I
 }
 
-public final class com/juul/krayon/color/Color$Companion {
-	public final fun getBlack-b4wfQcs ()I
-	public final fun getBlue-b4wfQcs ()I
-	public final fun getCyan-b4wfQcs ()I
-	public final fun getGreen-b4wfQcs ()I
-	public final fun getMagenta-b4wfQcs ()I
-	public final fun getRed-b4wfQcs ()I
-	public final fun getTransparent-b4wfQcs ()I
-	public final fun getWhite-b4wfQcs ()I
-	public final fun getYellow-b4wfQcs ()I
+public final class com/juul/krayon/color/OperationsKt {
+	public static final fun lerp-Lm3R1AU (IIF)I
 }
 
-public final class com/juul/krayon/color/ColorKt {
-	public static final fun lerp-Lm3R1AU (IIF)I
+public final class com/juul/krayon/color/RandomKt {
 	public static final fun nextColor (Lkotlin/random/Random;Z)I
 	public static synthetic fun nextColor$default (Lkotlin/random/Random;ZILjava/lang/Object;)I
+}
+
+public final class com/juul/krayon/color/WebColorsKt {
+	public static final fun getAliceBlue ()I
+	public static final fun getAntiqueWhite ()I
+	public static final fun getAqua ()I
+	public static final fun getAquamarine ()I
+	public static final fun getAzure ()I
+	public static final fun getBeige ()I
+	public static final fun getBisque ()I
+	public static final fun getBlack ()I
+	public static final fun getBlanchedAlmond ()I
+	public static final fun getBlue ()I
+	public static final fun getBlueViolet ()I
+	public static final fun getBrown ()I
+	public static final fun getBurlywood ()I
+	public static final fun getCadetBlue ()I
+	public static final fun getChartreuse ()I
+	public static final fun getChocolate ()I
+	public static final fun getCoral ()I
+	public static final fun getCornflowerBlue ()I
+	public static final fun getCornsilk ()I
+	public static final fun getCrimson ()I
+	public static final fun getCyan ()I
+	public static final fun getDarkBlue ()I
+	public static final fun getDarkCyan ()I
+	public static final fun getDarkGoldenrod ()I
+	public static final fun getDarkGray ()I
+	public static final fun getDarkGreen ()I
+	public static final fun getDarkKhaki ()I
+	public static final fun getDarkMagenta ()I
+	public static final fun getDarkOliveGreen ()I
+	public static final fun getDarkOrange ()I
+	public static final fun getDarkOrchid ()I
+	public static final fun getDarkRed ()I
+	public static final fun getDarkSeaGreen ()I
+	public static final fun getDarkSlateBlue ()I
+	public static final fun getDarkSlateGray ()I
+	public static final fun getDarkTurquoise ()I
+	public static final fun getDarkViolet ()I
+	public static final fun getDeepPink ()I
+	public static final fun getDeepSkyBlue ()I
+	public static final fun getDimGray ()I
+	public static final fun getDodgerBlue ()I
+	public static final fun getFirebrick ()I
+	public static final fun getFloralWhite ()I
+	public static final fun getForestGreen ()I
+	public static final fun getFuchsia ()I
+	public static final fun getGainsboro ()I
+	public static final fun getGhostWhite ()I
+	public static final fun getGold ()I
+	public static final fun getGoldenrod ()I
+	public static final fun getGray ()I
+	public static final fun getGreen ()I
+	public static final fun getGreenYellow ()I
+	public static final fun getHoneydew ()I
+	public static final fun getHotPink ()I
+	public static final fun getIndianRed ()I
+	public static final fun getIndigo ()I
+	public static final fun getIvory ()I
+	public static final fun getKhaki ()I
+	public static final fun getLavender ()I
+	public static final fun getLavenderBlush ()I
+	public static final fun getLawnGreen ()I
+	public static final fun getLemonChiffon ()I
+	public static final fun getLightBlue ()I
+	public static final fun getLightCoral ()I
+	public static final fun getLightCyan ()I
+	public static final fun getLightGoldenrodYellow ()I
+	public static final fun getLightGray ()I
+	public static final fun getLightGreen ()I
+	public static final fun getLightPink ()I
+	public static final fun getLightSalmon ()I
+	public static final fun getLightSeaGreen ()I
+	public static final fun getLightSkyBlue ()I
+	public static final fun getLightSlateGray ()I
+	public static final fun getLightSteelBlue ()I
+	public static final fun getLightYellow ()I
+	public static final fun getLime ()I
+	public static final fun getLimeGreen ()I
+	public static final fun getLinen ()I
+	public static final fun getMagenta ()I
+	public static final fun getMaroon ()I
+	public static final fun getMediumAquamarine ()I
+	public static final fun getMediumBlue ()I
+	public static final fun getMediumOrchid ()I
+	public static final fun getMediumPurple ()I
+	public static final fun getMediumSeaGreen ()I
+	public static final fun getMediumSlateBlue ()I
+	public static final fun getMediumSpringGreen ()I
+	public static final fun getMediumTurquoise ()I
+	public static final fun getMediumVioletRed ()I
+	public static final fun getMidnightBlue ()I
+	public static final fun getMintCream ()I
+	public static final fun getMistyRose ()I
+	public static final fun getMoccasin ()I
+	public static final fun getNavajoWhite ()I
+	public static final fun getNavy ()I
+	public static final fun getOldLace ()I
+	public static final fun getOlive ()I
+	public static final fun getOliveDrab ()I
+	public static final fun getOrange ()I
+	public static final fun getOrangeRed ()I
+	public static final fun getOrchid ()I
+	public static final fun getPaleGoldenrod ()I
+	public static final fun getPaleGreen ()I
+	public static final fun getPaleTurquoise ()I
+	public static final fun getPaleVioletRed ()I
+	public static final fun getPapayaWhip ()I
+	public static final fun getPeachPuff ()I
+	public static final fun getPeru ()I
+	public static final fun getPink ()I
+	public static final fun getPlum ()I
+	public static final fun getPowderBlue ()I
+	public static final fun getPurple ()I
+	public static final fun getRebeccaPurple ()I
+	public static final fun getRed ()I
+	public static final fun getRosyBrown ()I
+	public static final fun getRoyalBlue ()I
+	public static final fun getSaddleBrown ()I
+	public static final fun getSalmon ()I
+	public static final fun getSandyBrown ()I
+	public static final fun getSeaGreen ()I
+	public static final fun getSeashell ()I
+	public static final fun getSienna ()I
+	public static final fun getSilver ()I
+	public static final fun getSkyBlue ()I
+	public static final fun getSlateBlue ()I
+	public static final fun getSlateGray ()I
+	public static final fun getSnow ()I
+	public static final fun getSpringGreen ()I
+	public static final fun getSteelBlue ()I
+	public static final fun getTan ()I
+	public static final fun getTeal ()I
+	public static final fun getThistle ()I
+	public static final fun getTomato ()I
+	public static final fun getTransparent ()I
+	public static final fun getTurquoise ()I
+	public static final fun getViolet ()I
+	public static final fun getWheat ()I
+	public static final fun getWhite ()I
+	public static final fun getWhiteSmoke ()I
+	public static final fun getYellow ()I
+	public static final fun getYellowGreen ()I
 }
 

--- a/color/api/color.api
+++ b/color/api/color.api
@@ -1,0 +1,44 @@
+public final class com/juul/krayon/color/Color {
+	public static final field Companion Lcom/juul/krayon/color/Color$Companion;
+	public static final synthetic fun box-impl (I)Lcom/juul/krayon/color/Color;
+	public static fun constructor-impl (FFF)I
+	public static fun constructor-impl (FFFF)I
+	public static fun constructor-impl (I)I
+	public static fun constructor-impl (III)I
+	public static fun constructor-impl (IIII)I
+	public static final fun copy-b4wfQcs (IIIII)I
+	public static synthetic fun copy-b4wfQcs$default (IIIIIILjava/lang/Object;)I
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (ILjava/lang/Object;)Z
+	public static final fun equals-impl0 (II)Z
+	public static final fun getAlpha-impl (I)I
+	public final fun getArgb ()I
+	public static final fun getBlue-impl (I)I
+	public static final fun getGreen-impl (I)I
+	public static final fun getRed-impl (I)I
+	public static final fun getRgb-impl (I)I
+	public fun hashCode ()I
+	public static fun hashCode-impl (I)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (I)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()I
+}
+
+public final class com/juul/krayon/color/Color$Companion {
+	public final fun getBlack-b4wfQcs ()I
+	public final fun getBlue-b4wfQcs ()I
+	public final fun getCyan-b4wfQcs ()I
+	public final fun getGreen-b4wfQcs ()I
+	public final fun getMagenta-b4wfQcs ()I
+	public final fun getRed-b4wfQcs ()I
+	public final fun getTransparent-b4wfQcs ()I
+	public final fun getWhite-b4wfQcs ()I
+	public final fun getYellow-b4wfQcs ()I
+}
+
+public final class com/juul/krayon/color/ColorKt {
+	public static final fun lerp-Lm3R1AU (IIF)I
+	public static final fun nextColor (Lkotlin/random/Random;Z)I
+	public static synthetic fun nextColor$default (Lkotlin/random/Random;ZILjava/lang/Object;)I
+}
+

--- a/color/build.gradle.kts
+++ b/color/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
+    // Android plugin must be before multiplatform plugin until https://youtrack.jetbrains.com/issue/KT-34038 is fixed.
     id("com.android.library")
     kotlin("multiplatform")
     id("org.jmailen.kotlinter")

--- a/color/build.gradle.kts
+++ b/color/build.gradle.kts
@@ -23,7 +23,6 @@ kotlin {
 
         val commonMain by getting {
             dependencies {
-                api(project(":color"))
                 implementation(kotlin("stdlib"))
             }
         }
@@ -31,23 +30,14 @@ kotlin {
         val commonTest by getting {
             dependencies {
                 implementation(tuulbox.test())
-                implementation(kotlin("reflect"))
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
-            }
-        }
-
-        val androidMain by getting {
-            dependencies {
-                implementation("androidx.appcompat:appcompat:1.2.0")
             }
         }
 
         val androidTest by getting {
             dependencies {
                 implementation(kotlin("test-junit"))
-                implementation("androidx.test:core:1.3.0")
-                implementation("org.robolectric:robolectric:4.5.1")
             }
         }
 

--- a/color/gradle.properties
+++ b/color/gradle.properties
@@ -1,0 +1,1 @@
+POM_ARTIFACT_ID=color

--- a/color/src/androidMain/AndroidManifest.xml
+++ b/color/src/androidMain/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="com.juul.krayon.color" />

--- a/color/src/commonMain/kotlin/Color.kt
+++ b/color/src/commonMain/kotlin/Color.kt
@@ -1,4 +1,4 @@
-package com.juul.krayon.kanvas
+package com.juul.krayon.color
 
 import kotlin.math.roundToInt
 import kotlin.random.Random

--- a/color/src/commonMain/kotlin/Color.kt
+++ b/color/src/commonMain/kotlin/Color.kt
@@ -1,22 +1,6 @@
 package com.juul.krayon.color
 
 import kotlin.math.roundToInt
-import kotlin.random.Random
-
-private const val COMPONENT_MASK = 0xFF
-private const val RGB_MASK = 0xFFFFFF
-
-private const val ALPHA_SHIFT = 24
-private const val RED_SHIFT = 16
-private const val GREEN_SHIFT = 8
-private const val BLUE_SHIFT = 0
-
-private val FLOAT_COMPONENT_RANGE = 0f..1f
-
-private fun requireInRange(float: Float): Float {
-    require(float in FLOAT_COMPONENT_RANGE)
-    return float
-}
 
 /** A color in ARGB color space. */
 public inline class Color(public val argb: Int) {
@@ -24,42 +8,39 @@ public inline class Color(public val argb: Int) {
     /** Create a color from component integers. Components are masked to their last eight bits. */
     public constructor(alpha: Int, red: Int, green: Int, blue: Int) :
         this(
-            ((alpha and COMPONENT_MASK) shl ALPHA_SHIFT) or
-                ((red and COMPONENT_MASK) shl RED_SHIFT) or
-                ((green and COMPONENT_MASK) shl GREEN_SHIFT) or
-                ((blue and COMPONENT_MASK) shl BLUE_SHIFT)
+            ((alpha and MASK_COMPONENT) shl SHIFT_ALPHA) or
+                ((red and MASK_COMPONENT) shl SHIFT_RED) or
+                ((green and MASK_COMPONENT) shl SHIFT_GREEN) or
+                ((blue and MASK_COMPONENT) shl SHIFT_BLUE)
         )
 
     /** Create an opaque color from component integers. Components are masked to their last eight bits. */
     public constructor(red: Int, green: Int, blue: Int) :
-        this(alpha = 0xFF, red, green, blue)
+        this(alpha = COMPONENT_MAX, red, green, blue)
 
     /** Create a color from component floats. Components are multiplied by 255 and rounded. */
     public constructor(alpha: Float, red: Float, green: Float, blue: Float) : this(
-        (requireInRange(alpha) * 0xFF).roundToInt(),
-        (requireInRange(red) * 0xFF).roundToInt(),
-        (requireInRange(green) * 0xFF).roundToInt(),
-        (requireInRange(blue) * 0xFF).roundToInt()
+        alpha.toColorComponent(), red.toColorComponent(), green.toColorComponent(), blue.toColorComponent()
     )
 
     /** Create an opaque color from component floats. Components are multiplied by 255 and rounded. */
     public constructor(red: Float, green: Float, blue: Float) :
-        this(alpha = 1f, red, green, blue)
+        this(alpha = FLOAT_COMPONENT_MAX, red, green, blue)
 
     /** Gets the alpha component of this color as an eight bit integer. */
-    public val alpha: Int get() = (argb ushr ALPHA_SHIFT) and COMPONENT_MASK
+    public val alpha: Int get() = (argb ushr SHIFT_ALPHA) and MASK_COMPONENT
 
     /** Gets the red component of this color as an eight bit integer. */
-    public val red: Int get() = (argb ushr RED_SHIFT) and COMPONENT_MASK
+    public val red: Int get() = (argb ushr SHIFT_RED) and MASK_COMPONENT
 
     /** Gets the green component of this color as an eight bit integer. */
-    public val green: Int get() = (argb ushr GREEN_SHIFT) and COMPONENT_MASK
+    public val green: Int get() = (argb ushr SHIFT_GREEN) and MASK_COMPONENT
 
     /** Gets the blue component of this color as an eight bit integer. */
-    public val blue: Int get() = (argb ushr BLUE_SHIFT) and COMPONENT_MASK
+    public val blue: Int get() = (argb ushr SHIFT_BLUE) and MASK_COMPONENT
 
     /** Gets the rgb component of this color as a 24 bit integer. */
-    public val rgb: Int get() = argb and RGB_MASK
+    public val rgb: Int get() = argb and MASK_RGB
 
     /** Creates a copy of this color. */
     public fun copy(
@@ -69,34 +50,10 @@ public inline class Color(public val argb: Int) {
         blue: Int = this.blue,
     ): Color = Color(alpha, red, green, blue)
 
-    override fun toString(): String = "Color(${argb.toString(16).padStart(8, '0')})"
-
-    public companion object {
-        public val transparent: Color = Color(0x00, 0x00, 0x00, 0x00)
-
-        public val black: Color = Color(0x00, 0x00, 0x00)
-        public val white: Color = Color(0xFF, 0xFF, 0xFF)
-
-        public val red: Color = Color(0xFF, 0x00, 0x00)
-        public val green: Color = Color(0x00, 0xFF, 0x00)
-        public val blue: Color = Color(0x00, 0x00, 0xFF)
-
-        public val cyan: Color = Color(0x00, 0xFF, 0xFF)
-        public val magenta: Color = Color(0xFF, 0x00, 0xFF)
-        public val yellow: Color = Color(0xFF, 0xFF, 0x00)
-    }
+    override fun toString(): String = "Color(#${argb.toString(HEX_BASE).padStart(HEX_LENGTH, '0')})"
 }
 
-/** Linear interpolate towards another color. */
-public fun Color.lerp(other: Color, percent: Float): Color = Color(
-    alpha = (this.alpha + (other.alpha - this.alpha) * percent).roundToInt(),
-    red = (this.red + (other.red - this.red) * percent).roundToInt(),
-    green = (this.green + (other.green - this.green) * percent).roundToInt(),
-    blue = (this.blue + (other.blue - this.blue) * percent).roundToInt()
-)
-
-/** Get a random [Color]. If [isOpaque] is `true` (the default), then alpha is guaranteed to be `0xFF`. */
-public fun Random.nextColor(isOpaque: Boolean = true): Color = when (isOpaque) {
-    true -> Color((0xFF shl ALPHA_SHIFT) or (nextInt() and RGB_MASK))
-    false -> Color(nextInt())
+private fun Float.toColorComponent(): Int {
+    require(this in FLOAT_COMPONENT_RANGE) { "Value $this was outside expected range of [0, 1]." }
+    return (this * COMPONENT_MAX).roundToInt()
 }

--- a/color/src/commonMain/kotlin/Constants.kt
+++ b/color/src/commonMain/kotlin/Constants.kt
@@ -1,0 +1,20 @@
+package com.juul.krayon.color
+
+internal const val MASK_COMPONENT = 0xFF
+internal const val MASK_RGB = 0xFFFFFF
+
+internal const val SHIFT_ALPHA = 24
+internal const val SHIFT_RED = 16
+internal const val SHIFT_GREEN = 8
+internal const val SHIFT_BLUE = 0
+
+internal const val HEX_BASE = 16
+internal const val HEX_LENGTH = 8
+
+internal const val COMPONENT_MIN = 0x00
+internal const val COMPONENT_MAX = 0xFF
+internal val COMPONENT_RANGE = COMPONENT_MIN..COMPONENT_MAX
+
+internal const val FLOAT_COMPONENT_MIN = 0f
+internal const val FLOAT_COMPONENT_MAX = 1f
+internal val FLOAT_COMPONENT_RANGE = FLOAT_COMPONENT_MIN..FLOAT_COMPONENT_MAX

--- a/color/src/commonMain/kotlin/Operations.kt
+++ b/color/src/commonMain/kotlin/Operations.kt
@@ -1,0 +1,11 @@
+package com.juul.krayon.color
+
+import kotlin.math.roundToInt
+
+/** Linear interpolate towards another color. */
+public fun lerp(from: Color, to: Color, percent: Float): Color = Color(
+    alpha = (from.alpha + (to.alpha - from.alpha) * percent).roundToInt(),
+    red = (from.red + (to.red - from.red) * percent).roundToInt(),
+    green = (from.green + (to.green - from.green) * percent).roundToInt(),
+    blue = (from.blue + (to.blue - from.blue) * percent).roundToInt()
+)

--- a/color/src/commonMain/kotlin/Random.kt
+++ b/color/src/commonMain/kotlin/Random.kt
@@ -1,0 +1,9 @@
+package com.juul.krayon.color
+
+import kotlin.random.Random
+
+/** Get a random [Color]. If [isOpaque] is `true` (the default), then alpha is guaranteed to be `0xFF`. */
+public fun Random.nextColor(isOpaque: Boolean = true): Color = when (isOpaque) {
+    true -> Color((0xFF shl SHIFT_ALPHA) or (nextInt() and MASK_RGB))
+    false -> Color(nextInt())
+}

--- a/color/src/commonMain/kotlin/WebColors.kt
+++ b/color/src/commonMain/kotlin/WebColors.kt
@@ -1,0 +1,188 @@
+package com.juul.krayon.color
+
+// HTML Basic Colors
+
+// - Greyscale
+
+public val white: Color = Color(0xFFFFFFFF.toInt())
+public val silver: Color = Color(0xFFC0C0C0.toInt())
+public val gray: Color = Color(0xFF808080.toInt())
+public val black: Color = Color(0xFF000000.toInt())
+
+// - Colors
+
+public val red: Color = Color(0xFFFF0000.toInt())
+public val maroon: Color = Color(0xFF800000.toInt())
+public val yellow: Color = Color(0xFFFFFF00.toInt())
+public val olive: Color = Color(0xFF808000.toInt())
+public val lime: Color = Color(0xFF00FF00.toInt())
+public val green: Color = Color(0xFF008000.toInt())
+public val aqua: Color = Color(0xFF00FFFF.toInt())
+public val teal: Color = Color(0xFF008080.toInt())
+public val blue: Color = Color(0xFF0000FF.toInt())
+public val navy: Color = Color(0xFF000080.toInt())
+public val fuchsia: Color = Color(0xFFFF00FF.toInt())
+public val purple: Color = Color(0xFF800080.toInt())
+
+// HTML Extended Colors
+
+// - Pink Colors
+
+public val mediumVioletRed: Color = Color(0xFFC71585.toInt())
+public val deepPink: Color = Color(0xFFFF1493.toInt())
+public val paleVioletRed: Color = Color(0xFFDB7093.toInt())
+public val hotPink: Color = Color(0xFFFF69B4.toInt())
+public val lightPink: Color = Color(0xFFFFB6C1.toInt())
+public val pink: Color = Color(0xFFFFC0CB.toInt())
+
+// - Red Colors
+
+public val darkRed: Color = Color(0xFF8B0000.toInt())
+public val firebrick: Color = Color(0xFFB22222.toInt())
+public val crimson: Color = Color(0xFFDC143C.toInt())
+public val indianRed: Color = Color(0xFFCD5C5C.toInt())
+public val lightCoral: Color = Color(0xFFF08080.toInt())
+public val salmon: Color = Color(0xFFFA8072.toInt())
+public val lightSalmon: Color = Color(0xFFFFA07A.toInt())
+
+// - Orange Colors
+
+public val orangeRed: Color = Color(0xFFFF4500.toInt())
+public val tomato: Color = Color(0xFFFF6347.toInt())
+public val darkOrange: Color = Color(0xFFFF8C00.toInt())
+public val coral: Color = Color(0xFFFF7F50.toInt())
+public val orange: Color = Color(0xFFFFA500.toInt())
+
+// - Yellow Colors
+
+public val darkKhaki: Color = Color(0xFFBDB76B.toInt())
+public val gold: Color = Color(0xFFFFD700.toInt())
+public val khaki: Color = Color(0xFFF0E68C.toInt())
+public val peachPuff: Color = Color(0xFFFFDAB9.toInt())
+public val paleGoldenrod: Color = Color(0xFFEEE8AA.toInt())
+public val moccasin: Color = Color(0xFFFFE4B5.toInt())
+public val papayaWhip: Color = Color(0xFFFFEFD5.toInt())
+public val lightGoldenrodYellow: Color = Color(0xFFFAFAD2.toInt())
+public val lemonChiffon: Color = Color(0xFFFFFACD.toInt())
+public val lightYellow: Color = Color(0xFFFFFFE0.toInt())
+
+// - Brown Colors
+
+public val brown: Color = Color(0xFFA52A2A.toInt())
+public val saddleBrown: Color = Color(0xFF8B4513.toInt())
+public val sienna: Color = Color(0xFFA0522D.toInt())
+public val chocolate: Color = Color(0xFFD2691E.toInt())
+public val darkGoldenrod: Color = Color(0xFFB8860B.toInt())
+public val peru: Color = Color(0xFFCD853F.toInt())
+public val rosyBrown: Color = Color(0xFFBC8F8F.toInt())
+public val goldenrod: Color = Color(0xFFDAA520.toInt())
+public val sandyBrown: Color = Color(0xFFF4A460.toInt())
+public val tan: Color = Color(0xFFD2B48C.toInt())
+public val burlywood: Color = Color(0xFFDEB887.toInt())
+public val wheat: Color = Color(0xFFF5DEB3.toInt())
+public val navajoWhite: Color = Color(0xFFFFDEAD.toInt())
+public val bisque: Color = Color(0xFFFFE4C4.toInt())
+public val blanchedAlmond: Color = Color(0xFFFFEBCD.toInt())
+public val cornsilk: Color = Color(0xFFFFF8DC.toInt())
+
+// - Green Colors
+
+public val darkGreen: Color = Color(0xFF006400.toInt())
+public val darkOliveGreen: Color = Color(0xFF556B2F.toInt())
+public val forestGreen: Color = Color(0xFF228B22.toInt())
+public val seaGreen: Color = Color(0xFF2E8B57.toInt())
+public val oliveDrab: Color = Color(0xFF6B8E23.toInt())
+public val mediumSeaGreen: Color = Color(0xFF3CB371.toInt())
+public val limeGreen: Color = Color(0xFF32CD32.toInt())
+public val springGreen: Color = Color(0xFF00FF7F.toInt())
+public val mediumSpringGreen: Color = Color(0xFF00FA9A.toInt())
+public val darkSeaGreen: Color = Color(0xFF8FBC8F.toInt())
+public val mediumAquamarine: Color = Color(0xFF66CDAA.toInt())
+public val yellowGreen: Color = Color(0xFF9ACD32.toInt())
+public val lawnGreen: Color = Color(0xFF7CFC00.toInt())
+public val chartreuse: Color = Color(0xFF7FFF00.toInt())
+public val lightGreen: Color = Color(0xFF90EE90.toInt())
+public val greenYellow: Color = Color(0xFFADFF2F.toInt())
+public val paleGreen: Color = Color(0xFF98FB98.toInt())
+
+// - Cyan Colors
+
+public val darkCyan: Color = Color(0xFF008B8B.toInt())
+public val lightSeaGreen: Color = Color(0xFF20B2AA.toInt())
+public val cadetBlue: Color = Color(0xFF5F9EA0.toInt())
+public val darkTurquoise: Color = Color(0xFF00CED1.toInt())
+public val mediumTurquoise: Color = Color(0xFF48D1CC.toInt())
+public val turquoise: Color = Color(0xFF40E0D0.toInt())
+public val cyan: Color = Color(0xFF00FFFF.toInt())
+public val aquamarine: Color = Color(0xFF7FFFD4.toInt())
+public val paleTurquoise: Color = Color(0xFFAFEEEE.toInt())
+public val lightCyan: Color = Color(0xFFE0FFFF.toInt())
+
+// - Blue Colors
+
+public val darkBlue: Color = Color(0xFF00008B.toInt())
+public val mediumBlue: Color = Color(0xFF0000CD.toInt())
+public val midnightBlue: Color = Color(0xFF191970.toInt())
+public val royalBlue: Color = Color(0xFF4169E1.toInt())
+public val steelBlue: Color = Color(0xFF4682B4.toInt())
+public val dodgerBlue: Color = Color(0xFF1E90FF.toInt())
+public val deepSkyBlue: Color = Color(0xFF00BFFF.toInt())
+public val cornflowerBlue: Color = Color(0xFF6495ED.toInt())
+public val skyBlue: Color = Color(0xFF87CEEB.toInt())
+public val lightSkyBlue: Color = Color(0xFF87CEFA.toInt())
+public val lightSteelBlue: Color = Color(0xFFB0C4DE.toInt())
+public val lightBlue: Color = Color(0xFFADD8E6.toInt())
+public val powderBlue: Color = Color(0xFFB0E0E6.toInt())
+
+// - Purple, Violet, and Magenta Colors
+
+public val indigo: Color = Color(0xFF4B0082.toInt())
+public val darkMagenta: Color = Color(0xFF8B008B.toInt())
+public val darkViolet: Color = Color(0xFF9400D3.toInt())
+public val darkSlateBlue: Color = Color(0xFF483D8B.toInt())
+public val blueViolet: Color = Color(0xFF8A2BE2.toInt())
+public val darkOrchid: Color = Color(0xFF9932CC.toInt())
+public val magenta: Color = Color(0xFFFF00FF.toInt())
+public val slateBlue: Color = Color(0xFF6A5ACD.toInt())
+public val mediumSlateBlue: Color = Color(0xFF7B68EE.toInt())
+public val mediumOrchid: Color = Color(0xFFBA55D3.toInt())
+public val mediumPurple: Color = Color(0xFF9370DB.toInt())
+public val orchid: Color = Color(0xFFDA70D6.toInt())
+public val violet: Color = Color(0xFFEE82EE.toInt())
+public val plum: Color = Color(0xFFDDA0DD.toInt())
+public val thistle: Color = Color(0xFFD8BFD8.toInt())
+public val lavender: Color = Color(0xFFE6E6FA.toInt())
+
+// - White Colors
+
+public val mistyRose: Color = Color(0xFFFFE4E1.toInt())
+public val antiqueWhite: Color = Color(0xFFFAEBD7.toInt())
+public val linen: Color = Color(0xFFFAF0E6.toInt())
+public val beige: Color = Color(0xFFF5F5DC.toInt())
+public val whiteSmoke: Color = Color(0xFFF5F5F5.toInt())
+public val lavenderBlush: Color = Color(0xFFFFF0F5.toInt())
+public val oldLace: Color = Color(0xFFFDF5E6.toInt())
+public val aliceBlue: Color = Color(0xFFF0F8FF.toInt())
+public val seashell: Color = Color(0xFFFFF5EE.toInt())
+public val ghostWhite: Color = Color(0xFFF8F8FF.toInt())
+public val honeydew: Color = Color(0xFFF0FFF0.toInt())
+public val floralWhite: Color = Color(0xFFFFFAF0.toInt())
+public val azure: Color = Color(0xFFF0FFFF.toInt())
+public val mintCream: Color = Color(0xFFF5FFFA.toInt())
+public val snow: Color = Color(0xFFFFFAFA.toInt())
+public val ivory: Color = Color(0xFFFFFFF0.toInt())
+
+// - Gray Colors
+
+public val darkSlateGray: Color = Color(0xFF2F4F4F.toInt())
+public val dimGray: Color = Color(0xFF696969.toInt())
+public val slateGray: Color = Color(0xFF708090.toInt())
+public val lightSlateGray: Color = Color(0xFF778899.toInt())
+public val darkGray: Color = Color(0xFFA9A9A9.toInt())
+public val lightGray: Color = Color(0xFFD3D3D3.toInt())
+public val gainsboro: Color = Color(0xFFDCDCDC.toInt())
+
+// CSS Colors not in HTML
+
+public val transparent: Color = Color(0x00000000.toInt())
+public val rebeccaPurple: Color = Color(0xFF663399.toInt())

--- a/color/src/commonTest/kotlin/ColorTests.kt
+++ b/color/src/commonTest/kotlin/ColorTests.kt
@@ -29,26 +29,4 @@ class ColorTests {
     fun checkComponentsAreMasked() {
         assertEquals((0x23456789).toInt(), Color(alpha = 0x123, red = 0x345, green = 0x567, blue = 0x789).argb)
     }
-
-    /** This test is weird, but code coverage requires I do something with the builtins. */
-    @Test
-    fun checkBuiltInColors() {
-        fun assertColorEquals(alpha: Int, red: Int, green: Int, blue: Int, actual: Color) {
-            require(alpha in 0..0xFF && red in 0..0xFF && green in 0..0xFF && blue in 0..0xFF) { "You wrote the test wrong." }
-            assertEquals(Color(alpha, red, green, blue), actual)
-            assertEquals(alpha, actual.alpha)
-            assertEquals(red, actual.red)
-            assertEquals(green, actual.green)
-            assertEquals(blue, actual.blue)
-        }
-        assertColorEquals(alpha = 0x00, red = 0x00, green = 0x00, blue = 0x00, Color.transparent)
-        assertColorEquals(alpha = 0xFF, red = 0x00, green = 0x00, blue = 0x00, Color.black)
-        assertColorEquals(alpha = 0xFF, red = 0xFF, green = 0xFF, blue = 0xFF, Color.white)
-        assertColorEquals(alpha = 0xFF, red = 0xFF, green = 0x00, blue = 0x00, Color.red)
-        assertColorEquals(alpha = 0xFF, red = 0x00, green = 0xFF, blue = 0x00, Color.green)
-        assertColorEquals(alpha = 0xFF, red = 0x00, green = 0x00, blue = 0xFF, Color.blue)
-        assertColorEquals(alpha = 0xFF, red = 0x00, green = 0xFF, blue = 0xFF, Color.cyan)
-        assertColorEquals(alpha = 0xFF, red = 0xFF, green = 0x00, blue = 0xFF, Color.magenta)
-        assertColorEquals(alpha = 0xFF, red = 0xFF, green = 0xFF, blue = 0x00, Color.yellow)
-    }
 }

--- a/color/src/commonTest/kotlin/ColorTests.kt
+++ b/color/src/commonTest/kotlin/ColorTests.kt
@@ -1,4 +1,4 @@
-package com.juul.krayon.kanvas
+package com.juul.krayon.color
 
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/kanvas/api/kanvas.api
+++ b/kanvas/api/kanvas.api
@@ -30,50 +30,6 @@ public final class com/juul/krayon/kanvas/Clip$Rect : com/juul/krayon/kanvas/Cli
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/juul/krayon/kanvas/Color {
-	public static final field Companion Lcom/juul/krayon/kanvas/Color$Companion;
-	public static final synthetic fun box-impl (I)Lcom/juul/krayon/kanvas/Color;
-	public static fun constructor-impl (FFF)I
-	public static fun constructor-impl (FFFF)I
-	public static fun constructor-impl (I)I
-	public static fun constructor-impl (III)I
-	public static fun constructor-impl (IIII)I
-	public static final fun copy-Zb52D8Y (IIIII)I
-	public static synthetic fun copy-Zb52D8Y$default (IIIIIILjava/lang/Object;)I
-	public fun equals (Ljava/lang/Object;)Z
-	public static fun equals-impl (ILjava/lang/Object;)Z
-	public static final fun equals-impl0 (II)Z
-	public static final fun getAlpha-impl (I)I
-	public final fun getArgb ()I
-	public static final fun getBlue-impl (I)I
-	public static final fun getGreen-impl (I)I
-	public static final fun getRed-impl (I)I
-	public static final fun getRgb-impl (I)I
-	public fun hashCode ()I
-	public static fun hashCode-impl (I)I
-	public fun toString ()Ljava/lang/String;
-	public static fun toString-impl (I)Ljava/lang/String;
-	public final synthetic fun unbox-impl ()I
-}
-
-public final class com/juul/krayon/kanvas/Color$Companion {
-	public final fun getBlack-Zb52D8Y ()I
-	public final fun getBlue-Zb52D8Y ()I
-	public final fun getCyan-Zb52D8Y ()I
-	public final fun getGreen-Zb52D8Y ()I
-	public final fun getMagenta-Zb52D8Y ()I
-	public final fun getRed-Zb52D8Y ()I
-	public final fun getTransparent-Zb52D8Y ()I
-	public final fun getWhite-Zb52D8Y ()I
-	public final fun getYellow-Zb52D8Y ()I
-}
-
-public final class com/juul/krayon/kanvas/ColorKt {
-	public static final fun lerp-as0DGr8 (IIF)I
-	public static final fun nextColor (Lkotlin/random/Random;Z)I
-	public static synthetic fun nextColor$default (Lkotlin/random/Random;ZILjava/lang/Object;)I
-}
-
 public final class com/juul/krayon/kanvas/Font {
 	public fun <init> (Ljava/lang/String;[Ljava/lang/String;)V
 	public fun <init> (Ljava/util/List;)V
@@ -97,7 +53,7 @@ public abstract interface class com/juul/krayon/kanvas/Kanvas {
 	public abstract fun buildPath (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public abstract fun drawArc (FFFFFFLjava/lang/Object;)V
 	public abstract fun drawCircle (FFFLjava/lang/Object;)V
-	public abstract fun drawColor-IvQpv0M (I)V
+	public abstract fun drawColor-Z7dcaks (I)V
 	public abstract fun drawLine (FFFFLjava/lang/Object;)V
 	public abstract fun drawOval (FFFFLjava/lang/Object;)V
 	public abstract fun drawPath (Ljava/lang/Object;Ljava/lang/Object;)V
@@ -120,11 +76,11 @@ public abstract class com/juul/krayon/kanvas/Paint {
 
 public final class com/juul/krayon/kanvas/Paint$Fill : com/juul/krayon/kanvas/Paint {
 	public synthetic fun <init> (ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1-Zb52D8Y ()I
-	public final fun copy-IvQpv0M (I)Lcom/juul/krayon/kanvas/Paint$Fill;
-	public static synthetic fun copy-IvQpv0M$default (Lcom/juul/krayon/kanvas/Paint$Fill;IILjava/lang/Object;)Lcom/juul/krayon/kanvas/Paint$Fill;
+	public final fun component1-b4wfQcs ()I
+	public final fun copy-Z7dcaks (I)Lcom/juul/krayon/kanvas/Paint$Fill;
+	public static synthetic fun copy-Z7dcaks$default (Lcom/juul/krayon/kanvas/Paint$Fill;IILjava/lang/Object;)Lcom/juul/krayon/kanvas/Paint$Fill;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getColor-Zb52D8Y ()I
+	public final fun getColor-b4wfQcs ()I
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -132,16 +88,16 @@ public final class com/juul/krayon/kanvas/Paint$Fill : com/juul/krayon/kanvas/Pa
 public final class com/juul/krayon/kanvas/Paint$Stroke : com/juul/krayon/kanvas/Paint {
 	public synthetic fun <init> (IFLcom/juul/krayon/kanvas/Paint$Stroke$Cap;Lcom/juul/krayon/kanvas/Paint$Stroke$Join;Lcom/juul/krayon/kanvas/Paint$Stroke$Dash;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (IFLcom/juul/krayon/kanvas/Paint$Stroke$Cap;Lcom/juul/krayon/kanvas/Paint$Stroke$Join;Lcom/juul/krayon/kanvas/Paint$Stroke$Dash;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1-Zb52D8Y ()I
+	public final fun component1-b4wfQcs ()I
 	public final fun component2 ()F
 	public final fun component3 ()Lcom/juul/krayon/kanvas/Paint$Stroke$Cap;
 	public final fun component4 ()Lcom/juul/krayon/kanvas/Paint$Stroke$Join;
 	public final fun component5 ()Lcom/juul/krayon/kanvas/Paint$Stroke$Dash;
-	public final fun copy-ePyPsWE (IFLcom/juul/krayon/kanvas/Paint$Stroke$Cap;Lcom/juul/krayon/kanvas/Paint$Stroke$Join;Lcom/juul/krayon/kanvas/Paint$Stroke$Dash;)Lcom/juul/krayon/kanvas/Paint$Stroke;
-	public static synthetic fun copy-ePyPsWE$default (Lcom/juul/krayon/kanvas/Paint$Stroke;IFLcom/juul/krayon/kanvas/Paint$Stroke$Cap;Lcom/juul/krayon/kanvas/Paint$Stroke$Join;Lcom/juul/krayon/kanvas/Paint$Stroke$Dash;ILjava/lang/Object;)Lcom/juul/krayon/kanvas/Paint$Stroke;
+	public final fun copy-DBKG9Vw (IFLcom/juul/krayon/kanvas/Paint$Stroke$Cap;Lcom/juul/krayon/kanvas/Paint$Stroke$Join;Lcom/juul/krayon/kanvas/Paint$Stroke$Dash;)Lcom/juul/krayon/kanvas/Paint$Stroke;
+	public static synthetic fun copy-DBKG9Vw$default (Lcom/juul/krayon/kanvas/Paint$Stroke;IFLcom/juul/krayon/kanvas/Paint$Stroke$Cap;Lcom/juul/krayon/kanvas/Paint$Stroke$Join;Lcom/juul/krayon/kanvas/Paint$Stroke$Dash;ILjava/lang/Object;)Lcom/juul/krayon/kanvas/Paint$Stroke;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCap ()Lcom/juul/krayon/kanvas/Paint$Stroke$Cap;
-	public final fun getColor-Zb52D8Y ()I
+	public final fun getColor-b4wfQcs ()I
 	public final fun getDash ()Lcom/juul/krayon/kanvas/Paint$Stroke$Dash;
 	public final fun getJoin ()Lcom/juul/krayon/kanvas/Paint$Stroke$Join;
 	public final fun getWidth ()F
@@ -202,15 +158,15 @@ public final class com/juul/krayon/kanvas/Paint$Stroke$Join$Round : com/juul/kra
 
 public final class com/juul/krayon/kanvas/Paint$Text : com/juul/krayon/kanvas/Paint {
 	public synthetic fun <init> (IFLcom/juul/krayon/kanvas/Paint$Text$Alignment;Lcom/juul/krayon/kanvas/Font;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1-Zb52D8Y ()I
+	public final fun component1-b4wfQcs ()I
 	public final fun component2 ()F
 	public final fun component3 ()Lcom/juul/krayon/kanvas/Paint$Text$Alignment;
 	public final fun component4 ()Lcom/juul/krayon/kanvas/Font;
-	public final fun copy-pHt_YaU (IFLcom/juul/krayon/kanvas/Paint$Text$Alignment;Lcom/juul/krayon/kanvas/Font;)Lcom/juul/krayon/kanvas/Paint$Text;
-	public static synthetic fun copy-pHt_YaU$default (Lcom/juul/krayon/kanvas/Paint$Text;IFLcom/juul/krayon/kanvas/Paint$Text$Alignment;Lcom/juul/krayon/kanvas/Font;ILjava/lang/Object;)Lcom/juul/krayon/kanvas/Paint$Text;
+	public final fun copy-ErPXEY4 (IFLcom/juul/krayon/kanvas/Paint$Text$Alignment;Lcom/juul/krayon/kanvas/Font;)Lcom/juul/krayon/kanvas/Paint$Text;
+	public static synthetic fun copy-ErPXEY4$default (Lcom/juul/krayon/kanvas/Paint$Text;IFLcom/juul/krayon/kanvas/Paint$Text$Alignment;Lcom/juul/krayon/kanvas/Font;ILjava/lang/Object;)Lcom/juul/krayon/kanvas/Paint$Text;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAlignment ()Lcom/juul/krayon/kanvas/Paint$Text$Alignment;
-	public final fun getColor-Zb52D8Y ()I
+	public final fun getColor-b4wfQcs ()I
 	public final fun getFont ()Lcom/juul/krayon/kanvas/Font;
 	public final fun getSize ()F
 	public fun hashCode ()I
@@ -354,7 +310,7 @@ public final class com/juul/krayon/kanvas/svg/SvgKanvas : com/juul/krayon/kanvas
 	public synthetic fun drawArc (FFFFFFLjava/lang/Object;)V
 	public fun drawCircle (FFFLcom/juul/krayon/kanvas/Paint;)V
 	public synthetic fun drawCircle (FFFLjava/lang/Object;)V
-	public fun drawColor-IvQpv0M (I)V
+	public fun drawColor-Z7dcaks (I)V
 	public fun drawLine (FFFFLcom/juul/krayon/kanvas/Paint;)V
 	public synthetic fun drawLine (FFFFLjava/lang/Object;)V
 	public fun drawOval (FFFFLcom/juul/krayon/kanvas/Paint;)V

--- a/kanvas/src/androidMain/kotlin/AndroidKanvas.kt
+++ b/kanvas/src/androidMain/kotlin/AndroidKanvas.kt
@@ -3,6 +3,7 @@ package com.juul.krayon.kanvas
 import android.content.Context
 import android.graphics.Canvas
 import android.graphics.RectF
+import com.juul.krayon.color.Color
 import android.graphics.Paint as AndroidPaint
 import android.graphics.Path as AndroidPath
 

--- a/kanvas/src/androidTest/kotlin/AndroidPaintTests.kt
+++ b/kanvas/src/androidTest/kotlin/AndroidPaintTests.kt
@@ -1,7 +1,7 @@
 package com.juul.krayon.kanvas
 
 import androidx.test.core.app.ApplicationProvider
-import com.juul.krayon.color.Color
+import com.juul.krayon.color.black
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
@@ -15,21 +15,21 @@ class AndroidPaintTests {
 
     @Test
     fun checkFillPaintStyle() {
-        val source = Paint.Fill(Color.black)
+        val source = Paint.Fill(black)
         val dest = source.toAndroid()
         assertEquals(dest.style, AndroidPaint.Style.FILL)
     }
 
     @Test
     fun checkStrokePaintStyle() {
-        val source = Paint.Stroke(Color.black, width = 1f)
+        val source = Paint.Stroke(black, width = 1f)
         val dest = source.toAndroid()
         assertEquals(dest.style, AndroidPaint.Style.STROKE)
     }
 
     @Test
     fun checkTextPaintStyle() {
-        val source = Paint.Text(Color.black, size = 12f, Paint.Text.Alignment.Center, Font("Times New Roman"))
+        val source = Paint.Text(black, size = 12f, Paint.Text.Alignment.Center, Font("Times New Roman"))
         val dest = source.toAndroid(ApplicationProvider.getApplicationContext())
         assertEquals(dest.style, AndroidPaint.Style.FILL)
     }

--- a/kanvas/src/androidTest/kotlin/AndroidPaintTests.kt
+++ b/kanvas/src/androidTest/kotlin/AndroidPaintTests.kt
@@ -1,6 +1,7 @@
 package com.juul.krayon.kanvas
 
 import androidx.test.core.app.ApplicationProvider
+import com.juul.krayon.color.Color
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config

--- a/kanvas/src/commonMain/kotlin/Kanvas.kt
+++ b/kanvas/src/commonMain/kotlin/Kanvas.kt
@@ -1,5 +1,7 @@
 package com.juul.krayon.kanvas
 
+import com.juul.krayon.color.Color
+
 /** Something to draw on. Implementations are not required to be safe across multiple threads. */
 public interface Kanvas<PAINT, PATH> {
 

--- a/kanvas/src/commonMain/kotlin/Paint.kt
+++ b/kanvas/src/commonMain/kotlin/Paint.kt
@@ -1,5 +1,7 @@
 package com.juul.krayon.kanvas
 
+import com.juul.krayon.color.Color
+
 /** Default chosen to match SVG. See https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-miterlimit */
 public const val DEFAULT_MITER_LIMIT: Float = 4f
 

--- a/kanvas/src/commonMain/kotlin/svg/Paint.kt
+++ b/kanvas/src/commonMain/kotlin/svg/Paint.kt
@@ -1,6 +1,6 @@
 package com.juul.krayon.kanvas.svg
 
-import com.juul.krayon.kanvas.Color
+import com.juul.krayon.color.Color
 import com.juul.krayon.kanvas.DEFAULT_MITER_LIMIT
 import com.juul.krayon.kanvas.Paint
 import com.juul.krayon.kanvas.xml.XmlElement

--- a/kanvas/src/commonMain/kotlin/svg/SvgKanvas.kt
+++ b/kanvas/src/commonMain/kotlin/svg/SvgKanvas.kt
@@ -1,7 +1,7 @@
 package com.juul.krayon.kanvas.svg
 
+import com.juul.krayon.color.Color
 import com.juul.krayon.kanvas.Clip
-import com.juul.krayon.kanvas.Color
 import com.juul.krayon.kanvas.Kanvas
 import com.juul.krayon.kanvas.Paint
 import com.juul.krayon.kanvas.PathBuilder

--- a/kanvas/src/commonTest/kotlin/CallRecordingKanvas.kt
+++ b/kanvas/src/commonTest/kotlin/CallRecordingKanvas.kt
@@ -1,5 +1,7 @@
 package com.juul.krayon.kanvas
 
+import com.juul.krayon.color.Color
+
 object UnitPaint
 object UnitPath
 

--- a/kanvas/src/commonTest/kotlin/KanvasExtensionTests.kt
+++ b/kanvas/src/commonTest/kotlin/KanvasExtensionTests.kt
@@ -1,6 +1,6 @@
 package com.juul.krayon.kanvas
 
-import com.juul.krayon.color.Color
+import com.juul.krayon.color.black
 import kotlin.test.Test
 
 class KanvasExtensionTests {
@@ -9,7 +9,7 @@ class KanvasExtensionTests {
     fun checkWithClipMakesCorrectCalls() {
         val canvas = CallRecordingKanvas(100f, 100f)
         canvas.withClip(Clip.Rect(0f, 0f, 5f, 5f)) {
-            val paint = canvas.buildPaint(Paint.Stroke(Color.black, 1f))
+            val paint = canvas.buildPaint(Paint.Stroke(black, 1f))
             canvas.drawLine(0f, 0f, 10f, 10f, paint)
         }
         canvas.verifyFirst("pushClip called first") { it.function == canvas::pushClip }
@@ -23,7 +23,7 @@ class KanvasExtensionTests {
     fun checkWithTransformMakesCorrectCalls() {
         val canvas = CallRecordingKanvas(100f, 100f)
         canvas.withTransform(Transform.Scale(horizontal = 2f)) {
-            val paint = canvas.buildPaint(Paint.Stroke(Color.black, 1f))
+            val paint = canvas.buildPaint(Paint.Stroke(black, 1f))
             canvas.drawLine(0f, 0f, 10f, 10f, paint)
         }
         canvas.verifyFirst("pushTransform called first") { it.function == canvas::pushTransform }

--- a/kanvas/src/commonTest/kotlin/KanvasExtensionTests.kt
+++ b/kanvas/src/commonTest/kotlin/KanvasExtensionTests.kt
@@ -1,5 +1,6 @@
 package com.juul.krayon.kanvas
 
+import com.juul.krayon.color.Color
 import kotlin.test.Test
 
 class KanvasExtensionTests {

--- a/kanvas/src/commonTest/kotlin/SvgTests.kt
+++ b/kanvas/src/commonTest/kotlin/SvgTests.kt
@@ -1,5 +1,6 @@
 package com.juul.krayon.kanvas
 
+import com.juul.krayon.color.Color
 import com.juul.krayon.kanvas.Paint.Stroke.Dash.Pattern
 import com.juul.krayon.kanvas.svg.SvgKanvas
 import kotlin.test.Test

--- a/kanvas/src/commonTest/kotlin/SvgTests.kt
+++ b/kanvas/src/commonTest/kotlin/SvgTests.kt
@@ -1,6 +1,9 @@
 package com.juul.krayon.kanvas
 
-import com.juul.krayon.color.Color
+import com.juul.krayon.color.black
+import com.juul.krayon.color.blue
+import com.juul.krayon.color.lime
+import com.juul.krayon.color.red
 import com.juul.krayon.kanvas.Paint.Stroke.Dash.Pattern
 import com.juul.krayon.kanvas.svg.SvgKanvas
 import kotlin.test.Test
@@ -30,11 +33,11 @@ class SvgTests {
         """.trimIndent()
         val actual = run {
             val svg = SvgKanvas(width = 100f, height = 100f)
-            val blackFill = Paint.Fill(Color.black)
-            val redStroke = Paint.Stroke(Color.red, width = 2f)
-            val greenStroke = Paint.Stroke(Color.green, width = 1f)
+            val blackFill = Paint.Fill(black)
+            val redStroke = Paint.Stroke(red, width = 2f)
+            val greenStroke = Paint.Stroke(lime, width = 1f)
             val dashedGreenStroke = greenStroke.copy(dash = Pattern(2f, 1f))
-            val blueText = Paint.Text(Color.blue, size = 16f, Paint.Text.Alignment.Center, Font("Times New Roman", serif))
+            val blueText = Paint.Text(blue, size = 16f, Paint.Text.Alignment.Center, Font("Times New Roman", serif))
             svg.drawCircle(16f, 84f, 8f, blackFill)
             svg.withClip(Clip.Rect(16f, 16f, 84f, 84f)) {
                 drawLine(0f, 100f, 100f, 0f, redStroke)

--- a/sample/api/sample.api
+++ b/sample/api/sample.api
@@ -2,8 +2,8 @@ public final class com/juul/krayon/sample/CustomCanvasView : com/juul/krayon/kan
 	public fun <init> (Landroid/content/Context;)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
 	public synthetic fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun getCircleColor-Zb52D8Y ()I
-	public final fun setCircleColor-IvQpv0M (I)V
+	public final fun getCircleColor-b4wfQcs ()I
+	public final fun setCircleColor-Z7dcaks (I)V
 }
 
 public final class com/juul/krayon/sample/DemoActivity : android/app/Activity {

--- a/sample/src/main/java/com/juul/krayon/sample/CustomCanvasView.kt
+++ b/sample/src/main/java/com/juul/krayon/sample/CustomCanvasView.kt
@@ -3,6 +3,7 @@ package com.juul.krayon.sample
 import android.content.Context
 import android.util.AttributeSet
 import com.juul.krayon.color.Color
+import com.juul.krayon.color.black
 import com.juul.krayon.kanvas.Kanvas
 import com.juul.krayon.kanvas.KanvasView
 import com.juul.krayon.kanvas.Paint
@@ -18,9 +19,9 @@ class CustomCanvasView @JvmOverloads constructor(
     attrs: AttributeSet? = null,
 ) : KanvasView(context, attrs) {
 
-    private val linePaint = Paint.Stroke(Color.black, width = 2f, cap = Round, dash = Pattern(0f, 4f)).toAndroid()
-    private val textPaint = Paint.Text(Color.black, size = 18f, alignment = Left, Fonts.robotoSlab).toAndroid(context)
-    private var circlePaint = Paint.Stroke(Color.black, width = 4f).toAndroid()
+    private val linePaint = Paint.Stroke(black, width = 2f, cap = Round, dash = Pattern(0f, 4f)).toAndroid()
+    private val textPaint = Paint.Text(black, size = 18f, alignment = Left, Fonts.robotoSlab).toAndroid(context)
+    private var circlePaint = Paint.Stroke(black, width = 4f).toAndroid()
 
     var circleColor: Color
         get() = Color(circlePaint.color)

--- a/sample/src/main/java/com/juul/krayon/sample/CustomCanvasView.kt
+++ b/sample/src/main/java/com/juul/krayon/sample/CustomCanvasView.kt
@@ -2,7 +2,7 @@ package com.juul.krayon.sample
 
 import android.content.Context
 import android.util.AttributeSet
-import com.juul.krayon.kanvas.Color
+import com.juul.krayon.color.Color
 import com.juul.krayon.kanvas.Kanvas
 import com.juul.krayon.kanvas.KanvasView
 import com.juul.krayon.kanvas.Paint

--- a/sample/src/main/java/com/juul/krayon/sample/DemoActivity.kt
+++ b/sample/src/main/java/com/juul/krayon/sample/DemoActivity.kt
@@ -7,7 +7,7 @@ import com.juul.krayon.chart.data.ClusteredDataSet
 import com.juul.krayon.chart.data.toCluster
 import com.juul.krayon.chart.data.toRectangularDataSet
 import com.juul.krayon.chart.render.BarChartRenderer
-import com.juul.krayon.kanvas.nextColor
+import com.juul.krayon.color.nextColor
 import com.juul.krayon.sample.databinding.ActivityDemoBinding
 import kotlin.random.Random
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -23,6 +23,7 @@ pluginManagement {
 
 include(
     "chart",
+    "color",
     "kanvas",
     "sample"
 )


### PR DESCRIPTION
### Includes Breaking Changes ###

- Package change.
- Receiver on `lerp` removed in favor of function argument
- Color constants are no longer namespaced in the `Color` class
- Color constants updated to match [web colors](https://en.wikipedia.org/wiki/Web_colors#HTML_color_names)

Closes #20.
