### PR TITLE
Update CI scripts and use in-memory ascii-armored key for signing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,76 +1,63 @@
 name: CI
 on:
-  push:
+  pull_request:
+
+env:
+  GRADLE_OPTS: "-Dorg.gradle.daemon=false"
 
 jobs:
   build:
-    strategy:
-      matrix:
-        os: [ubuntu-18.04]
-        # Use the following line instead if we add an OSX target.
-        # os: [ubuntu-18.04, macos-10.15]
-    runs-on: ${{ matrix.os }}
-
-    env:
-      GRADLE_ARGS: >-
-        --no-daemon
-        --max-workers 2
-        -Pkotlin.incremental=false
-
+    runs-on: ubuntu-20.04
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Set up JDK
-        uses: actions/setup-java@v1
+      - uses: actions/checkout@v2
+      - uses: gradle/wrapper-validation-action@v1
+      - uses: actions/setup-java@v2
         with:
-          java-version: 1.8
+          distribution: "adopt-hotspot"
+          java-version: "11.0.11+9"
 
-      - name: Gradle cache
-        uses: actions/cache@v2
+      - uses: actions/cache@v2
         with:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
             ~/.konan
-          key: ${{ runner.os }}-build-${{ hashFiles('**/build.gradle.kts') }}
+            ~/.android/build-cache
+            ~/.android/cache
+          key: ${{ runner.os }}-build-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-build-
             ${{ runner.os }}-
 
-      # Uncomment the following to add an OSX target
-      # - name: Compile (macOS)
-      #   if: runner.os == 'macOS'
-      #   run: ./gradlew $GRADLE_ARGS compileKotlinMacosX64
-      #
-      # - name: Test (macOS)
-      #   if: runner.os == 'macOS'
-      #   run: ./gradlew $GRADLE_ARGS macosX64Test
+      - run: ./gradlew assemble
+      - run: ./gradlew check jacocoTestReport
 
-      - name: Assemble (Linux)
-        if: runner.os == 'Linux'
-        run: ./gradlew $GRADLE_ARGS assemble
+      - uses: EnricoMi/publish-unit-test-result-action@v1
+        with:
+          files: '**/build/test-results/**/*.xml'
+          report_individual_runs: 'true'
 
-      - name: Check (Linux)
-        if: runner.os == 'Linux'
-        run: ./gradlew $GRADLE_ARGS check jacocoTestReport
-
-      - name: Keyring
-        run: echo "${{ secrets.SIGNING_SECRET_KEY_RING }}" | base64 --decode > "$HOME/secring.gpg"
-
-      - name: Publish Locally
-        run: >-
-          ./gradlew
-          $GRADLE_ARGS
-          --no-parallel
-          -PVERSION_NAME=unspecified
-          -Psigning.keyId="${{ secrets.SIGNING_KEY_ID }}"
-          -Psigning.password="${{ secrets.SIGNING_PASSWORD }}"
-          -Psigning.secretKeyRingFile="$HOME/secring.gpg"
-          publishToMavenLocal
-
-      - name: Codecov (Linux)
-        if: runner.os == 'Linux'
-        uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v1
         with:
           fail_ci_if_error: true
+
+      - run: |
+          set -o xtrace
+          if [ ! -z "${{ secrets.SIGNING_KEY }}" ]; then
+            ./gradlew \
+            --no-parallel \
+            -PVERSION_NAME="unspecified" \
+            -PsigningInMemoryKey="${{ secrets.SIGNING_KEY }}" \
+            -PsigningInMemoryKeyPassword="${{ secrets.SIGNING_PASSWORD }}" \
+            publishToMavenLocal
+          else
+            ./gradlew \
+            --no-parallel \
+            -PVERSION_NAME="unspecified-SNAPSHOT" \
+            publishToMavenLocal
+          fi
+        if: github.repository_owner == 'JuulLabs'
+
+      - run: |
+          rm -f ~/.gradle/caches/modules-2/modules-2.lock
+          rm -f ~/.gradle/caches/modules-2/gc.properties

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -4,42 +4,39 @@ on:
     branches:
       - main
 
+env:
+  GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+
 jobs:
   deploy:
-    runs-on: ubuntu-18.04
-
-    env:
-      GRADLE_ARGS: >-
-        --no-daemon
-        --max-workers 2
-        -Pkotlin.incremental=false
-
+    runs-on: ubuntu-20.04
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Set up JDK
-        uses: actions/setup-java@v1
+      - uses: actions/checkout@v2
+      - uses: gradle/wrapper-validation-action@v1
+      - uses: actions/setup-java@v2
         with:
-          java-version: 1.8
+          distribution: "adopt-hotspot"
+          java-version: "11.0.11+9"
 
-      - name: Cache
-        uses: actions/cache@v2
+      - uses: actions/cache@v2
         with:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
             ~/.konan
-          key: ${{ runner.os }}-gh-pages-${{ hashFiles('**/build.gradle.kts') }}
+            ~/.android/build-cache
+            ~/.android/cache
+          key: ${{ runner.os }}-gh-pages-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-gh-pages-
             ${{ runner.os }}-
 
-      - name: Dokka
-        run: ./gradlew $GRADLE_ARGS dokkaHtmlMultiModule
-
-      - name: Deploy to Github Pages
-        uses: JamesIves/github-pages-deploy-action@4.1.0
+      - run: ./gradlew dokkaHtmlMultiModule
+      - uses: JamesIves/github-pages-deploy-action@4.1.4
         with:
-          BRANCH: gh-pages
-          FOLDER: build/gh-pages
+          branch: gh-pages
+          folder: build/gh-pages
+
+      - run: |
+          rm -f ~/.gradle/caches/modules-2/modules-2.lock
+          rm -f ~/.gradle/caches/modules-2/gc.properties

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,57 +1,47 @@
 name: Publish
 on:
   release:
-    types: [published]
+    types:
+      - published
+
+env:
+  GRADLE_OPTS: "-Dorg.gradle.daemon=false"
 
 jobs:
-  build:
-    runs-on: ubuntu-18.04
-    # Use the following line instead if we add an OSX target.
-    # runs-on: macos-10.15
-
-    env:
-      GRADLE_ARGS: >-
-        --no-daemon
-        --max-workers 2
-        -Pkotlin.incremental=false
-
+  publish:
+    runs-on: ubuntu-20.04
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Set up JDK
-        uses: actions/setup-java@v1
+      - uses: actions/checkout@v2
+      - uses: gradle/wrapper-validation-action@v1
+      - uses: actions/setup-java@v2
         with:
-          java-version: 1.8
+          distribution: "adopt-hotspot"
+          java-version: "11.0.11+9"
 
-      - name: Gradle cache
-        uses: actions/cache@v2
+      - uses: actions/cache@v2
         with:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
             ~/.konan
-          key: ${{ runner.os }}-publish-${{ hashFiles('**/build.gradle.kts') }}
+            ~/.android/build-cache
+            ~/.android/cache
+          key: ${{ runner.os }}-publish-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-publish-
             ${{ runner.os }}-
 
-      - name: Check
-        run: ./gradlew $GRADLE_ARGS check
-
-      - name: Keyring
-        run: echo "${{ secrets.SIGNING_SECRET_KEY_RING }}" | base64 --decode > ~/secring.gpg
-
-      - name: Publish
-        env:
-          SONATYPE_NEXUS_USERNAME: ${{ secrets.OSS_SONATYPE_NEXUS_USERNAME }}
-          SONATYPE_NEXUS_PASSWORD: ${{ secrets.OSS_SONATYPE_NEXUS_PASSWORD }}
-        run: >-
+      - run: ./gradlew check
+      - run: >-
           ./gradlew
-          $GRADLE_ARGS
           --no-parallel
-          -PVERSION_NAME=${GITHUB_REF/refs\/tags\//}
-          -Psigning.keyId="${{ secrets.SIGNING_KEY_ID }}"
-          -Psigning.password="${{ secrets.SIGNING_PASSWORD }}"
-          -Psigning.secretKeyRingFile="$HOME/secring.gpg"
-          uploadArchives
+          -PVERSION_NAME="${GITHUB_REF/refs\/tags\//}"
+          -PsigningInMemoryKey="${{ secrets.SIGNING_KEY }}"
+          -PsigningInMemoryKeyPassword="${{ secrets.SIGNING_PASSWORD }}"
+          -PmavenCentralUsername="${{ secrets.OSS_SONATYPE_NEXUS_USERNAME }}"
+          -PmavenCentralPassword="${{ secrets.OSS_SONATYPE_NEXUS_PASSWORD }}"
+          publish
+
+      - run: |
+          rm -f ~/.gradle/caches/modules-2/modules-2.lock
+          rm -f ~/.gradle/caches/modules-2/gc.properties

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -4,44 +4,42 @@ on:
     branches:
       - main
 
+env:
+  GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+
 jobs:
   snapshot:
-    runs-on: ubuntu-18.04
-    # Use the following line instead if we add an OSX target.
-    # runs-on: macos-10.15
-
-    env:
-      GRADLE_ARGS: >-
-        --no-daemon
-        --max-workers 2
-        -Pkotlin.incremental=false
-
+    runs-on: ubuntu-20.04
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Set up JDK
-        uses: actions/setup-java@v1
+      - uses: actions/checkout@v2
+      - uses: gradle/wrapper-validation-action@v1
+      - uses: actions/setup-java@v2
         with:
-          java-version: 1.8
+          distribution: "adopt-hotspot"
+          java-version: "11.0.11+9"
 
-      - name: Gradle cache
-        uses: actions/cache@v2
+      - uses: actions/cache@v2
         with:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
             ~/.konan
-          key: ${{ runner.os }}-snapshot-${{ hashFiles('**/build.gradle.kts') }}
+            ~/.android/build-cache
+            ~/.android/cache
+          key: ${{ runner.os }}-snapshot-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-snapshot-
             ${{ runner.os }}-
 
-      - name: Check
-        run: ./gradlew $GRADLE_ARGS check
+      - run: ./gradlew check
+      - run: >-
+          ./gradlew
+          --no-parallel
+          -PVERSION_NAME=main-SNAPSHOT
+          -PmavenCentralUsername="${{ secrets.OSS_SONATYPE_NEXUS_USERNAME }}"
+          -PmavenCentralPassword="${{ secrets.OSS_SONATYPE_NEXUS_PASSWORD }}"
+          publish
 
-      - name: Snapshot
-        env:
-          SONATYPE_NEXUS_USERNAME: ${{ secrets.OSS_SONATYPE_NEXUS_USERNAME }}
-          SONATYPE_NEXUS_PASSWORD: ${{ secrets.OSS_SONATYPE_NEXUS_PASSWORD }}
-        run: ./gradlew $GRADLE_ARGS --no-parallel -PVERSION_NAME=main-SNAPSHOT uploadArchives
+      - run: |
+          rm -f ~/.gradle/caches/modules-2/modules-2.lock
+          rm -f ~/.gradle/caches/modules-2/gc.properties

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,3 @@
-import org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
-import java.net.URI
-
 buildscript {
     repositories {
         google()
@@ -14,7 +11,7 @@ plugins {
     id("com.android.library") version "4.2.0" apply false
     id("kotlinx-atomicfu") version "0.16.2" apply false
     id("org.jmailen.kotlinter") version "3.4.5" apply false
-    id("org.jetbrains.dokka") version "1.4.30"
+    id("org.jetbrains.dokka") version "1.5.0"
     id("com.vanniktech.maven.publish") version "0.17.0" apply false
     id("net.mbonnin.one.eight") version "0.2"
 
@@ -23,21 +20,19 @@ plugins {
     // > org.gradle.api.internal.tasks.DefaultTaskContainer$DuplicateTaskException: Cannot add task 'apiBuild' as a task with that name already exists.
     //
     // Disabling until https://github.com/Kotlin/binary-compatibility-validator/issues/38 is fixed.
-    //    id("binary-compatibility-validator") version "0.6.0"
+//    id("binary-compatibility-validator") version "0.6.0"
 }
 
 allprojects {
     repositories {
         google()
         mavenCentral()
-        maven("https://maven.pkg.jetbrains.space/public/p/kotlinx-html/maven")
-        maven("https://kotlin.bintray.com/kotlinx/")
     }
 
     tasks.withType<Test>().configureEach {
         testLogging {
             events("started", "passed", "skipped", "failed", "standardOut", "standardError")
-            exceptionFormat = FULL
+            exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
             showExceptions = true
             showStackTraces = true
             showCauses = true


### PR DESCRIPTION
Supports the latest version of `com.vanniktech.maven.publish` Gradle plugin that was updated in #31.
Adds Gradle wrapper validator.
Now properly supports building PRs from forks.

Also removes Mac OS X configuration (that was commented out), we can update CI scripts with Mac OS X configuration when we have a need for that virtual environment.