### PR TITLE
Revert Maven publish version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ plugins {
     id("kotlinx-atomicfu") version "0.16.2" apply false
     id("org.jmailen.kotlinter") version "3.4.5" apply false
     id("org.jetbrains.dokka") version "1.4.30"
-    id("com.vanniktech.maven.publish") version "0.17.0" apply false
+    id("com.vanniktech.maven.publish") version "0.14.0" apply false
     id("net.mbonnin.one.eight") version "0.2"
 
     // Breaks with:


### PR DESCRIPTION
Upgrading the maven publish version to `0.17.0` introduced a [breaking change ](https://github.com/vanniktech/gradle-maven-publish-plugin/blob/master/CHANGELOG.md#version-0150-2021-04-24)


> * What went wrong:
> An exception occurred applying plugin request [id: 'com.vanniktech.maven.publish']
> Failed to apply plugin 'com.vanniktech.maven.publish'.
>   The env var SONATYPE_NEXUS_USERNAME was removed. Use the Gradle property mavenCentralUsername or the env > >.  var ORG_GRADLE_PROJECT_mavenCentralUsername instead.
