### PR TITLE
Install to Maven local for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,20 @@ jobs:
         if: runner.os == 'Linux'
         run: ./gradlew $GRADLE_ARGS check jacocoTestReport
 
+      - name: Keyring
+        run: echo "${{ secrets.SIGNING_SECRET_KEY_RING }}" | base64 --decode > "$HOME/secring.gpg"
+
+      - name: Publish Locally
+        run: >-
+          ./gradlew
+          $GRADLE_ARGS
+          --no-parallel
+          -PVERSION_NAME=unspecified
+          -Psigning.keyId="${{ secrets.SIGNING_KEY_ID }}"
+          -Psigning.password="${{ secrets.SIGNING_PASSWORD }}"
+          -Psigning.secretKeyRingFile="$HOME/secring.gpg"
+          publishToMavenLocal
+
       - name: Codecov (Linux)
         if: runner.os == 'Linux'
         uses: codecov/codecov-action@v1


### PR DESCRIPTION
Validates that project is ready for later Maven **Central** publication by performing a signed Maven **Local** installation during CI check.