### PR TITLE
Remove codecov token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,5 +73,4 @@ jobs:
         if: runner.os == 'Linux'
         uses: codecov/codecov-action@v1
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true


### PR DESCRIPTION
Token is not necessary for public (open source) repositories.

Per codecov settings for the project:

![Screen Shot 2021-04-29 at 1 10 26 AM](https://user-images.githubusercontent.com/98017/116520539-b5dad180-a887-11eb-89c3-c383449c5486.png)
