### PR TITLE
Drop Android and add JavaScript target to 'color' module

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,14 +9,14 @@ buildscript {
 }
 
 plugins {
-    kotlin("multiplatform") version "1.4.10" apply false
-    id("com.android.application") version "4.1.0" apply false
-    id("com.android.library") version "4.1.0" apply false
+    kotlin("multiplatform") version "1.4.32" apply false
+    id("com.android.application") version "4.1.3" apply false
+    id("com.android.library") version "4.1.3" apply false
     id("kotlinx-atomicfu") version "0.14.4" apply false
     id("org.jmailen.kotlinter") version "3.2.0" apply false
     id("binary-compatibility-validator") version "0.2.3"
     id("org.jetbrains.dokka") version "1.4.30"
-    id("com.vanniktech.maven.publish") version "0.13.0" apply false
+    id("com.vanniktech.maven.publish") version "0.14.0" apply false
     id("net.mbonnin.one.eight") version "0.1"
 }
 

--- a/chart/build.gradle.kts
+++ b/chart/build.gradle.kts
@@ -20,7 +20,6 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 api(project(":kanvas"))
-                implementation(kotlin("stdlib"))
             }
         }
 

--- a/color/api/color.api
+++ b/color/api/color.api
@@ -5,8 +5,8 @@ public final class com/juul/krayon/color/Color {
 	public static fun constructor-impl (I)I
 	public static fun constructor-impl (III)I
 	public static fun constructor-impl (IIII)I
-	public static final fun copy-b4wfQcs (IIIII)I
-	public static synthetic fun copy-b4wfQcs$default (IIIIIILjava/lang/Object;)I
+	public static final fun copy-VL1fjKE (IIIII)I
+	public static synthetic fun copy-VL1fjKE$default (IIIIIILjava/lang/Object;)I
 	public fun equals (Ljava/lang/Object;)Z
 	public static fun equals-impl (ILjava/lang/Object;)Z
 	public static final fun equals-impl0 (II)Z
@@ -25,7 +25,7 @@ public final class com/juul/krayon/color/Color {
 }
 
 public final class com/juul/krayon/color/OperationsKt {
-	public static final fun lerp-Lm3R1AU (IIF)I
+	public static final fun lerp-5Jni88Q (IIF)I
 }
 
 public final class com/juul/krayon/color/RandomKt {

--- a/color/build.gradle.kts
+++ b/color/build.gradle.kts
@@ -1,6 +1,4 @@
 plugins {
-    // Android plugin must be before multiplatform plugin until https://youtrack.jetbrains.com/issue/KT-34038 is fixed.
-    id("com.android.library")
     kotlin("multiplatform")
     id("org.jmailen.kotlinter")
     jacoco
@@ -14,18 +12,12 @@ apply(from = rootProject.file("gradle/publish.gradle.kts"))
 kotlin {
     explicitApi()
 
-    android { publishAllLibraryVariants() }
     jvm()
+    js().browser()
 
     sourceSets {
         all {
             languageSettings.enableLanguageFeature("InlineClasses")
-        }
-
-        val commonMain by getting {
-            dependencies {
-                implementation(kotlin("stdlib"))
-            }
         }
 
         val commonTest by getting {
@@ -36,36 +28,16 @@ kotlin {
             }
         }
 
-        val androidTest by getting {
-            dependencies {
-                implementation(kotlin("test-junit"))
-            }
-        }
-
         val jvmTest by getting {
             dependencies {
                 implementation(kotlin("test-junit"))
             }
         }
-    }
-}
 
-android {
-    compileSdkVersion(AndroidSdk.Compile)
-
-    defaultConfig {
-        minSdkVersion(AndroidSdk.Minimum)
-        targetSdkVersion(AndroidSdk.Target)
-    }
-
-    lintOptions {
-        isAbortOnError = true
-        isWarningsAsErrors = true
-    }
-
-    sourceSets {
-        val main by getting {
-            manifest.srcFile("src/androidMain/AndroidManifest.xml")
+        val jsTest by getting {
+            dependencies {
+                implementation(kotlin("test-js"))
+            }
         }
     }
 }

--- a/color/src/androidMain/AndroidManifest.xml
+++ b/color/src/androidMain/AndroidManifest.xml
@@ -1,1 +1,0 @@
-<manifest package="com.juul.krayon.color" />

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/kanvas/api/kanvas.api
+++ b/kanvas/api/kanvas.api
@@ -93,8 +93,8 @@ public final class com/juul/krayon/kanvas/Paint$Stroke : com/juul/krayon/kanvas/
 	public final fun component3 ()Lcom/juul/krayon/kanvas/Paint$Stroke$Cap;
 	public final fun component4 ()Lcom/juul/krayon/kanvas/Paint$Stroke$Join;
 	public final fun component5 ()Lcom/juul/krayon/kanvas/Paint$Stroke$Dash;
-	public final fun copy-DBKG9Vw (IFLcom/juul/krayon/kanvas/Paint$Stroke$Cap;Lcom/juul/krayon/kanvas/Paint$Stroke$Join;Lcom/juul/krayon/kanvas/Paint$Stroke$Dash;)Lcom/juul/krayon/kanvas/Paint$Stroke;
-	public static synthetic fun copy-DBKG9Vw$default (Lcom/juul/krayon/kanvas/Paint$Stroke;IFLcom/juul/krayon/kanvas/Paint$Stroke$Cap;Lcom/juul/krayon/kanvas/Paint$Stroke$Join;Lcom/juul/krayon/kanvas/Paint$Stroke$Dash;ILjava/lang/Object;)Lcom/juul/krayon/kanvas/Paint$Stroke;
+	public final fun copy-Z8wwC0M (IFLcom/juul/krayon/kanvas/Paint$Stroke$Cap;Lcom/juul/krayon/kanvas/Paint$Stroke$Join;Lcom/juul/krayon/kanvas/Paint$Stroke$Dash;)Lcom/juul/krayon/kanvas/Paint$Stroke;
+	public static synthetic fun copy-Z8wwC0M$default (Lcom/juul/krayon/kanvas/Paint$Stroke;IFLcom/juul/krayon/kanvas/Paint$Stroke$Cap;Lcom/juul/krayon/kanvas/Paint$Stroke$Join;Lcom/juul/krayon/kanvas/Paint$Stroke$Dash;ILjava/lang/Object;)Lcom/juul/krayon/kanvas/Paint$Stroke;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCap ()Lcom/juul/krayon/kanvas/Paint$Stroke$Cap;
 	public final fun getColor-b4wfQcs ()I
@@ -162,8 +162,8 @@ public final class com/juul/krayon/kanvas/Paint$Text : com/juul/krayon/kanvas/Pa
 	public final fun component2 ()F
 	public final fun component3 ()Lcom/juul/krayon/kanvas/Paint$Text$Alignment;
 	public final fun component4 ()Lcom/juul/krayon/kanvas/Font;
-	public final fun copy-ErPXEY4 (IFLcom/juul/krayon/kanvas/Paint$Text$Alignment;Lcom/juul/krayon/kanvas/Font;)Lcom/juul/krayon/kanvas/Paint$Text;
-	public static synthetic fun copy-ErPXEY4$default (Lcom/juul/krayon/kanvas/Paint$Text;IFLcom/juul/krayon/kanvas/Paint$Text$Alignment;Lcom/juul/krayon/kanvas/Font;ILjava/lang/Object;)Lcom/juul/krayon/kanvas/Paint$Text;
+	public final fun copy-jDi6J3E (IFLcom/juul/krayon/kanvas/Paint$Text$Alignment;Lcom/juul/krayon/kanvas/Font;)Lcom/juul/krayon/kanvas/Paint$Text;
+	public static synthetic fun copy-jDi6J3E$default (Lcom/juul/krayon/kanvas/Paint$Text;IFLcom/juul/krayon/kanvas/Paint$Text$Alignment;Lcom/juul/krayon/kanvas/Font;ILjava/lang/Object;)Lcom/juul/krayon/kanvas/Paint$Text;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAlignment ()Lcom/juul/krayon/kanvas/Paint$Text$Alignment;
 	public final fun getColor-b4wfQcs ()I
@@ -305,7 +305,7 @@ public final class com/juul/krayon/kanvas/svg/SvgKanvas : com/juul/krayon/kanvas
 	public fun buildPaint (Lcom/juul/krayon/kanvas/Paint;)Lcom/juul/krayon/kanvas/Paint;
 	public synthetic fun buildPaint (Lcom/juul/krayon/kanvas/Paint;)Ljava/lang/Object;
 	public synthetic fun buildPath (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
-	public fun buildPath-vNHZNVA (Lkotlin/jvm/functions/Function1;)Ljava/lang/String;
+	public fun buildPath-tG2Avo8 (Lkotlin/jvm/functions/Function1;)Ljava/lang/String;
 	public fun drawArc (FFFFFFLcom/juul/krayon/kanvas/Paint;)V
 	public synthetic fun drawArc (FFFFFFLjava/lang/Object;)V
 	public fun drawCircle (FFFLcom/juul/krayon/kanvas/Paint;)V
@@ -316,7 +316,7 @@ public final class com/juul/krayon/kanvas/svg/SvgKanvas : com/juul/krayon/kanvas
 	public fun drawOval (FFFFLcom/juul/krayon/kanvas/Paint;)V
 	public synthetic fun drawOval (FFFFLjava/lang/Object;)V
 	public synthetic fun drawPath (Ljava/lang/Object;Ljava/lang/Object;)V
-	public fun drawPath-E0N_TaA (Ljava/lang/String;Lcom/juul/krayon/kanvas/Paint;)V
+	public fun drawPath-tz8rt4E (Ljava/lang/String;Lcom/juul/krayon/kanvas/Paint;)V
 	public fun drawRect (FFFFLcom/juul/krayon/kanvas/Paint;)V
 	public synthetic fun drawRect (FFFFLjava/lang/Object;)V
 	public fun drawText (Ljava/lang/CharSequence;FFLcom/juul/krayon/kanvas/Paint;)V

--- a/kanvas/build.gradle.kts
+++ b/kanvas/build.gradle.kts
@@ -24,7 +24,6 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 api(project(":color"))
-                implementation(kotlin("stdlib"))
             }
         }
 


### PR DESCRIPTION
Some dependency version bumps were needed to have Gradle play nice with Android modules depending on the JVM `color` module.