### PR TITLE
Implement Data Selection API

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ buildscript {
 }
 
 plugins {
-    kotlin("multiplatform") version "1.5.20" apply false
+    kotlin("multiplatform") version "1.6.0" apply false
     id("com.android.application") version "4.2.0" apply false
     id("com.android.library") version "4.2.0" apply false
     id("kotlinx-atomicfu") version "0.16.2" apply false

--- a/buildSrc/src/main/kotlin/AndroidSdk.kt
+++ b/buildSrc/src/main/kotlin/AndroidSdk.kt
@@ -1,8 +1,8 @@
 object AndroidSdk {
     private const val KitKat = 19
-    private const val R = 31
+    private const val S = 31
 
     const val Minimum = KitKat
-    const val Target = R
-    const val Compile = R
+    const val Target = S
+    const val Compile = S
 }

--- a/buildSrc/src/main/kotlin/AndroidSdk.kt
+++ b/buildSrc/src/main/kotlin/AndroidSdk.kt
@@ -1,6 +1,6 @@
 object AndroidSdk {
     private const val KitKat = 19
-    private const val R = 30
+    private const val R = 31
 
     const val Minimum = KitKat
     const val Target = R

--- a/color/build.gradle.kts
+++ b/color/build.gradle.kts
@@ -19,10 +19,6 @@ kotlin {
     js().browser()
 
     sourceSets {
-        all {
-            languageSettings.enableLanguageFeature("InlineClasses")
-        }
-
         val commonTest by getting {
             dependencies {
                 implementation(tuulbox.test())

--- a/color/src/commonMain/kotlin/Color.kt
+++ b/color/src/commonMain/kotlin/Color.kt
@@ -1,9 +1,11 @@
 package com.juul.krayon.color
 
+import kotlin.jvm.JvmInline
 import kotlin.math.roundToInt
 
 /** A color in ARGB color space. */
-public inline class Color(public val argb: Int) {
+@JvmInline
+public value class Color(public val argb: Int) {
 
     /** Create a color from component integers. Components are masked to their last eight bits. */
     public constructor(alpha: Int, red: Int, green: Int, blue: Int) :

--- a/element/build.gradle.kts
+++ b/element/build.gradle.kts
@@ -1,0 +1,52 @@
+plugins {
+    kotlin("multiplatform")
+    id("org.jmailen.kotlinter")
+    jacoco
+    id("org.jetbrains.dokka")
+    id("com.vanniktech.maven.publish")
+}
+
+apply(from = rootProject.file("gradle/jacoco.gradle.kts"))
+
+jacoco {
+    toolVersion = "0.8.7"
+}
+
+kotlin {
+    explicitApi()
+
+    jvm()
+    js().browser()
+
+    sourceSets {
+        all {
+            languageSettings.enableLanguageFeature("InlineClasses")
+        }
+
+        val commonMain by getting {
+            dependencies {
+                api(project(":kanvas"))
+            }
+        }
+
+        val commonTest by getting {
+            dependencies {
+                implementation(tuulbox.test())
+                implementation(kotlin("test-common"))
+                implementation(kotlin("test-annotations-common"))
+            }
+        }
+
+        val jvmTest by getting {
+            dependencies {
+                implementation(kotlin("test-junit"))
+            }
+        }
+
+        val jsTest by getting {
+            dependencies {
+                implementation(kotlin("test-js"))
+            }
+        }
+    }
+}

--- a/element/build.gradle.kts
+++ b/element/build.gradle.kts
@@ -19,10 +19,6 @@ kotlin {
     js().browser()
 
     sourceSets {
-        all {
-            languageSettings.enableLanguageFeature("InlineClasses")
-        }
-
         val commonMain by getting {
             dependencies {
                 api(project(":kanvas"))

--- a/element/gradle.properties
+++ b/element/gradle.properties
@@ -1,0 +1,1 @@
+POM_ARTIFACT_ID=element

--- a/element/src/commonMain/kotlin/CircleElement.kt
+++ b/element/src/commonMain/kotlin/CircleElement.kt
@@ -1,0 +1,15 @@
+package com.juul.krayon.element
+
+import com.juul.krayon.kanvas.Kanvas
+import com.juul.krayon.kanvas.Paint
+
+public class CircleElement(
+    public var centerX: Float,
+    public var centerY: Float,
+    public var radius: Float,
+    public var paint: Paint,
+) : Element() {
+    override fun <PAINT, PATH> applyTo(canvas: Kanvas<PAINT, PATH>) {
+        canvas.drawCircle(centerX, centerY, radius, canvas.buildPaint(paint))
+    }
+}

--- a/element/src/commonMain/kotlin/CircleElement.kt
+++ b/element/src/commonMain/kotlin/CircleElement.kt
@@ -4,14 +4,14 @@ import com.juul.krayon.color.black
 import com.juul.krayon.kanvas.Kanvas
 import com.juul.krayon.kanvas.Paint
 
-public class CircleElement(
-    public var centerX: Float = 0f,
-    public var centerY: Float = 0f,
-    public var radius: Float = 0f,
-    public var paint: Paint = Paint.Fill(black),
-) : Element() {
+public class CircleElement : Element() {
 
-    override fun <PAINT, PATH> applyTo(canvas: Kanvas<PAINT, PATH>) {
+    public var centerX: Float by attributes.withDefault { 0f }
+    public var centerY: Float by attributes.withDefault { 0f }
+    public var radius: Float by attributes.withDefault { 0f }
+    public var paint: Paint by attributes.withDefault { Paint.Fill(black) }
+
+    override fun <PAINT, PATH> draw(canvas: Kanvas<PAINT, PATH>) {
         canvas.drawCircle(centerX, centerY, radius, canvas.buildPaint(paint))
     }
 

--- a/element/src/commonMain/kotlin/CircleElement.kt
+++ b/element/src/commonMain/kotlin/CircleElement.kt
@@ -15,7 +15,8 @@ public class CircleElement(
         canvas.drawCircle(centerX, centerY, radius, canvas.buildPaint(paint))
     }
 
-    public companion object : TypeSelector<CircleElement> {
+    public companion object : ElementBuilder<CircleElement>, TypeSelector<CircleElement> {
+        override fun build(): CircleElement = CircleElement()
         override fun trySelect(element: Element): CircleElement? = element as? CircleElement
     }
 }

--- a/element/src/commonMain/kotlin/CircleElement.kt
+++ b/element/src/commonMain/kotlin/CircleElement.kt
@@ -6,6 +6,8 @@ import com.juul.krayon.kanvas.Paint
 
 public class CircleElement : Element() {
 
+    override val tag: String get() = "circle"
+
     public var centerX: Float by attributes.withDefault { 0f }
     public var centerY: Float by attributes.withDefault { 0f }
     public var radius: Float by attributes.withDefault { 0f }

--- a/element/src/commonMain/kotlin/CircleElement.kt
+++ b/element/src/commonMain/kotlin/CircleElement.kt
@@ -10,7 +10,12 @@ public class CircleElement(
     public var radius: Float = 0f,
     public var paint: Paint = Paint.Fill(black),
 ) : Element() {
+
     override fun <PAINT, PATH> applyTo(canvas: Kanvas<PAINT, PATH>) {
         canvas.drawCircle(centerX, centerY, radius, canvas.buildPaint(paint))
+    }
+
+    public companion object : TypeSelector<CircleElement> {
+        override fun trySelect(element: Element): CircleElement? = element as? CircleElement
     }
 }

--- a/element/src/commonMain/kotlin/Element.kt
+++ b/element/src/commonMain/kotlin/Element.kt
@@ -1,0 +1,47 @@
+package com.juul.krayon.element
+
+import com.juul.krayon.kanvas.Kanvas
+
+public abstract class Element {
+    public var data: Any? = null
+
+    public open var parent: Element? = null
+
+    private val _children: MutableList<Element> = mutableListOf()
+    public val children: List<Element> = _children
+
+    public open fun appendChild(child: Element): Element {
+        child.parent?.removeChild(child)
+        child.parent = this
+        _children.add(child)
+        return child
+    }
+
+    public open fun insertBefore(child: Element, reference: Element?): Element {
+        child.parent?.removeChild(child)
+        child.parent = this
+        when (reference) {
+            null -> _children.add(child)
+            else -> when (val index = children.indexOf(reference)) {
+                -1 -> _children.add(child)
+                else -> _children.add(index, child)
+            }
+        }
+        return child
+    }
+
+    public fun removeChild(child: Element): Element {
+        _children.remove(child)
+        return child
+    }
+
+    public abstract fun <PAINT, PATH> applyTo(canvas: Kanvas<PAINT, PATH>)
+}
+
+public val Element.descendents: Sequence<Element>
+    get() = sequence {
+        for (child in children) {
+            yield(child)
+            yieldAll(child.descendents)
+        }
+    }

--- a/element/src/commonMain/kotlin/Element.kt
+++ b/element/src/commonMain/kotlin/Element.kt
@@ -3,6 +3,9 @@ package com.juul.krayon.element
 import com.juul.krayon.kanvas.Kanvas
 
 public abstract class Element {
+
+    public abstract val tag: String
+
     protected val attributes: MutableMap<String, Any?> = mutableMapOf()
 
     public var data: Any? by attributes.withDefault { null }
@@ -33,8 +36,9 @@ public abstract class Element {
     }
 
     public fun <E : Element> removeChild(child: E): E {
-        child.parent = null
-        _children.remove(child)
+        if (_children.remove(child)) {
+            child.parent = null
+        }
         return child
     }
 
@@ -42,7 +46,7 @@ public abstract class Element {
 
     override fun toString(): String = buildString {
         append('(')
-        append(this@Element::class.simpleName)
+        append(tag)
         for ((key, value) in attributes) {
             append(" :$key $value")
         }

--- a/element/src/commonMain/kotlin/Element.kt
+++ b/element/src/commonMain/kotlin/Element.kt
@@ -1,9 +1,12 @@
 package com.juul.krayon.element
 
 import com.juul.krayon.kanvas.Kanvas
+import kotlin.random.Random
 
 public abstract class Element {
-    public var data: Any? = null
+    protected val attributes: MutableMap<String, Any?> = mutableMapOf()
+
+    public var data: Any? by attributes.withDefault { null }
 
     public open var parent: Element? = null
 
@@ -31,11 +34,25 @@ public abstract class Element {
     }
 
     public fun <E: Element> removeChild(child: E): E {
+        child.parent = null
         _children.remove(child)
         return child
     }
 
-    public abstract fun <PAINT, PATH> applyTo(canvas: Kanvas<PAINT, PATH>)
+    public abstract fun <PAINT, PATH> draw(canvas: Kanvas<PAINT, PATH>)
+
+    override fun toString(): String = buildString {
+        append('(')
+        append(this@Element::class.simpleName)
+        for ((key, value) in attributes) {
+            append(" :$key $value")
+        }
+        for (child in children) {
+            append(' ')
+            append(child)
+        }
+        append(')')
+    }
 }
 
 public val Element.descendents: Sequence<Element>

--- a/element/src/commonMain/kotlin/Element.kt
+++ b/element/src/commonMain/kotlin/Element.kt
@@ -1,7 +1,6 @@
 package com.juul.krayon.element
 
 import com.juul.krayon.kanvas.Kanvas
-import kotlin.random.Random
 
 public abstract class Element {
     protected val attributes: MutableMap<String, Any?> = mutableMapOf()
@@ -13,14 +12,14 @@ public abstract class Element {
     private val _children: MutableList<Element> = mutableListOf()
     public val children: List<Element> = _children
 
-    public open fun <E: Element> appendChild(child: E): E {
+    public open fun <E : Element> appendChild(child: E): E {
         child.parent?.removeChild(child)
         child.parent = this
         _children.add(child)
         return child
     }
 
-    public open fun <E: Element> insertBefore(child: E, reference: Element?): E {
+    public open fun <E : Element> insertBefore(child: E, reference: Element?): E {
         child.parent?.removeChild(child)
         child.parent = this
         when (reference) {
@@ -33,7 +32,7 @@ public abstract class Element {
         return child
     }
 
-    public fun <E: Element> removeChild(child: E): E {
+    public fun <E : Element> removeChild(child: E): E {
         child.parent = null
         _children.remove(child)
         return child

--- a/element/src/commonMain/kotlin/Element.kt
+++ b/element/src/commonMain/kotlin/Element.kt
@@ -10,14 +10,14 @@ public abstract class Element {
     private val _children: MutableList<Element> = mutableListOf()
     public val children: List<Element> = _children
 
-    public open fun appendChild(child: Element): Element {
+    public open fun <E: Element> appendChild(child: E): E {
         child.parent?.removeChild(child)
         child.parent = this
         _children.add(child)
         return child
     }
 
-    public open fun insertBefore(child: Element, reference: Element?): Element {
+    public open fun <E: Element> insertBefore(child: E, reference: Element?): E {
         child.parent?.removeChild(child)
         child.parent = this
         when (reference) {
@@ -30,7 +30,7 @@ public abstract class Element {
         return child
     }
 
-    public fun removeChild(child: Element): Element {
+    public fun <E: Element> removeChild(child: E): E {
         _children.remove(child)
         return child
     }

--- a/element/src/commonMain/kotlin/Element.kt
+++ b/element/src/commonMain/kotlin/Element.kt
@@ -58,10 +58,10 @@ public abstract class Element {
     }
 }
 
-public val Element.descendents: Sequence<Element>
+public val Element.descendants: Sequence<Element>
     get() = sequence {
         for (child in children) {
             yield(child)
-            yieldAll(child.descendents)
+            yieldAll(child.descendants)
         }
     }

--- a/element/src/commonMain/kotlin/ElementBuilder.kt
+++ b/element/src/commonMain/kotlin/ElementBuilder.kt
@@ -1,0 +1,5 @@
+package com.juul.krayon.element
+
+public interface ElementBuilder<E: Element> {
+    public fun build(): E
+}

--- a/element/src/commonMain/kotlin/ElementBuilder.kt
+++ b/element/src/commonMain/kotlin/ElementBuilder.kt
@@ -1,5 +1,5 @@
 package com.juul.krayon.element
 
-public interface ElementBuilder<E: Element> {
+public interface ElementBuilder<E : Element> {
     public fun build(): E
 }

--- a/element/src/commonMain/kotlin/GroupElement.kt
+++ b/element/src/commonMain/kotlin/GroupElement.kt
@@ -1,0 +1,16 @@
+package com.juul.krayon.element
+
+import com.juul.krayon.kanvas.Kanvas
+import com.juul.krayon.kanvas.Transform
+import com.juul.krayon.kanvas.withTransform
+
+public class GroupElement(
+    public var transform: Transform
+) : Element() {
+
+    override fun <PAINT, PATH> applyTo(canvas: Kanvas<PAINT, PATH>) {
+        canvas.withTransform(transform) {
+            descendents.forEach { it.applyTo(canvas) }
+        }
+    }
+}

--- a/element/src/commonMain/kotlin/RectangleElement.kt
+++ b/element/src/commonMain/kotlin/RectangleElement.kt
@@ -6,6 +6,8 @@ import com.juul.krayon.kanvas.Paint
 
 public class RectangleElement : Element() {
 
+    override val tag: String get() = "rectangle"
+
     public var left: Float by attributes.withDefault { 0f }
     public var top: Float by attributes.withDefault { 0f }
     public var right: Float by attributes.withDefault { 0f }

--- a/element/src/commonMain/kotlin/RectangleElement.kt
+++ b/element/src/commonMain/kotlin/RectangleElement.kt
@@ -4,13 +4,15 @@ import com.juul.krayon.color.black
 import com.juul.krayon.kanvas.Kanvas
 import com.juul.krayon.kanvas.Paint
 
-public class CircleElement(
-    public var centerX: Float = 0f,
-    public var centerY: Float = 0f,
-    public var radius: Float = 0f,
+public class RectangleElement(
+    public var left: Float = 0f,
+    public var top: Float = 0f,
+    public var right: Float = 0f,
+    public var bottom: Float = 0f,
     public var paint: Paint = Paint.Fill(black),
 ) : Element() {
+
     override fun <PAINT, PATH> applyTo(canvas: Kanvas<PAINT, PATH>) {
-        canvas.drawCircle(centerX, centerY, radius, canvas.buildPaint(paint))
+        canvas.drawRect(left, top, right, bottom, canvas.buildPaint(paint))
     }
 }

--- a/element/src/commonMain/kotlin/RectangleElement.kt
+++ b/element/src/commonMain/kotlin/RectangleElement.kt
@@ -16,7 +16,8 @@ public class RectangleElement(
         canvas.drawRect(left, top, right, bottom, canvas.buildPaint(paint))
     }
 
-    public companion object : TypeSelector<RectangleElement> {
+    public companion object : ElementBuilder<RectangleElement>, TypeSelector<RectangleElement> {
+        override fun build(): RectangleElement = RectangleElement()
         override fun trySelect(element: Element): RectangleElement? = element as? RectangleElement
     }
 }

--- a/element/src/commonMain/kotlin/RectangleElement.kt
+++ b/element/src/commonMain/kotlin/RectangleElement.kt
@@ -15,4 +15,8 @@ public class RectangleElement(
     override fun <PAINT, PATH> applyTo(canvas: Kanvas<PAINT, PATH>) {
         canvas.drawRect(left, top, right, bottom, canvas.buildPaint(paint))
     }
+
+    public companion object : TypeSelector<RectangleElement> {
+        override fun trySelect(element: Element): RectangleElement? = element as? RectangleElement
+    }
 }

--- a/element/src/commonMain/kotlin/RectangleElement.kt
+++ b/element/src/commonMain/kotlin/RectangleElement.kt
@@ -4,15 +4,15 @@ import com.juul.krayon.color.black
 import com.juul.krayon.kanvas.Kanvas
 import com.juul.krayon.kanvas.Paint
 
-public class RectangleElement(
-    public var left: Float = 0f,
-    public var top: Float = 0f,
-    public var right: Float = 0f,
-    public var bottom: Float = 0f,
-    public var paint: Paint = Paint.Fill(black),
-) : Element() {
+public class RectangleElement : Element() {
 
-    override fun <PAINT, PATH> applyTo(canvas: Kanvas<PAINT, PATH>) {
+    public var left: Float by attributes.withDefault { 0f }
+    public var top: Float by attributes.withDefault { 0f }
+    public var right: Float by attributes.withDefault { 0f }
+    public var bottom: Float by attributes.withDefault { 0f }
+    public var paint: Paint by attributes.withDefault { Paint.Fill(black) }
+
+    override fun <PAINT, PATH> draw(canvas: Kanvas<PAINT, PATH>) {
         canvas.drawRect(left, top, right, bottom, canvas.buildPaint(paint))
     }
 

--- a/element/src/commonMain/kotlin/RootElement.kt
+++ b/element/src/commonMain/kotlin/RootElement.kt
@@ -3,7 +3,12 @@ package com.juul.krayon.element
 import com.juul.krayon.kanvas.Kanvas
 
 public class RootElement : Element() {
+
     override fun <PAINT, PATH> applyTo(canvas: Kanvas<PAINT, PATH>) {
         descendents.forEach { it.applyTo(canvas) }
+    }
+
+    public companion object : TypeSelector<RootElement> {
+        override fun trySelect(element: Element): RootElement? = element as? RootElement
     }
 }

--- a/element/src/commonMain/kotlin/RootElement.kt
+++ b/element/src/commonMain/kotlin/RootElement.kt
@@ -1,0 +1,9 @@
+package com.juul.krayon.element
+
+import com.juul.krayon.kanvas.Kanvas
+
+public class RootElement : Element() {
+    override fun <PAINT, PATH> applyTo(canvas: Kanvas<PAINT, PATH>) {
+        descendents.forEach { it.applyTo(canvas) }
+    }
+}

--- a/element/src/commonMain/kotlin/RootElement.kt
+++ b/element/src/commonMain/kotlin/RootElement.kt
@@ -4,8 +4,8 @@ import com.juul.krayon.kanvas.Kanvas
 
 public class RootElement : Element() {
 
-    override fun <PAINT, PATH> applyTo(canvas: Kanvas<PAINT, PATH>) {
-        descendents.forEach { it.applyTo(canvas) }
+    override fun <PAINT, PATH> draw(canvas: Kanvas<PAINT, PATH>) {
+        descendents.forEach { it.draw(canvas) }
     }
 
     public companion object : TypeSelector<RootElement> {

--- a/element/src/commonMain/kotlin/RootElement.kt
+++ b/element/src/commonMain/kotlin/RootElement.kt
@@ -7,7 +7,7 @@ public class RootElement : Element() {
     override val tag: String get() = "root"
 
     override fun <PAINT, PATH> draw(canvas: Kanvas<PAINT, PATH>) {
-        descendents.forEach { it.draw(canvas) }
+        children.forEach { it.draw(canvas) }
     }
 
     public companion object : TypeSelector<RootElement> {

--- a/element/src/commonMain/kotlin/RootElement.kt
+++ b/element/src/commonMain/kotlin/RootElement.kt
@@ -4,6 +4,8 @@ import com.juul.krayon.kanvas.Kanvas
 
 public class RootElement : Element() {
 
+    override val tag: String get() = "root"
+
     override fun <PAINT, PATH> draw(canvas: Kanvas<PAINT, PATH>) {
         descendents.forEach { it.draw(canvas) }
     }

--- a/element/src/commonMain/kotlin/TransformElement.kt
+++ b/element/src/commonMain/kotlin/TransformElement.kt
@@ -4,13 +4,12 @@ import com.juul.krayon.kanvas.Kanvas
 import com.juul.krayon.kanvas.Transform
 import com.juul.krayon.kanvas.withTransform
 
-public class TransformElement(
-    public var transform: Transform = Transform.Translate()
-) : Element() {
+public class TransformElement : Element() {
+    public var transform: Transform by attributes.withDefault { Transform.Translate() }
 
-    override fun <PAINT, PATH> applyTo(canvas: Kanvas<PAINT, PATH>) {
+    override fun <PAINT, PATH> draw(canvas: Kanvas<PAINT, PATH>) {
         canvas.withTransform(transform) {
-            descendents.forEach { it.applyTo(canvas) }
+            descendents.forEach { it.draw(canvas) }
         }
     }
 

--- a/element/src/commonMain/kotlin/TransformElement.kt
+++ b/element/src/commonMain/kotlin/TransformElement.kt
@@ -5,7 +5,7 @@ import com.juul.krayon.kanvas.Transform
 import com.juul.krayon.kanvas.withTransform
 
 public class TransformElement(
-    public var transform: Transform
+    public var transform: Transform = Transform.Translate()
 ) : Element() {
 
     override fun <PAINT, PATH> applyTo(canvas: Kanvas<PAINT, PATH>) {
@@ -14,7 +14,8 @@ public class TransformElement(
         }
     }
 
-    public companion object : TypeSelector<TransformElement> {
+    public companion object : ElementBuilder<TransformElement>, TypeSelector<TransformElement> {
+        override fun build(): TransformElement = TransformElement()
         override fun trySelect(element: Element): TransformElement? = element as? TransformElement
     }
 }

--- a/element/src/commonMain/kotlin/TransformElement.kt
+++ b/element/src/commonMain/kotlin/TransformElement.kt
@@ -12,7 +12,7 @@ public class TransformElement : Element() {
 
     override fun <PAINT, PATH> draw(canvas: Kanvas<PAINT, PATH>) {
         canvas.withTransform(transform) {
-            descendents.forEach { it.draw(canvas) }
+            children.forEach { it.draw(canvas) }
         }
     }
 

--- a/element/src/commonMain/kotlin/TransformElement.kt
+++ b/element/src/commonMain/kotlin/TransformElement.kt
@@ -13,4 +13,8 @@ public class TransformElement(
             descendents.forEach { it.applyTo(canvas) }
         }
     }
+
+    public companion object : TypeSelector<TransformElement> {
+        override fun trySelect(element: Element): TransformElement? = element as? TransformElement
+    }
 }

--- a/element/src/commonMain/kotlin/TransformElement.kt
+++ b/element/src/commonMain/kotlin/TransformElement.kt
@@ -4,7 +4,7 @@ import com.juul.krayon.kanvas.Kanvas
 import com.juul.krayon.kanvas.Transform
 import com.juul.krayon.kanvas.withTransform
 
-public class GroupElement(
+public class TransformElement(
     public var transform: Transform
 ) : Element() {
 

--- a/element/src/commonMain/kotlin/TransformElement.kt
+++ b/element/src/commonMain/kotlin/TransformElement.kt
@@ -5,6 +5,9 @@ import com.juul.krayon.kanvas.Transform
 import com.juul.krayon.kanvas.withTransform
 
 public class TransformElement : Element() {
+
+    override val tag: String get() = "transform"
+
     public var transform: Transform by attributes.withDefault { Transform.Translate() }
 
     override fun <PAINT, PATH> draw(canvas: Kanvas<PAINT, PATH>) {

--- a/element/src/commonMain/kotlin/TypeSelector.kt
+++ b/element/src/commonMain/kotlin/TypeSelector.kt
@@ -1,5 +1,5 @@
 package com.juul.krayon.element
 
-public interface TypeSelector<E: Element> {
+public interface TypeSelector<E : Element> {
     public fun trySelect(element: Element): E?
 }

--- a/element/src/commonMain/kotlin/TypeSelector.kt
+++ b/element/src/commonMain/kotlin/TypeSelector.kt
@@ -1,0 +1,5 @@
+package com.juul.krayon.element
+
+public interface TypeSelector<E: Element> {
+    public fun trySelect(element: Element): E?
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -31,4 +31,4 @@ POM_DEVELOPER_NAME=Travis Wyatt
 POM_DEVELOPER_URL=https://github.com/twyatt
 
 kotlin.js.webpack.major.version=5
-kotlin.js.compiler=both
+kotlin.js.compiler=IR

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/kanvas/build.gradle.kts
+++ b/kanvas/build.gradle.kts
@@ -42,7 +42,7 @@ kotlin {
 
         val androidMain by getting {
             dependencies {
-                implementation("androidx.appcompat:appcompat:1.3.0")
+                implementation("androidx.appcompat:appcompat:1.4.0")
             }
         }
 

--- a/kanvas/build.gradle.kts
+++ b/kanvas/build.gradle.kts
@@ -21,10 +21,6 @@ kotlin {
     js().browser()
 
     sourceSets {
-        all {
-            languageSettings.enableLanguageFeature("InlineClasses")
-        }
-
         val commonMain by getting {
             dependencies {
                 api(project(":color"))

--- a/kanvas/src/commonMain/kotlin/RelativePathBuilder.kt
+++ b/kanvas/src/commonMain/kotlin/RelativePathBuilder.kt
@@ -16,7 +16,8 @@ public abstract class RelativePathBuilder<P> : PathBuilder<P> {
     private var lastX: Float = 0f
     private var lastY: Float = 0f
 
-    public fun getState(): State = State(closeToX, closeToY, lastX, lastY)
+    public val state: State
+        get() = State(closeToX, closeToY, lastX, lastY)
 
     private fun updatePosition(x: Float, y: Float) {
         lastX = x

--- a/kanvas/src/commonMain/kotlin/RelativePathBuilder.kt
+++ b/kanvas/src/commonMain/kotlin/RelativePathBuilder.kt
@@ -3,11 +3,20 @@ package com.juul.krayon.kanvas
 /** Handles relative path building when the underlying output type can't. */
 public abstract class RelativePathBuilder<P> : PathBuilder<P> {
 
+    public data class State(
+        val closeToX: Float = 0f,
+        val closeToY: Float = 0f,
+        val lastX: Float = 0f,
+        val lastY: Float = 0f,
+    )
+
     private var closeToX: Float = 0f
     private var closeToY: Float = 0f
 
     private var lastX: Float = 0f
     private var lastY: Float = 0f
+
+    public fun getState(): State = State(closeToX, closeToY, lastX, lastY)
 
     private fun updatePosition(x: Float, y: Float) {
         lastX = x
@@ -90,15 +99,4 @@ public abstract class RelativePathBuilder<P> : PathBuilder<P> {
         closeToX = 0f
         closeToY = 0f
     }
-
-    /** No @TestOnly or @VisibleForTesting or anything in Kotlin Multiplatform. */
-    internal fun getTestState() = TestState(closeToX, closeToY, lastX, lastY)
-
-    /** No @TestOnly or @VisibleForTesting or anything in Kotlin Multiplatform. */
-    internal data class TestState(
-        val closeToX: Float = 0f,
-        val closeToY: Float = 0f,
-        val lastX: Float = 0f,
-        val lastY: Float = 0f,
-    )
 }

--- a/kanvas/src/commonMain/kotlin/svg/PathString.kt
+++ b/kanvas/src/commonMain/kotlin/svg/PathString.kt
@@ -4,9 +4,11 @@ import com.juul.krayon.kanvas.PathBuilder
 import com.juul.krayon.kanvas.getEllipseX
 import com.juul.krayon.kanvas.getEllipseY
 import com.juul.krayon.kanvas.xml.NumberFormatter
+import kotlin.jvm.JvmInline
 import kotlin.math.abs
 
-public inline class PathString(public val string: String)
+@JvmInline
+public value class PathString(public val string: String)
 
 internal class PathStringBuilder(private val fmt: NumberFormatter) : PathBuilder<PathString> {
     private val buffer = StringBuilder()

--- a/kanvas/src/commonTest/kotlin/Call.kt
+++ b/kanvas/src/commonTest/kotlin/Call.kt
@@ -1,8 +1,6 @@
 package com.juul.krayon.kanvas
 
-import kotlin.reflect.KCallable
-
 data class Call(
-    val callable: KCallable<*>,
+    val callableName: String,
     val arguments: List<Any?>,
 )

--- a/kanvas/src/commonTest/kotlin/CallRecord.kt
+++ b/kanvas/src/commonTest/kotlin/CallRecord.kt
@@ -6,40 +6,40 @@ interface CallRecord {
     val calls: List<Call>
 }
 
-inline fun CallRecord.verify(
+fun CallRecord.verify(
     expectation: String,
-    crossinline condition: (calls: List<Call>) -> Boolean,
+    condition: (calls: List<Call>) -> Boolean,
 ) {
     if (!calls.run(condition)) {
         fail("Unable to verify `$expectation`. Recorded calls:\n${calls.joinToString(separator = "\n")}")
     }
 }
 
-inline fun CallRecord.verifyAll(
+fun CallRecord.verifyAll(
     expectation: String,
-    crossinline predicate: (Call) -> Boolean,
+    predicate: (Call) -> Boolean,
 ) = verify(expectation) { it.all(predicate) }
 
-inline fun CallRecord.verifyAny(
+fun CallRecord.verifyAny(
     expectation: String,
-    crossinline predicate: (Call) -> Boolean,
+    predicate: (Call) -> Boolean,
 ) = verify(expectation) { it.any(predicate) }
 
 fun CallRecord.verifyCallCount(expectedCount: Int) {
     verify("call count is $expectedCount") { it.size == expectedCount }
 }
 
-inline fun CallRecord.verifyFirst(
+fun CallRecord.verifyFirst(
     expectation: String,
-    crossinline predicate: (Call) -> Boolean,
+    predicate: (Call) -> Boolean,
 ) = verify(expectation) { it.first().run(predicate) }
 
-inline fun CallRecord.verifyLast(
+fun CallRecord.verifyLast(
     expectation: String,
-    crossinline predicate: (Call) -> Boolean,
+    predicate: (Call) -> Boolean,
 ) = verify(expectation) { it.last().run(predicate) }
 
-inline fun CallRecord.verifySingle(
+fun CallRecord.verifySingle(
     expectation: String,
-    crossinline predicate: (Call) -> Boolean,
+    predicate: (Call) -> Boolean,
 ) = verify(expectation) { it.count(predicate) == 1 }

--- a/kanvas/src/commonTest/kotlin/CallRecorder.kt
+++ b/kanvas/src/commonTest/kotlin/CallRecorder.kt
@@ -1,14 +1,12 @@
 package com.juul.krayon.kanvas
 
-import kotlin.reflect.KCallable
-
 class CallRecorder : CallRecord {
 
     private val _calls = mutableListOf<Call>()
     override val calls: List<Call>
         get() = _calls
 
-    fun record(function: KCallable<*>, vararg args: Any?) {
-        _calls += Call(function, args.toList())
+    fun record(functionName: String, vararg args: Any?) {
+        _calls += Call(functionName, args.toList())
     }
 }

--- a/kanvas/src/commonTest/kotlin/CallRecordingKanvas.kt
+++ b/kanvas/src/commonTest/kotlin/CallRecordingKanvas.kt
@@ -17,24 +17,24 @@ class CallRecordingKanvas(
     private val _width = width
     override val width: Float
         get() {
-            recorder.record(this::width)
+            recorder.record("width")
             return _width
         }
 
     private val _height = height
     override val height: Float
         get() {
-            recorder.record(this::height)
+            recorder.record("height")
             return _height
         }
 
     override fun buildPaint(paint: Paint): UnitPaint {
-        recorder.record(this::buildPaint, paint)
+        recorder.record("buildPaint", paint)
         return UnitPaint
     }
 
     override fun buildPath(actions: PathBuilder<*>.() -> Unit): UnitPath {
-        recorder.record(this::buildPath, actions)
+        recorder.record("buildPath", actions)
         return UnitPath
     }
 
@@ -47,46 +47,46 @@ class CallRecordingKanvas(
         sweepAngle: Float,
         paint: UnitPaint,
     ) {
-        recorder.record(this::drawArc, left, top, right, bottom, startAngle, sweepAngle, paint)
+        recorder.record("drawArc", left, top, right, bottom, startAngle, sweepAngle, paint)
     }
 
     override fun drawCircle(centerX: Float, centerY: Float, radius: Float, paint: UnitPaint) {
-        recorder.record(this::drawCircle, centerX, centerY, radius, paint)
+        recorder.record("drawCircle", centerX, centerY, radius, paint)
     }
 
     override fun drawColor(color: Color) {
-        recorder.record(this::drawColor, color)
+        recorder.record("drawColor", color)
     }
 
     override fun drawLine(startX: Float, startY: Float, endX: Float, endY: Float, paint: UnitPaint) {
-        recorder.record(this::drawLine, startX, startY, endX, endY, paint)
+        recorder.record("drawLine", startX, startY, endX, endY, paint)
     }
 
     override fun drawOval(left: Float, top: Float, right: Float, bottom: Float, paint: UnitPaint) {
-        recorder.record(this::drawOval, left, top, right, bottom, paint)
+        recorder.record("drawOval", left, top, right, bottom, paint)
     }
 
     override fun drawPath(path: UnitPath, paint: UnitPaint) {
-        recorder.record(this::drawPath, path, paint)
+        recorder.record("drawPath", path, paint)
     }
 
     override fun drawRect(left: Float, top: Float, right: Float, bottom: Float, paint: UnitPaint) {
-        recorder.record(this::drawRect, left, top, right, bottom, paint)
+        recorder.record("drawRect", left, top, right, bottom, paint)
     }
 
     override fun drawText(text: CharSequence, x: Float, y: Float, paint: UnitPaint) {
-        recorder.record(this::drawText, text, x, y, paint)
+        recorder.record("drawText", text, x, y, paint)
     }
 
     override fun pushClip(clip: Clip<UnitPath>) {
-        recorder.record(this::pushClip, clip)
+        recorder.record("pushClip", clip)
     }
 
     override fun pushTransform(transform: Transform) {
-        recorder.record(this::pushTransform, transform)
+        recorder.record("pushTransform", transform)
     }
 
     override fun pop() {
-        recorder.record(this::pop)
+        recorder.record("pop")
     }
 }

--- a/kanvas/src/commonTest/kotlin/CallRecordingPathBuilder.kt
+++ b/kanvas/src/commonTest/kotlin/CallRecordingPathBuilder.kt
@@ -7,42 +7,42 @@ class CallRecordingPathBuilder : RelativePathBuilder<UnitPath>(), CallRecord {
 
     override fun moveTo(x: Float, y: Float) {
         super.moveTo(x, y)
-        recorder.record(this::moveTo, x, y)
+        recorder.record("moveTo", x, y)
     }
 
     override fun relativeMoveTo(x: Float, y: Float) {
         super.relativeMoveTo(x, y)
-        recorder.record(this::relativeMoveTo, x, y)
+        recorder.record("relativeMoveTo", x, y)
     }
 
     override fun lineTo(x: Float, y: Float) {
         super.lineTo(x, y)
-        recorder.record(this::lineTo, x, y)
+        recorder.record("lineTo", x, y)
     }
 
     override fun relativeLineTo(x: Float, y: Float) {
         super.relativeLineTo(x, y)
-        recorder.record(this::relativeLineTo, x, y)
+        recorder.record("relativeLineTo", x, y)
     }
 
     override fun arcTo(left: Float, top: Float, right: Float, bottom: Float, startAngle: Float, sweepAngle: Float, forceMoveTo: Boolean) {
         super.arcTo(left, top, right, bottom, startAngle, sweepAngle, forceMoveTo)
-        recorder.record(this::arcTo, left, top, right, bottom, startAngle, sweepAngle, forceMoveTo)
+        recorder.record("arcTo", left, top, right, bottom, startAngle, sweepAngle, forceMoveTo)
     }
 
     override fun quadraticTo(controlX: Float, controlY: Float, endX: Float, endY: Float) {
         super.quadraticTo(controlX, controlY, endX, endY)
-        recorder.record(this::quadraticTo, controlX, controlY, endX, endY)
+        recorder.record("quadraticTo", controlX, controlY, endX, endY)
     }
 
     override fun relativeQuadraticTo(controlX: Float, controlY: Float, endX: Float, endY: Float) {
         super.relativeQuadraticTo(controlX, controlY, endX, endY)
-        recorder.record(this::relativeQuadraticTo, controlX, controlY, endX, endY)
+        recorder.record("relativeQuadraticTo", controlX, controlY, endX, endY)
     }
 
     override fun cubicTo(beginControlX: Float, beginControlY: Float, endControlX: Float, endControlY: Float, endX: Float, endY: Float) {
         super.cubicTo(beginControlX, beginControlY, endControlX, endControlY, endX, endY)
-        recorder.record(this::cubicTo, beginControlX, beginControlY, endControlX, endControlY, endX, endY)
+        recorder.record("cubicTo", beginControlX, beginControlY, endControlX, endControlY, endX, endY)
     }
 
     override fun relativeCubicTo(
@@ -54,21 +54,21 @@ class CallRecordingPathBuilder : RelativePathBuilder<UnitPath>(), CallRecord {
         endY: Float,
     ) {
         super.relativeCubicTo(beginControlX, beginControlY, endControlX, endControlY, endX, endY)
-        recorder.record(this::relativeCubicTo, beginControlX, beginControlY, endControlX, endControlY, endX, endY)
+        recorder.record("relativeCubicTo", beginControlX, beginControlY, endControlX, endControlY, endX, endY)
     }
 
     override fun close() {
         super.close()
-        recorder.record(this::close)
+        recorder.record("close")
     }
 
     override fun reset() {
         super.reset()
-        recorder.record(this::reset)
+        recorder.record("reset")
     }
 
     override fun build(): UnitPath {
-        recorder.record(this::build)
+        recorder.record("build")
         return UnitPath
     }
 }

--- a/kanvas/src/commonTest/kotlin/KanvasExtensionTests.kt
+++ b/kanvas/src/commonTest/kotlin/KanvasExtensionTests.kt
@@ -12,10 +12,10 @@ class KanvasExtensionTests {
             val paint = canvas.buildPaint(Paint.Stroke(black, 1f))
             canvas.drawLine(0f, 0f, 10f, 10f, paint)
         }
-        canvas.verifyFirst("pushClip called first") { it.callable.name == canvas::pushClip.name }
-        canvas.verifyAny("lambda was called") { it.callable.name == canvas::buildPaint.name }
-        canvas.verifyAny("lambda was called") { it.callable.name == canvas::drawLine.name }
-        canvas.verifyLast("pop was called last") { it.callable.name == canvas::pop.name }
+        canvas.verifyFirst("pushClip called first") { it.callableName == "pushClip" }
+        canvas.verifyAny("lambda was called") { it.callableName == "buildPaint" }
+        canvas.verifyAny("lambda was called") { it.callableName == "drawLine" }
+        canvas.verifyLast("pop was called last") { it.callableName == "pop" }
         canvas.verifyCallCount(4)
     }
 
@@ -26,10 +26,10 @@ class KanvasExtensionTests {
             val paint = canvas.buildPaint(Paint.Stroke(black, 1f))
             canvas.drawLine(0f, 0f, 10f, 10f, paint)
         }
-        canvas.verifyFirst("pushTransform called first") { it.callable.name == canvas::pushTransform.name }
-        canvas.verifyAny("lambda was called") { it.callable.name == canvas::buildPaint.name }
-        canvas.verifyAny("lambda was called") { it.callable.name == canvas::drawLine.name }
-        canvas.verifyLast("pop was called last") { it.callable.name == canvas::pop.name }
+        canvas.verifyFirst("pushTransform called first") { it.callableName == "pushTransform" }
+        canvas.verifyAny("lambda was called") { it.callableName == "buildPaint" }
+        canvas.verifyAny("lambda was called") { it.callableName == "drawLine" }
+        canvas.verifyLast("pop was called last") { it.callableName == "pop" }
         canvas.verifyCallCount(4)
     }
 }

--- a/kanvas/src/commonTest/kotlin/RelativePathBuilderTests.kt
+++ b/kanvas/src/commonTest/kotlin/RelativePathBuilderTests.kt
@@ -11,7 +11,7 @@ class RelativePathBuilderTests {
     fun arcTo_fromRightToBottom_hasCorrectEndPosition() {
         val pathBuilder = CallRecordingPathBuilder()
         pathBuilder.arcTo(0f, 0f, 100f, 100f, 0f, 90f, false)
-        val state = pathBuilder.getState()
+        val state = pathBuilder.state
         assertEquals(50f, actual = state.lastX, absoluteTolerance = EPSILON)
         assertEquals(100f, actual = state.lastY, absoluteTolerance = EPSILON)
     }
@@ -20,7 +20,7 @@ class RelativePathBuilderTests {
     fun arcTo_withForceMove_changesContourStart() {
         val pathBuilder = CallRecordingPathBuilder()
         pathBuilder.arcTo(0f, 0f, 100f, 100f, 0f, 90f, true)
-        val state = pathBuilder.getState()
+        val state = pathBuilder.state
         assertEquals(100f, actual = state.closeToX, absoluteTolerance = EPSILON)
         assertEquals(50f, actual = state.closeToY, absoluteTolerance = EPSILON)
     }
@@ -29,7 +29,7 @@ class RelativePathBuilderTests {
     fun arcTo_withoutForceMove_doesNotChangeContourStart() {
         val pathBuilder = CallRecordingPathBuilder()
         pathBuilder.arcTo(0f, 0f, 100f, 100f, 0f, 90f, false)
-        val state = pathBuilder.getState()
+        val state = pathBuilder.state
         assertEquals(0f, state.closeToX)
         assertEquals(0f, state.closeToY)
     }
@@ -39,7 +39,7 @@ class RelativePathBuilderTests {
         val pathBuilder = CallRecordingPathBuilder()
         pathBuilder.moveTo(50f, 50f)
         pathBuilder.relativeCubicTo(10f, 0f, 20f, 30f, 30f, 30f)
-        val state = pathBuilder.getState()
+        val state = pathBuilder.state
         assertEquals(80f, state.lastX)
         assertEquals(80f, state.lastY)
     }
@@ -59,7 +59,7 @@ class RelativePathBuilderTests {
         val pathBuilder = CallRecordingPathBuilder()
         pathBuilder.moveTo(50f, 50f)
         pathBuilder.relativeLineTo(30f, 30f)
-        val state = pathBuilder.getState()
+        val state = pathBuilder.state
         assertEquals(80f, state.lastX)
         assertEquals(80f, state.lastY)
     }
@@ -78,7 +78,7 @@ class RelativePathBuilderTests {
     fun moveTo_startsNewContour() {
         val pathBuilder = CallRecordingPathBuilder()
         pathBuilder.moveTo(50f, 50f)
-        val state = pathBuilder.getState()
+        val state = pathBuilder.state
         assertEquals(50f, state.closeToX)
         assertEquals(50f, state.closeToY)
     }
@@ -88,7 +88,7 @@ class RelativePathBuilderTests {
         val pathBuilder = CallRecordingPathBuilder()
         pathBuilder.moveTo(50f, 50f)
         pathBuilder.relativeMoveTo(30f, 30f)
-        val state = pathBuilder.getState()
+        val state = pathBuilder.state
         assertEquals(80f, state.lastX)
         assertEquals(80f, state.lastY)
     }
@@ -108,7 +108,7 @@ class RelativePathBuilderTests {
         val pathBuilder = CallRecordingPathBuilder()
         pathBuilder.moveTo(50f, 50f)
         pathBuilder.relativeQuadraticTo(10f, 0f, 30f, 30f)
-        val state = pathBuilder.getState()
+        val state = pathBuilder.state
         assertEquals(80f, state.lastX)
         assertEquals(80f, state.lastY)
     }
@@ -129,7 +129,7 @@ class RelativePathBuilderTests {
         pathBuilder.moveTo(50f, 50f)
         pathBuilder.lineTo(100f, 100f)
         pathBuilder.close()
-        val state = pathBuilder.getState()
+        val state = pathBuilder.state
         assertEquals(50f, state.lastX)
         assertEquals(50f, state.lastY)
     }
@@ -139,7 +139,7 @@ class RelativePathBuilderTests {
         val pathBuilder = CallRecordingPathBuilder()
         pathBuilder.moveTo(50f, 50f)
         pathBuilder.reset()
-        val state = pathBuilder.getState()
+        val state = pathBuilder.state
         assertEquals(0f, state.closeToX)
         assertEquals(0f, state.closeToY)
     }
@@ -149,7 +149,7 @@ class RelativePathBuilderTests {
         val pathBuilder = CallRecordingPathBuilder()
         pathBuilder.moveTo(50f, 50f)
         pathBuilder.reset()
-        val state = pathBuilder.getState()
+        val state = pathBuilder.state
         assertEquals(0f, state.lastX)
         assertEquals(0f, state.lastY)
     }

--- a/kanvas/src/commonTest/kotlin/RelativePathBuilderTests.kt
+++ b/kanvas/src/commonTest/kotlin/RelativePathBuilderTests.kt
@@ -1,6 +1,5 @@
 package com.juul.krayon.kanvas
 
-import com.juul.tuulbox.test.assertSimilar
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -12,25 +11,25 @@ class RelativePathBuilderTests {
     fun arcTo_fromRightToBottom_hasCorrectEndPosition() {
         val pathBuilder = CallRecordingPathBuilder()
         pathBuilder.arcTo(0f, 0f, 100f, 100f, 0f, 90f, false)
-        val state = pathBuilder.getTestState()
-        assertSimilar(target = 50f, EPSILON, value = state.lastX)
-        assertSimilar(target = 100f, EPSILON, value = state.lastY)
+        val state = pathBuilder.getState()
+        assertEquals(50f, actual = state.lastX, absoluteTolerance = EPSILON)
+        assertEquals(100f, actual = state.lastY, absoluteTolerance = EPSILON)
     }
 
     @Test
     fun arcTo_withForceMove_changesContourStart() {
         val pathBuilder = CallRecordingPathBuilder()
         pathBuilder.arcTo(0f, 0f, 100f, 100f, 0f, 90f, true)
-        val state = pathBuilder.getTestState()
-        assertSimilar(target = 100f, EPSILON, value = state.closeToX)
-        assertSimilar(target = 50f, EPSILON, value = state.closeToY)
+        val state = pathBuilder.getState()
+        assertEquals(100f, actual = state.closeToX, absoluteTolerance = EPSILON)
+        assertEquals(50f, actual = state.closeToY, absoluteTolerance = EPSILON)
     }
 
     @Test
     fun arcTo_withoutForceMove_doesNotChangeContourStart() {
         val pathBuilder = CallRecordingPathBuilder()
         pathBuilder.arcTo(0f, 0f, 100f, 100f, 0f, 90f, false)
-        val state = pathBuilder.getTestState()
+        val state = pathBuilder.getState()
         assertEquals(0f, state.closeToX)
         assertEquals(0f, state.closeToY)
     }
@@ -40,7 +39,7 @@ class RelativePathBuilderTests {
         val pathBuilder = CallRecordingPathBuilder()
         pathBuilder.moveTo(50f, 50f)
         pathBuilder.relativeCubicTo(10f, 0f, 20f, 30f, 30f, 30f)
-        val state = pathBuilder.getTestState()
+        val state = pathBuilder.getState()
         assertEquals(80f, state.lastX)
         assertEquals(80f, state.lastY)
     }
@@ -51,7 +50,7 @@ class RelativePathBuilderTests {
         pathBuilder.moveTo(50f, 50f)
         pathBuilder.relativeCubicTo(10f, 0f, 20f, 30f, 30f, 30f)
         pathBuilder.verifySingle("called cubicTo with correct arguments") { call ->
-            call.callable.name == PathBuilder<*>::cubicTo.name && call.arguments == listOf(60f, 50f, 70f, 80f, 80f, 80f)
+            call.callableName == "cubicTo" && call.arguments == listOf(60f, 50f, 70f, 80f, 80f, 80f)
         }
     }
 
@@ -60,7 +59,7 @@ class RelativePathBuilderTests {
         val pathBuilder = CallRecordingPathBuilder()
         pathBuilder.moveTo(50f, 50f)
         pathBuilder.relativeLineTo(30f, 30f)
-        val state = pathBuilder.getTestState()
+        val state = pathBuilder.getState()
         assertEquals(80f, state.lastX)
         assertEquals(80f, state.lastY)
     }
@@ -71,7 +70,7 @@ class RelativePathBuilderTests {
         pathBuilder.moveTo(50f, 50f)
         pathBuilder.relativeLineTo(30f, 30f)
         pathBuilder.verifySingle("called lineTo with correct arguments") { call ->
-            call.callable.name == PathBuilder<*>::lineTo.name && call.arguments == listOf(80f, 80f)
+            call.callableName == "lineTo" && call.arguments == listOf(80f, 80f)
         }
     }
 
@@ -79,7 +78,7 @@ class RelativePathBuilderTests {
     fun moveTo_startsNewContour() {
         val pathBuilder = CallRecordingPathBuilder()
         pathBuilder.moveTo(50f, 50f)
-        val state = pathBuilder.getTestState()
+        val state = pathBuilder.getState()
         assertEquals(50f, state.closeToX)
         assertEquals(50f, state.closeToY)
     }
@@ -89,7 +88,7 @@ class RelativePathBuilderTests {
         val pathBuilder = CallRecordingPathBuilder()
         pathBuilder.moveTo(50f, 50f)
         pathBuilder.relativeMoveTo(30f, 30f)
-        val state = pathBuilder.getTestState()
+        val state = pathBuilder.getState()
         assertEquals(80f, state.lastX)
         assertEquals(80f, state.lastY)
     }
@@ -100,7 +99,7 @@ class RelativePathBuilderTests {
         pathBuilder.moveTo(50f, 50f)
         pathBuilder.relativeMoveTo(30f, 30f)
         pathBuilder.verifySingle("called moveTo with correct arguments") { call ->
-            call.callable.name == PathBuilder<*>::moveTo.name && call.arguments == listOf(80f, 80f)
+            call.callableName == "moveTo" && call.arguments == listOf(80f, 80f)
         }
     }
 
@@ -109,7 +108,7 @@ class RelativePathBuilderTests {
         val pathBuilder = CallRecordingPathBuilder()
         pathBuilder.moveTo(50f, 50f)
         pathBuilder.relativeQuadraticTo(10f, 0f, 30f, 30f)
-        val state = pathBuilder.getTestState()
+        val state = pathBuilder.getState()
         assertEquals(80f, state.lastX)
         assertEquals(80f, state.lastY)
     }
@@ -120,7 +119,7 @@ class RelativePathBuilderTests {
         pathBuilder.moveTo(50f, 50f)
         pathBuilder.relativeQuadraticTo(10f, 0f, 30f, 30f)
         pathBuilder.verifySingle("called quadraticTo with correct arguments") { call ->
-            call.callable.name == PathBuilder<*>::quadraticTo.name && call.arguments == listOf(60f, 50f, 80f, 80f)
+            call.callableName == "quadraticTo" && call.arguments == listOf(60f, 50f, 80f, 80f)
         }
     }
 
@@ -130,7 +129,7 @@ class RelativePathBuilderTests {
         pathBuilder.moveTo(50f, 50f)
         pathBuilder.lineTo(100f, 100f)
         pathBuilder.close()
-        val state = pathBuilder.getTestState()
+        val state = pathBuilder.getState()
         assertEquals(50f, state.lastX)
         assertEquals(50f, state.lastY)
     }
@@ -140,7 +139,7 @@ class RelativePathBuilderTests {
         val pathBuilder = CallRecordingPathBuilder()
         pathBuilder.moveTo(50f, 50f)
         pathBuilder.reset()
-        val state = pathBuilder.getTestState()
+        val state = pathBuilder.getState()
         assertEquals(0f, state.closeToX)
         assertEquals(0f, state.closeToY)
     }
@@ -150,7 +149,7 @@ class RelativePathBuilderTests {
         val pathBuilder = CallRecordingPathBuilder()
         pathBuilder.moveTo(50f, 50f)
         pathBuilder.reset()
-        val state = pathBuilder.getTestState()
+        val state = pathBuilder.getState()
         assertEquals(0f, state.lastX)
         assertEquals(0f, state.lastY)
     }

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -6,12 +6,16 @@ plugins {
 
 kotlin {
     android()
-    js().browser()
+    js {
+        browser()
+        binaries.executable()
+    }
 
     sourceSets {
         val commonMain by getting {
             dependencies {
                 api(project(":chart"))
+                api(project(":selection"))
                 implementation(kotlin("stdlib"))
             }
         }

--- a/sample/src/androidMain/AndroidManifest.xml
+++ b/sample/src/androidMain/AndroidManifest.xml
@@ -1,7 +1,8 @@
 <manifest package="com.juul.krayon.sample"
     xmlns:android="http://schemas.android.com/apk/res/android">
     <application>
-        <activity android:name=".DemoActivity">
+        <activity android:name=".DemoActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/sample/src/jsMain/kotlin/Main.kt
+++ b/sample/src/jsMain/kotlin/Main.kt
@@ -28,11 +28,9 @@ import kotlin.random.Random
 private val data = MutableStateFlow(listOf(1f, 1f, 1f, 1f, 1f))
 
 fun main() {
-    // Kanvas
     val canvasElement = document.getElementById("canvas") as HTMLCanvasElement
     val kanvas = HtmlCanvas(canvasElement)
 
-    // Selection
     val root = RootElement()
     val transform = root.appendChild(TransformElement())
 
@@ -40,17 +38,11 @@ fun main() {
         awaitWebFonts("Roboto Slab")
         launch {
             while (true) {
-                data.value = when (data.value.size) {
-                    0 -> listOf(1f)
-                    else -> when (Random.nextDouble()) {
-                        in 0.0..0.1 -> ArrayList(data.value).also { it.removeAt(Random.nextInt(data.value.size)) }
-                        in 0.1..0.2 -> ArrayList(data.value).also { it.add(1f) }
-                        else -> ArrayList(data.value).also { it[Random.nextInt(data.value.size)] += 1f }
-                    }
-                }
+                data.value = newData()
                 delay(16)
             }
         }
+
         launch {
             data.collect { data ->
                 kanvas.drawRect(0f, 0f, kanvas.width, kanvas.height, kanvas.buildPaint(Paint.Fill(white)))
@@ -73,6 +65,19 @@ fun main() {
                 root.draw(kanvas)
             }
         }
+    }
+}
+
+private fun newData(): List<Float> = when (data.value.size) {
+    0 -> listOf(1f)
+    in 1..5 -> when (Random.nextDouble()) {
+        in 0.0..0.2 -> ArrayList(data.value).also { it.add(1f) }
+        else -> ArrayList(data.value).also { it[Random.nextInt(data.value.size)] += 1f }
+    }
+    else -> when (Random.nextDouble()) {
+        in 0.0..0.1 -> ArrayList(data.value).also { it.removeAt(Random.nextInt(data.value.size)) }
+        in 0.1..0.2 -> ArrayList(data.value).also { it.add(1f) }
+        else -> ArrayList(data.value).also { it[Random.nextInt(data.value.size)] += 1f }
     }
 }
 

--- a/sample/src/jsMain/kotlin/Main.kt
+++ b/sample/src/jsMain/kotlin/Main.kt
@@ -13,7 +13,6 @@ import com.juul.krayon.selection.asSelection
 import com.juul.krayon.selection.data
 import com.juul.krayon.selection.select
 import com.juul.krayon.selection.selectAll
-import com.juul.krayon.selection.selectAllDescendents
 import kotlinx.browser.document
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.await
@@ -56,7 +55,7 @@ fun main() {
 
                 transform.transform = Transform.Scale(vertical = 480 / (data.maxOrNull() ?: 1f), pivotY = 480f)
                 val bars = transform.asSelection()
-                    .selectAllDescendents { this is RectangleElement }
+                    .selectAll(RectangleElement)
                     .data(data)
 
                 bars.enter.append { _, _, _ -> RectangleElement(paint = Paint.Fill(Random.nextColor())) }

--- a/sample/src/jsMain/kotlin/Main.kt
+++ b/sample/src/jsMain/kotlin/Main.kt
@@ -34,20 +34,21 @@ fun main() {
 
     // Selection
     val root = RootElement()
-    val transform = root.appendChild(TransformElement(Transform.Scale()))
+    val transform = root.appendChild(TransformElement())
 
     GlobalScope.launch {
         awaitWebFonts("Roboto Slab")
         launch {
             while (true) {
                 data.value = when (data.value.size) {
+                    0 -> listOf(1f)
                     else -> when (Random.nextDouble()) {
-                        in 0.0..0.25 -> ArrayList(data.value).also { it.removeAt(Random.nextInt(data.value.size)) }
-                        in 0.25..0.5 -> ArrayList(data.value).also { it.add(1f) }
+                        in 0.0..0.1 -> ArrayList(data.value).also { it.removeAt(Random.nextInt(data.value.size)) }
+                        in 0.1..0.2 -> ArrayList(data.value).also { it.add(1f) }
                         else -> ArrayList(data.value).also { it[Random.nextInt(data.value.size)] += 1f }
                     }
                 }
-                delay(5000)
+                delay(16)
             }
         }
         launch {
@@ -69,10 +70,7 @@ fun main() {
                     .each { right = left + 10f }
                     .each { top = bottom - it.datum }
 
-                root.applyTo(kanvas)
-
-                println(data)
-                println(root)
+                root.draw(kanvas)
             }
         }
     }

--- a/sample/src/jsMain/kotlin/Main.kt
+++ b/sample/src/jsMain/kotlin/Main.kt
@@ -31,8 +31,7 @@ fun main() {
     val canvasElement = document.getElementById("canvas") as HTMLCanvasElement
     val kanvas = HtmlCanvas(canvasElement)
 
-    val root = RootElement()
-    val transform = root.appendChild(TransformElement())
+    val root = TransformElement()
 
     GlobalScope.launch {
         awaitWebFonts("Roboto Slab")
@@ -43,27 +42,25 @@ fun main() {
             }
         }
 
-        launch {
-            data.collect { data ->
-                kanvas.drawRect(0f, 0f, kanvas.width, kanvas.height, kanvas.buildPaint(Paint.Fill(white)))
+        data.collect { data ->
+            kanvas.drawRect(0f, 0f, kanvas.width, kanvas.height, kanvas.buildPaint(Paint.Fill(white)))
 
-                transform.transform = Transform.Scale(vertical = 480 / (data.maxOrNull() ?: 1f), pivotY = 480f)
+            root.transform = Transform.Scale(vertical = 480 / (data.maxOrNull() ?: 1f), pivotY = 480f)
 
-                transform.asSelection()
-                    .selectAll(RectangleElement)
-                    .data(data)
-                    .join(
-                        onEnter = {
-                            append(RectangleElement)
-                                .each { paint = Paint.Fill(Random.nextColor()) }
-                                .each { bottom = kanvas.height }
-                        }
-                    ).each { left = it.index * 10f }
-                    .each { right = left + 10f }
-                    .each { top = bottom - it.datum }
+            root.asSelection()
+                .selectAll(RectangleElement)
+                .data(data)
+                .join(
+                    onEnter = {
+                        append(RectangleElement)
+                            .each { paint = Paint.Fill(Random.nextColor()) }
+                            .each { bottom = kanvas.height }
+                    }
+                ).each { left = it.index * 10f }
+                .each { right = left + 10f }
+                .each { top = bottom - it.datum }
 
-                root.draw(kanvas)
-            }
+            root.draw(kanvas)
         }
     }
 }

--- a/sample/src/jsMain/kotlin/Main.kt
+++ b/sample/src/jsMain/kotlin/Main.kt
@@ -1,36 +1,79 @@
 package com.juul.krayon.sample
 
-import com.juul.krayon.chart.render.BarChartRenderer
-import com.juul.krayon.color.black
+import com.juul.krayon.color.nextColor
 import com.juul.krayon.color.white
-import com.juul.krayon.kanvas.Font
+import com.juul.krayon.element.RectangleElement
+import com.juul.krayon.element.RootElement
+import com.juul.krayon.element.TransformElement
 import com.juul.krayon.kanvas.HtmlCanvas
 import com.juul.krayon.kanvas.Paint
-import com.juul.krayon.kanvas.serif
+import com.juul.krayon.kanvas.Transform
+import com.juul.krayon.selection.append
+import com.juul.krayon.selection.asSelection
+import com.juul.krayon.selection.data
+import com.juul.krayon.selection.select
+import com.juul.krayon.selection.selectAll
+import com.juul.krayon.selection.selectAllDescendents
 import kotlinx.browser.document
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.await
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import org.w3c.dom.HTMLCanvasElement
 import kotlin.js.Promise
+import kotlin.random.Random
 
+private val data = MutableStateFlow(listOf(1f, 1f, 1f, 1f, 1f))
 fun main() {
+    // Kanvas
     val canvasElement = document.getElementById("canvas") as HTMLCanvasElement
     val kanvas = HtmlCanvas(canvasElement)
-    val renderer = BarChartRenderer()
 
-    fun render() {
-        // TODO: should probably add a "clear" function of "fillWithColor" or something.
-        kanvas.drawRect(0f, 0f, kanvas.width, kanvas.height, kanvas.buildPaint(Paint.Fill(white)))
-        renderer.render(getRandomData(), kanvas)
-        val textPaint = Paint.Text(black, 18f, Paint.Text.Alignment.Left, Font("Roboto Slab", serif))
-        kanvas.drawText("This is a test", 32f, 32f, textPaint)
-    }
+    // Selection
+    val root = RootElement()
+    val transform = root.appendChild(TransformElement(Transform.Scale()))
 
     GlobalScope.launch {
         awaitWebFonts("Roboto Slab")
-        render()
-        canvasElement.onclick = { render() }
+        launch {
+            while (true) {
+                data.value = when (data.value.size) {
+                    0 -> listOf(1f)
+                    else -> when (Random.nextDouble()) {
+                        in 0.0..0.1 -> ArrayList(data.value).also { it.removeAt(Random.nextInt(data.value.size)) }
+                        in 0.1..0.2 -> ArrayList(data.value).also { it.add(1f) }
+                        else -> ArrayList(data.value).also { it[Random.nextInt(data.value.size)] += 1f }
+                    }
+                }
+                delay(16)
+            }
+        }
+        launch {
+            data.collect { data ->
+                kanvas.drawRect(0f, 0f, kanvas.width, kanvas.height, kanvas.buildPaint(Paint.Fill(white)))
+
+                transform.transform = Transform.Scale(vertical = 480 / (data.maxOrNull() ?: 1f), pivotY = 480f)
+                val bars = transform.asSelection()
+                    .selectAllDescendents { this is RectangleElement }
+                    .data(data)
+
+                bars.enter.append { _, _, _ -> RectangleElement(paint = Paint.Fill(Random.nextColor())) }
+                bars.exit.select { _, _, _ -> parent?.removeChild(this) }
+
+                bars.select { datum, index, _ ->
+                    this as RectangleElement
+                    left = index * 10f
+                    right = left + 10f
+                    bottom = kanvas.height
+                    top = bottom - datum
+                    this
+                }
+
+                root.applyTo(kanvas)
+            }
+        }
     }
 }
 

--- a/sample/src/jsMain/kotlin/Main.kt
+++ b/sample/src/jsMain/kotlin/Main.kt
@@ -3,7 +3,6 @@ package com.juul.krayon.sample
 import com.juul.krayon.color.nextColor
 import com.juul.krayon.color.white
 import com.juul.krayon.element.RectangleElement
-import com.juul.krayon.element.RootElement
 import com.juul.krayon.element.TransformElement
 import com.juul.krayon.kanvas.HtmlCanvas
 import com.juul.krayon.kanvas.Paint

--- a/selection/build.gradle.kts
+++ b/selection/build.gradle.kts
@@ -19,10 +19,6 @@ kotlin {
     js().browser()
 
     sourceSets {
-        all {
-            languageSettings.enableLanguageFeature("InlineClasses")
-        }
-
         val commonMain by getting {
             dependencies {
                 api(project(":element"))

--- a/selection/build.gradle.kts
+++ b/selection/build.gradle.kts
@@ -1,0 +1,52 @@
+plugins {
+    kotlin("multiplatform")
+    id("org.jmailen.kotlinter")
+    jacoco
+    id("org.jetbrains.dokka")
+    id("com.vanniktech.maven.publish")
+}
+
+apply(from = rootProject.file("gradle/jacoco.gradle.kts"))
+
+jacoco {
+    toolVersion = "0.8.7"
+}
+
+kotlin {
+    explicitApi()
+
+    jvm()
+    js().browser()
+
+    sourceSets {
+        all {
+            languageSettings.enableLanguageFeature("InlineClasses")
+        }
+
+        val commonMain by getting {
+            dependencies {
+                api(project(":element"))
+            }
+        }
+
+        val commonTest by getting {
+            dependencies {
+                implementation(tuulbox.test())
+                implementation(kotlin("test-common"))
+                implementation(kotlin("test-annotations-common"))
+            }
+        }
+
+        val jvmTest by getting {
+            dependencies {
+                implementation(kotlin("test-junit"))
+            }
+        }
+
+        val jsTest by getting {
+            dependencies {
+                implementation(kotlin("test-js"))
+            }
+        }
+    }
+}

--- a/selection/gradle.properties
+++ b/selection/gradle.properties
@@ -1,0 +1,1 @@
+POM_ARTIFACT_ID=selection

--- a/selection/src/commonMain/kotlin/Append.kt
+++ b/selection/src/commonMain/kotlin/Append.kt
@@ -1,7 +1,12 @@
 package com.juul.krayon.selection
 
 import com.juul.krayon.element.Element
+import com.juul.krayon.element.ElementBuilder
+
+public fun <E1: Element, E2: Element, D> Selection<E1, D>.append(
+    builder: ElementBuilder<E2>
+): Selection<E2, D> = select { appendChild(builder.build()) }
 
 public inline fun <E1: Element, E2: Element, D> Selection<E1, D>.append(
-    crossinline value: E1.(datum: D, index: Int, group: Group<E1, D>) -> E2,
-): Selection<E2, D> = select { datum, index, group -> appendChild(value(datum, index, group)) }
+    crossinline value: E1.(Arguments<E1, D>) -> E2,
+): Selection<E2, D> = select { args -> appendChild(value(args)) }

--- a/selection/src/commonMain/kotlin/Append.kt
+++ b/selection/src/commonMain/kotlin/Append.kt
@@ -2,6 +2,6 @@ package com.juul.krayon.selection
 
 import com.juul.krayon.element.Element
 
-public inline fun <T> Selection<T>.append(
-    crossinline value: Element.(datum: T, index: Int, group: Group<T>) -> Element,
-): Selection<T> = select { datum, index, group -> appendChild(value(datum, index, group)) }
+public inline fun <E1: Element, E2: Element, D> Selection<E1, D>.append(
+    crossinline value: E1.(datum: D, index: Int, group: Group<E1, D>) -> E2,
+): Selection<E2, D> = select { datum, index, group -> appendChild(value(datum, index, group)) }

--- a/selection/src/commonMain/kotlin/Append.kt
+++ b/selection/src/commonMain/kotlin/Append.kt
@@ -3,10 +3,10 @@ package com.juul.krayon.selection
 import com.juul.krayon.element.Element
 import com.juul.krayon.element.ElementBuilder
 
-public fun <E1: Element, E2: Element, D> Selection<E1, D>.append(
-    builder: ElementBuilder<E2>
+public fun <E1 : Element, E2 : Element, D> Selection<E1, D>.append(
+    builder: ElementBuilder<E2>,
 ): Selection<E2, D> = select { appendChild(builder.build()) }
 
-public inline fun <E1: Element, E2: Element, D> Selection<E1, D>.append(
+public inline fun <E1 : Element, E2 : Element, D> Selection<E1, D>.append(
     crossinline value: E1.(Arguments<E1, D>) -> E2,
 ): Selection<E2, D> = select { args -> appendChild(value(args)) }

--- a/selection/src/commonMain/kotlin/Append.kt
+++ b/selection/src/commonMain/kotlin/Append.kt
@@ -1,0 +1,7 @@
+package com.juul.krayon.selection
+
+import com.juul.krayon.element.Element
+
+public inline fun <T> Selection<T>.append(
+    crossinline value: Element.(datum: T, index: Int, group: Group<T>) -> Element,
+): Selection<T> = select { datum, index, group -> appendChild(value(datum, index, group)) }

--- a/selection/src/commonMain/kotlin/Append.kt
+++ b/selection/src/commonMain/kotlin/Append.kt
@@ -3,10 +3,12 @@ package com.juul.krayon.selection
 import com.juul.krayon.element.Element
 import com.juul.krayon.element.ElementBuilder
 
+/** See analogous [d3 function](https://github.com/d3/d3-selection#selection_append). */
 public fun <E1 : Element, E2 : Element, D> Selection<E1, D>.append(
     builder: ElementBuilder<E2>,
 ): Selection<E2, D> = select { appendChild(builder.build()) }
 
+/** See analogous [d3 function](https://github.com/d3/d3-selection#selection_append). */
 public inline fun <E1 : Element, E2 : Element, D> Selection<E1, D>.append(
     crossinline value: E1.(Arguments<E1, D>) -> E2,
 ): Selection<E2, D> = select { args -> appendChild(value(args)) }

--- a/selection/src/commonMain/kotlin/Arguments.kt
+++ b/selection/src/commonMain/kotlin/Arguments.kt
@@ -2,8 +2,8 @@ package com.juul.krayon.selection
 
 import com.juul.krayon.element.Element
 
-public data class Arguments<E: Element, D>(
+public data class Arguments<E : Element, D>(
     public val datum: D,
     public val index: Int,
-    public val group: List<E?>
+    public val group: List<E?>,
 )

--- a/selection/src/commonMain/kotlin/Arguments.kt
+++ b/selection/src/commonMain/kotlin/Arguments.kt
@@ -2,6 +2,10 @@ package com.juul.krayon.selection
 
 import com.juul.krayon.element.Element
 
+/**
+ * Wrapper around d3's standard argument order. This helps serve as syntax sugar for their style of overloading,
+ * where you often don't use the arguments at all, or only bind the first one or two.
+ */
 public data class Arguments<E : Element, D>(
     public val datum: D,
     public val index: Int,

--- a/selection/src/commonMain/kotlin/Arguments.kt
+++ b/selection/src/commonMain/kotlin/Arguments.kt
@@ -1,0 +1,9 @@
+package com.juul.krayon.selection
+
+import com.juul.krayon.element.Element
+
+public data class Arguments<E: Element, D>(
+    public val datum: D,
+    public val index: Int,
+    public val group: List<E?>
+)

--- a/selection/src/commonMain/kotlin/Data.kt
+++ b/selection/src/commonMain/kotlin/Data.kt
@@ -2,16 +2,16 @@ package com.juul.krayon.selection
 
 import com.juul.krayon.element.Element
 
-public fun <P, C> Selection<P>.data(
-    value: List<C>,
-): UpdateSelection<C> = data { _, _ -> value }
+public fun <E: Element, D1, D2> Selection<E, D1>.data(
+    value: List<D2>,
+): UpdateSelection<E, D2> = data { _, _ -> value }
 
-public fun <P, C> Selection<P>.data(
-    value: (index: Int, group: Group<P>) -> List<C>,
-): UpdateSelection<C> {
-    val update = ArrayList<Group<C>>(groups.size)
-    val enter = ArrayList<Group<C>>(groups.size)
-    val exit = ArrayList<Group<C>>(groups.size)
+public fun <E: Element, D1, D2> Selection<E, D1>.data(
+    value: (index: Int, group: Group<E, D1>) -> List<D2>,
+): UpdateSelection<E, D2> {
+    val update = ArrayList<Group<E, D2>>(groups.size)
+    val enter = ArrayList<Group<EnterElement, D2>>(groups.size)
+    val exit = ArrayList<Group<E, D2>>(groups.size)
 
     for ((index, group) in groups.withIndex()) {
         val data = value(index, group)
@@ -38,13 +38,13 @@ public fun <P, C> Selection<P>.data(
     return UpdateSelection(update, EnterSelection(enter), ExitSelection(exit))
 }
 
-private fun <P, C> bindIndex(
-    group: Group<P>,
-    data: List<C>,
-): Triple<List<Element?>, List<EnterElement?>, List<Element?>> {
-    val update = ArrayList<Element?>(data.size)
+private fun <E: Element, D1, D2> bindIndex(
+    group: Group<E, D1>,
+    data: List<D2>,
+): Triple<List<E?>, List<EnterElement?>, List<E?>> {
+    val update = ArrayList<E?>(data.size)
     val enter = ArrayList<EnterElement?>(data.size)
-    val exit = ArrayList<Element?>(maxOf(data.size, group.nodes.size))
+    val exit = ArrayList<E?>(maxOf(data.size, group.nodes.size))
     data.withIndex().forEach { (index, value) ->
         val node = group.nodes.getOrNull(index)
         if (node != null) {

--- a/selection/src/commonMain/kotlin/Data.kt
+++ b/selection/src/commonMain/kotlin/Data.kt
@@ -2,11 +2,11 @@ package com.juul.krayon.selection
 
 import com.juul.krayon.element.Element
 
-public fun <E: Element, D1, D2> Selection<E, D1>.data(
+public fun <E : Element, D1, D2> Selection<E, D1>.data(
     value: List<D2>,
 ): UpdateSelection<E, D2> = data { _, _ -> value }
 
-public fun <E: Element, D1, D2> Selection<E, D1>.data(
+public fun <E : Element, D1, D2> Selection<E, D1>.data(
     value: (index: Int, group: Group<E, D1>) -> List<D2>,
 ): UpdateSelection<E, D2> {
     val update = ArrayList<Group<E, D2>>(groups.size)
@@ -38,7 +38,7 @@ public fun <E: Element, D1, D2> Selection<E, D1>.data(
     return UpdateSelection(update, EnterSelection(enter), ExitSelection(exit))
 }
 
-private fun <E: Element, D1, D2> bindIndex(
+private fun <E : Element, D1, D2> bindIndex(
     group: Group<E, D1>,
     data: List<D2>,
 ): Triple<List<E?>, List<EnterElement?>, List<E?>> {

--- a/selection/src/commonMain/kotlin/Data.kt
+++ b/selection/src/commonMain/kotlin/Data.kt
@@ -2,10 +2,12 @@ package com.juul.krayon.selection
 
 import com.juul.krayon.element.Element
 
+/** See analogous [d3 function](https://github.com/d3/d3-selection#selection_data). */
 public fun <E : Element, D1, D2> Selection<E, D1>.data(
     value: List<D2>,
 ): UpdateSelection<E, D2> = data { _, _ -> value }
 
+/** See analogous [d3 function](https://github.com/d3/d3-selection#selection_data). */
 public fun <E : Element, D1, D2> Selection<E, D1>.data(
     value: (index: Int, group: Group<E, D1>) -> List<D2>,
 ): UpdateSelection<E, D2> {

--- a/selection/src/commonMain/kotlin/Data.kt
+++ b/selection/src/commonMain/kotlin/Data.kt
@@ -1,0 +1,72 @@
+package com.juul.krayon.selection
+
+import com.juul.krayon.element.Element
+
+public fun <P, C> Selection<P>.data(
+    value: List<C>,
+): UpdateSelection<C> = data { _, _ -> value }
+
+public fun <P, C> Selection<P>.data(
+    value: (index: Int, group: Group<P>) -> List<C>,
+): UpdateSelection<C> {
+    val update = ArrayList<Group<C>>(groups.size)
+    val enter = ArrayList<Group<C>>(groups.size)
+    val exit = ArrayList<Group<C>>(groups.size)
+
+    for ((index, group) in groups.withIndex()) {
+        val data = value(index, group)
+        val (updateNodes, enterNodes, exitNodes) = bindIndex(group, data)
+        update += Group(group.parent, updateNodes)
+        enter += Group(group.parent, enterNodes)
+        exit += Group(group.parent, exitNodes)
+
+        // Associate enter elements with their next update element
+        var updateIndex = 0
+        for ((enterIndex, node) in enterNodes.withIndex()) {
+            if (node != null) {
+                if (enterIndex >= updateIndex) {
+                    updateIndex = enterIndex + 1
+                }
+                node.next = updateNodes.subList(updateIndex, updateNodes.size)
+                    .onEach { if (it == null) updateIndex += 1 }
+                    .filterNotNull()
+                    .firstOrNull()
+            }
+        }
+    }
+
+    return UpdateSelection(update, EnterSelection(enter), ExitSelection(exit))
+}
+
+private fun <P, C> bindIndex(
+    group: Group<P>,
+    data: List<C>,
+): Triple<List<Element?>, List<EnterElement?>, List<Element?>> {
+    val update = ArrayList<Element?>(data.size)
+    val enter = ArrayList<EnterElement?>(data.size)
+    val exit = ArrayList<Element?>(maxOf(data.size, group.nodes.size))
+    data.withIndex().forEach { (index, value) ->
+        val node = group.nodes.getOrNull(index)
+        if (node != null) {
+            update.add(node.also { it.data = value })
+            enter.add(null)
+        } else {
+            update.add(null)
+            enter.add(
+                EnterElement().also {
+                    it.data = value
+                    it.parent = group.parent
+                }
+            )
+        }
+        exit.add(null)
+    }
+    if (group.nodes.size > data.size) {
+        group.nodes
+            .subList(data.size, group.nodes.size)
+            .forEach { node ->
+                exit.add(node)
+            }
+    }
+    return Triple(update, enter, exit)
+}

--- a/selection/src/commonMain/kotlin/Each.kt
+++ b/selection/src/commonMain/kotlin/Each.kt
@@ -2,6 +2,13 @@ package com.juul.krayon.selection
 
 import com.juul.krayon.element.Element
 
+/**
+ * See analogous [d3 function](https://github.com/d3/d3-selection#selection_each).
+ *
+ * Note that this serves triple-duty for [d3 attr](https://github.com/d3/d3-selection#selection_attr)
+ * and [d3 style](https://github.com/d3/d3-selection#selection_style) due to strong typing and a lack
+ * of CSS, respectively.
+ */
 public inline fun <E : Element, D, S : Selection<E, D>> S.each(
     crossinline action: E.(Arguments<E, D>) -> Unit,
 ): S {

--- a/selection/src/commonMain/kotlin/Each.kt
+++ b/selection/src/commonMain/kotlin/Each.kt
@@ -1,0 +1,14 @@
+package com.juul.krayon.selection
+
+import com.juul.krayon.element.Element
+
+public inline fun <E : Element, D, S : Selection<E, D>> S.each(
+    crossinline action: E.(Arguments<E, D>) -> Unit,
+): S {
+    groups.forEach { group ->
+        group.nodes.forEachIndexed { index, node ->
+            node?.action(Arguments(node.data as D, index, group.nodes))
+        }
+    }
+    return this
+}

--- a/selection/src/commonMain/kotlin/EnterElement.kt
+++ b/selection/src/commonMain/kotlin/EnterElement.kt
@@ -4,6 +4,9 @@ import com.juul.krayon.element.Element
 import com.juul.krayon.kanvas.Kanvas
 
 public class EnterElement : Element() {
+
+    override val tag: String get() = "enter"
+
     public var next: Element? = null
 
     override fun <E : Element> appendChild(child: E): E =
@@ -13,6 +16,6 @@ public class EnterElement : Element() {
         checkNotNull(parent).insertBefore(child, reference)
 
     override fun <PAINT, PATH> draw(canvas: Kanvas<PAINT, PATH>) {
-        error("EnterElement should not be present in the DOM.")
+        error("$tag should not be present in the DOM.")
     }
 }

--- a/selection/src/commonMain/kotlin/EnterElement.kt
+++ b/selection/src/commonMain/kotlin/EnterElement.kt
@@ -6,10 +6,10 @@ import com.juul.krayon.kanvas.Kanvas
 public class EnterElement: Element() {
     public var next: Element? = null
 
-    override fun appendChild(child: Element): Element =
+    override fun <E: Element> appendChild(child: E): E =
         checkNotNull(parent).insertBefore(child, next)
 
-    override fun insertBefore(child: Element, reference: Element?): Element =
+    override fun <E: Element> insertBefore(child: E, reference: Element?): E =
         checkNotNull(parent).insertBefore(child, reference)
 
     override fun <PAINT, PATH> applyTo(canvas: Kanvas<PAINT, PATH>) {

--- a/selection/src/commonMain/kotlin/EnterElement.kt
+++ b/selection/src/commonMain/kotlin/EnterElement.kt
@@ -12,7 +12,7 @@ public class EnterElement: Element() {
     override fun <E: Element> insertBefore(child: E, reference: Element?): E =
         checkNotNull(parent).insertBefore(child, reference)
 
-    override fun <PAINT, PATH> applyTo(canvas: Kanvas<PAINT, PATH>) {
+    override fun <PAINT, PATH> draw(canvas: Kanvas<PAINT, PATH>) {
         error("EnterElement should not be present in the DOM.")
     }
 }

--- a/selection/src/commonMain/kotlin/EnterElement.kt
+++ b/selection/src/commonMain/kotlin/EnterElement.kt
@@ -1,0 +1,18 @@
+package com.juul.krayon.selection
+
+import com.juul.krayon.element.Element
+import com.juul.krayon.kanvas.Kanvas
+
+public class EnterElement: Element() {
+    public var next: Element? = null
+
+    override fun appendChild(child: Element): Element =
+        checkNotNull(parent).insertBefore(child, next)
+
+    override fun insertBefore(child: Element, reference: Element?): Element =
+        checkNotNull(parent).insertBefore(child, reference)
+
+    override fun <PAINT, PATH> applyTo(canvas: Kanvas<PAINT, PATH>) {
+        error("EnterElement should not be present in the DOM.")
+    }
+}

--- a/selection/src/commonMain/kotlin/EnterElement.kt
+++ b/selection/src/commonMain/kotlin/EnterElement.kt
@@ -3,13 +3,13 @@ package com.juul.krayon.selection
 import com.juul.krayon.element.Element
 import com.juul.krayon.kanvas.Kanvas
 
-public class EnterElement: Element() {
+public class EnterElement : Element() {
     public var next: Element? = null
 
-    override fun <E: Element> appendChild(child: E): E =
+    override fun <E : Element> appendChild(child: E): E =
         checkNotNull(parent).insertBefore(child, next)
 
-    override fun <E: Element> insertBefore(child: E, reference: Element?): E =
+    override fun <E : Element> insertBefore(child: E, reference: Element?): E =
         checkNotNull(parent).insertBefore(child, reference)
 
     override fun <PAINT, PATH> draw(canvas: Kanvas<PAINT, PATH>) {

--- a/selection/src/commonMain/kotlin/EnterElement.kt
+++ b/selection/src/commonMain/kotlin/EnterElement.kt
@@ -16,6 +16,6 @@ public class EnterElement : Element() {
         checkNotNull(parent).insertBefore(child, reference)
 
     override fun <PAINT, PATH> draw(canvas: Kanvas<PAINT, PATH>) {
-        error("$tag should not be present in the DOM.")
+        error("$tag should not be present in the element tree.")
     }
 }

--- a/selection/src/commonMain/kotlin/Group.kt
+++ b/selection/src/commonMain/kotlin/Group.kt
@@ -2,7 +2,7 @@ package com.juul.krayon.selection
 
 import com.juul.krayon.element.Element
 
-public data class Group<E: Element, D>(
+public data class Group<E : Element, D>(
     public val parent: Element?,
-    public val nodes: List<E?>
+    public val nodes: List<E?>,
 )

--- a/selection/src/commonMain/kotlin/Group.kt
+++ b/selection/src/commonMain/kotlin/Group.kt
@@ -2,7 +2,7 @@ package com.juul.krayon.selection
 
 import com.juul.krayon.element.Element
 
-public data class Group<T>(
+public data class Group<E: Element, D>(
     public val parent: Element?,
-    public val nodes: List<Element?>
+    public val nodes: List<E?>
 )

--- a/selection/src/commonMain/kotlin/Group.kt
+++ b/selection/src/commonMain/kotlin/Group.kt
@@ -1,0 +1,8 @@
+package com.juul.krayon.selection
+
+import com.juul.krayon.element.Element
+
+public data class Group<T>(
+    public val parent: Element?,
+    public val nodes: List<Element?>
+)

--- a/selection/src/commonMain/kotlin/Join.kt
+++ b/selection/src/commonMain/kotlin/Join.kt
@@ -3,8 +3,8 @@ package com.juul.krayon.selection
 import com.juul.krayon.element.Element
 import com.juul.krayon.element.ElementBuilder
 
-public fun <E: Element, D> UpdateSelection<E, D>.join(
-    builder: ElementBuilder<E>
+public fun <E : Element, D> UpdateSelection<E, D>.join(
+    builder: ElementBuilder<E>,
 ): Selection<E, D> = join(onEnter = { append(builder) })
 
 public inline fun <E : Element, D> UpdateSelection<E, D>.join(

--- a/selection/src/commonMain/kotlin/Join.kt
+++ b/selection/src/commonMain/kotlin/Join.kt
@@ -14,6 +14,6 @@ public inline fun <E : Element, D> UpdateSelection<E, D>.join(
 ): Selection<E, D> {
     val enter = enter.onEnter()
     val update = onUpdate()
-    onExit()
+    exit.onExit()
     return enter.merge(update).order()
 }

--- a/selection/src/commonMain/kotlin/Join.kt
+++ b/selection/src/commonMain/kotlin/Join.kt
@@ -3,10 +3,12 @@ package com.juul.krayon.selection
 import com.juul.krayon.element.Element
 import com.juul.krayon.element.ElementBuilder
 
+/** See analogous [d3 function](https://github.com/d3/d3-selection#selection_join). */
 public fun <E : Element, D> UpdateSelection<E, D>.join(
     builder: ElementBuilder<E>,
 ): Selection<E, D> = join(onEnter = { append(builder) })
 
+/** See analogous [d3 function](https://github.com/d3/d3-selection#selection_join). */
 public inline fun <E : Element, D> UpdateSelection<E, D>.join(
     crossinline onEnter: EnterSelection<D>.() -> Selection<E, D>,
     crossinline onUpdate: Selection<E, D>.() -> Selection<E, D> = { this },

--- a/selection/src/commonMain/kotlin/Join.kt
+++ b/selection/src/commonMain/kotlin/Join.kt
@@ -1,0 +1,19 @@
+package com.juul.krayon.selection
+
+import com.juul.krayon.element.Element
+import com.juul.krayon.element.ElementBuilder
+
+public fun <E: Element, D> UpdateSelection<E, D>.join(
+    builder: ElementBuilder<E>
+): Selection<E, D> = join(onEnter = { append(builder) })
+
+public inline fun <E : Element, D> UpdateSelection<E, D>.join(
+    crossinline onEnter: EnterSelection<D>.() -> Selection<E, D>,
+    crossinline onUpdate: Selection<E, D>.() -> Selection<E, D> = { this },
+    crossinline onExit: Selection<E, D>.() -> Unit = { remove() },
+): Selection<E, D> {
+    val enter = enter.onEnter()
+    val update = onUpdate()
+    onExit()
+    return enter.merge(update).order()
+}

--- a/selection/src/commonMain/kotlin/Merge.kt
+++ b/selection/src/commonMain/kotlin/Merge.kt
@@ -1,0 +1,16 @@
+package com.juul.krayon.selection
+
+import com.juul.krayon.element.Element
+
+public fun <E : Element, D> Selection<E, D>.merge(
+    other: Selection<E, D>,
+): Selection<E, D> = Selection(
+    groups.mapIndexed { groupIndex, group ->
+        Group(
+            group.parent,
+            group.nodes.mapIndexed { nodeIndex, node ->
+                node ?: other.groups[groupIndex].nodes[nodeIndex]
+            }
+        )
+    }
+)

--- a/selection/src/commonMain/kotlin/Merge.kt
+++ b/selection/src/commonMain/kotlin/Merge.kt
@@ -2,6 +2,7 @@ package com.juul.krayon.selection
 
 import com.juul.krayon.element.Element
 
+/** See analogous [d3 function](https://github.com/d3/d3-selection#selection_merge). */
 public fun <E : Element, D> Selection<E, D>.merge(
     other: Selection<E, D>,
 ): Selection<E, D> = Selection(

--- a/selection/src/commonMain/kotlin/Order.kt
+++ b/selection/src/commonMain/kotlin/Order.kt
@@ -2,6 +2,7 @@ package com.juul.krayon.selection
 
 import com.juul.krayon.element.Element
 
+/** See analogous [d3 function](https://github.com/d3/d3-selection#selection_order). */
 public fun <E : Element, D> Selection<E, D>.order(): Selection<E, D> {
     for (group in groups) {
         val parent = group.parent ?: continue

--- a/selection/src/commonMain/kotlin/Order.kt
+++ b/selection/src/commonMain/kotlin/Order.kt
@@ -2,7 +2,7 @@ package com.juul.krayon.selection
 
 import com.juul.krayon.element.Element
 
-public fun <E: Element, D> Selection<E, D>.order(): Selection<E, D> {
+public fun <E : Element, D> Selection<E, D>.order(): Selection<E, D> {
     for (group in groups) {
         val parent = group.parent ?: continue
         for (node in group.nodes) {

--- a/selection/src/commonMain/kotlin/Order.kt
+++ b/selection/src/commonMain/kotlin/Order.kt
@@ -3,7 +3,6 @@ package com.juul.krayon.selection
 import com.juul.krayon.element.Element
 
 public fun <E: Element, D> Selection<E, D>.order(): Selection<E, D> {
-    // TODO: This could be optimized to not move stuff around if things are already in place.
     for (group in groups) {
         val parent = group.parent ?: continue
         for (node in group.nodes) {

--- a/selection/src/commonMain/kotlin/Order.kt
+++ b/selection/src/commonMain/kotlin/Order.kt
@@ -1,0 +1,16 @@
+package com.juul.krayon.selection
+
+import com.juul.krayon.element.Element
+
+public fun <E: Element, D> Selection<E, D>.order(): Selection<E, D> {
+    // TODO: This could be optimized to not move stuff around if things are already in place.
+    for (group in groups) {
+        val parent = group.parent ?: continue
+        for (node in group.nodes) {
+            if (node != null) {
+                parent.appendChild(parent.removeChild(node))
+            }
+        }
+    }
+    return this
+}

--- a/selection/src/commonMain/kotlin/Remove.kt
+++ b/selection/src/commonMain/kotlin/Remove.kt
@@ -2,6 +2,6 @@ package com.juul.krayon.selection
 
 import com.juul.krayon.element.Element
 
-public fun <E : Element, D, S : Selection<E, D>> S.remove(): S {
-    return this.each { parent?.removeChild(this) }
-}
+/** See analogous [d3 function](https://github.com/d3/d3-selection#selection_remove). */
+public fun <E : Element, D, S : Selection<E, D>> S.remove(): S =
+    each { parent?.removeChild(this) }

--- a/selection/src/commonMain/kotlin/Remove.kt
+++ b/selection/src/commonMain/kotlin/Remove.kt
@@ -1,0 +1,7 @@
+package com.juul.krayon.selection
+
+import com.juul.krayon.element.Element
+
+public fun <E: Element, D, S: Selection<E, D>> S.remove(): S {
+    return this.each { parent?.removeChild(this) }
+}

--- a/selection/src/commonMain/kotlin/Remove.kt
+++ b/selection/src/commonMain/kotlin/Remove.kt
@@ -2,6 +2,6 @@ package com.juul.krayon.selection
 
 import com.juul.krayon.element.Element
 
-public fun <E: Element, D, S: Selection<E, D>> S.remove(): S {
+public fun <E : Element, D, S : Selection<E, D>> S.remove(): S {
     return this.each { parent?.removeChild(this) }
 }

--- a/selection/src/commonMain/kotlin/Select.kt
+++ b/selection/src/commonMain/kotlin/Select.kt
@@ -3,7 +3,7 @@ package com.juul.krayon.selection
 import com.juul.krayon.element.Element
 
 public inline fun <T> Selection<T>.select(
-    crossinline select: Element.(datum: T, index: Int, nodes: List<Element?>) -> Element?,
+    crossinline select: Element.(datum: T, index: Int, group: Group<T>) -> Element?,
 ): Selection<T> = Selection(
     groups.map { group ->
         Group(
@@ -11,7 +11,7 @@ public inline fun <T> Selection<T>.select(
             group.nodes
                 .withIndex()
                 .map { (index, node) ->
-                    node?.select(node.data as T, index, group.nodes)
+                    node?.select(node.data as T, index, group)
                         ?.also { it.data = node.data }
                 }
         )

--- a/selection/src/commonMain/kotlin/Select.kt
+++ b/selection/src/commonMain/kotlin/Select.kt
@@ -1,17 +1,23 @@
 package com.juul.krayon.selection
 
 import com.juul.krayon.element.Element
+import com.juul.krayon.element.TypeSelector
+import com.juul.krayon.element.descendents
 
-public inline fun <T> Selection<T>.select(
-    crossinline select: Element.(datum: T, index: Int, group: Group<T>) -> Element?,
-): Selection<T> = Selection(
+public fun <E1 : Element, E2 : Element, D> Selection<E1, D>.select(
+    selector: TypeSelector<E2>,
+): Selection<E2, D> = select { _, _, _ -> descendents.mapNotNull { selector.trySelect(it) }.firstOrNull() }
+
+public inline fun <E1: Element, E2: Element, D> Selection<E1, D>.select(
+    crossinline select: E1.(datum: D, index: Int, group: List<E1?>) -> E2?,
+): Selection<E2, D> = Selection(
     groups.map { group ->
         Group(
             group.parent,
             group.nodes
                 .withIndex()
                 .map { (index, node) ->
-                    node?.select(node.data as T, index, group)
+                    node?.select(node.data as D, index, group.nodes)
                         ?.also { it.data = node.data }
                 }
         )

--- a/selection/src/commonMain/kotlin/Select.kt
+++ b/selection/src/commonMain/kotlin/Select.kt
@@ -6,10 +6,10 @@ import com.juul.krayon.element.descendents
 
 public fun <E1 : Element, E2 : Element, D> Selection<E1, D>.select(
     selector: TypeSelector<E2>,
-): Selection<E2, D> = select { _, _, _ -> descendents.mapNotNull { selector.trySelect(it) }.firstOrNull() }
+): Selection<E2, D> = select { descendents.mapNotNull { selector.trySelect(it) }.firstOrNull() }
 
 public inline fun <E1: Element, E2: Element, D> Selection<E1, D>.select(
-    crossinline select: E1.(datum: D, index: Int, group: List<E1?>) -> E2?,
+    crossinline select: E1.(Arguments<E1, D>) -> E2?,
 ): Selection<E2, D> = Selection(
     groups.map { group ->
         Group(
@@ -17,7 +17,7 @@ public inline fun <E1: Element, E2: Element, D> Selection<E1, D>.select(
             group.nodes
                 .withIndex()
                 .map { (index, node) ->
-                    node?.select(node.data as D, index, group.nodes)
+                    node?.select(Arguments(node.data as D, index, group.nodes))
                         ?.also { it.data = node.data }
                 }
         )

--- a/selection/src/commonMain/kotlin/Select.kt
+++ b/selection/src/commonMain/kotlin/Select.kt
@@ -8,7 +8,7 @@ public fun <E1 : Element, E2 : Element, D> Selection<E1, D>.select(
     selector: TypeSelector<E2>,
 ): Selection<E2, D> = select { descendents.mapNotNull { selector.trySelect(it) }.firstOrNull() }
 
-public inline fun <E1: Element, E2: Element, D> Selection<E1, D>.select(
+public inline fun <E1 : Element, E2 : Element, D> Selection<E1, D>.select(
     crossinline select: E1.(Arguments<E1, D>) -> E2?,
 ): Selection<E2, D> = Selection(
     groups.map { group ->

--- a/selection/src/commonMain/kotlin/Select.kt
+++ b/selection/src/commonMain/kotlin/Select.kt
@@ -1,0 +1,19 @@
+package com.juul.krayon.selection
+
+import com.juul.krayon.element.Element
+
+public inline fun <T> Selection<T>.select(
+    crossinline select: Element.(datum: T, index: Int, nodes: List<Element?>) -> Element?,
+): Selection<T> = Selection(
+    groups.map { group ->
+        Group(
+            group.parent,
+            group.nodes
+                .withIndex()
+                .map { (index, node) ->
+                    node?.select(node.data as T, index, group.nodes)
+                        ?.also { it.data = node.data }
+                }
+        )
+    }
+)

--- a/selection/src/commonMain/kotlin/Select.kt
+++ b/selection/src/commonMain/kotlin/Select.kt
@@ -2,12 +2,12 @@ package com.juul.krayon.selection
 
 import com.juul.krayon.element.Element
 import com.juul.krayon.element.TypeSelector
-import com.juul.krayon.element.descendents
+import com.juul.krayon.element.descendants
 
 /** See analogous [d3 function](https://github.com/d3/d3-selection#selection_select). */
 public fun <E1 : Element, E2 : Element, D> Selection<E1, D>.select(
     selector: TypeSelector<E2>,
-): Selection<E2, D> = select { descendents.mapNotNull { selector.trySelect(it) }.firstOrNull() }
+): Selection<E2, D> = select { descendants.mapNotNull { selector.trySelect(it) }.firstOrNull() }
 
 /** See analogous [d3 function](https://github.com/d3/d3-selection#selection_select). */
 public inline fun <E1 : Element, E2 : Element, D> Selection<E1, D>.select(

--- a/selection/src/commonMain/kotlin/Select.kt
+++ b/selection/src/commonMain/kotlin/Select.kt
@@ -4,10 +4,12 @@ import com.juul.krayon.element.Element
 import com.juul.krayon.element.TypeSelector
 import com.juul.krayon.element.descendents
 
+/** See analogous [d3 function](https://github.com/d3/d3-selection#selection_select). */
 public fun <E1 : Element, E2 : Element, D> Selection<E1, D>.select(
     selector: TypeSelector<E2>,
 ): Selection<E2, D> = select { descendents.mapNotNull { selector.trySelect(it) }.firstOrNull() }
 
+/** See analogous [d3 function](https://github.com/d3/d3-selection#selection_select). */
 public inline fun <E1 : Element, E2 : Element, D> Selection<E1, D>.select(
     crossinline select: E1.(Arguments<E1, D>) -> E2?,
 ): Selection<E2, D> = Selection(

--- a/selection/src/commonMain/kotlin/SelectAll.kt
+++ b/selection/src/commonMain/kotlin/SelectAll.kt
@@ -4,10 +4,12 @@ import com.juul.krayon.element.Element
 import com.juul.krayon.element.TypeSelector
 import com.juul.krayon.element.descendents
 
+/** See analogous [d3 function](https://github.com/d3/d3-selection#selection_selectAll). */
 public fun <E1 : Element, E2 : Element, D> Selection<E1, D>.selectAll(
     selector: TypeSelector<E2>,
 ): Selection<E2, D> = selectAll { descendents.mapNotNull { selector.trySelect(it) } }
 
+/** See analogous [d3 function](https://github.com/d3/d3-selection#selection_selectAll). */
 public inline fun <E1 : Element, E2 : Element, D> Selection<E1, D>.selectAll(
     crossinline select: E1.(Arguments<E1, D>) -> Sequence<E2>,
 ): Selection<E2, D> = Selection(

--- a/selection/src/commonMain/kotlin/SelectAll.kt
+++ b/selection/src/commonMain/kotlin/SelectAll.kt
@@ -6,10 +6,10 @@ import com.juul.krayon.element.descendents
 
 public fun <E1 : Element, E2 : Element, D> Selection<E1, D>.selectAll(
     selector: TypeSelector<E2>,
-): Selection<E2, D> = selectAll { _, _, _ -> descendents.mapNotNull { selector.trySelect(it) } }
+): Selection<E2, D> = selectAll { descendents.mapNotNull { selector.trySelect(it) } }
 
 public inline fun <E1 : Element, E2 : Element, D> Selection<E1, D>.selectAll(
-    crossinline select: Element.(datum: D, index: Int, group: List<E1?>) -> Sequence<E2>,
+    crossinline select: E1.(Arguments<E1, D>) -> Sequence<E2>,
 ): Selection<E2, D> = Selection(
     groups.flatMap { group ->
         group.nodes.asSequence()
@@ -19,7 +19,7 @@ public inline fun <E1 : Element, E2 : Element, D> Selection<E1, D>.selectAll(
                 node as Element
                 Group(
                     node,
-                    node.select(node.data as D, index, group.nodes)
+                    node.select(Arguments(node.data as D, index, group.nodes))
                         .onEach { it.data = node.data }
                         .toList()
                 )

--- a/selection/src/commonMain/kotlin/SelectAll.kt
+++ b/selection/src/commonMain/kotlin/SelectAll.kt
@@ -1,0 +1,21 @@
+package com.juul.krayon.selection
+
+import com.juul.krayon.element.Element
+
+public inline fun <T> Selection<T>.selectAll(
+    crossinline select: Element.(datum: T, index: Int, nodes: List<Element?>) -> List<Element>,
+): Selection<T> = Selection(
+    groups.flatMap { group ->
+        group.nodes.asSequence()
+            .withIndex()
+            .filter { (_, node) -> node != null }
+            .map { (index, node) ->
+                node as Element
+                Group(
+                    node,
+                    node.select(node.data as T, index, group.nodes)
+                        .onEach { it.data = node.data }
+                )
+            }
+    }
+)

--- a/selection/src/commonMain/kotlin/SelectAll.kt
+++ b/selection/src/commonMain/kotlin/SelectAll.kt
@@ -1,9 +1,10 @@
 package com.juul.krayon.selection
 
 import com.juul.krayon.element.Element
+import com.juul.krayon.element.descendents
 
 public inline fun <T> Selection<T>.selectAll(
-    crossinline select: Element.(datum: T, index: Int, nodes: List<Element?>) -> List<Element>,
+    crossinline select: Element.(datum: T, index: Int, group: Group<T>) -> List<Element>,
 ): Selection<T> = Selection(
     groups.flatMap { group ->
         group.nodes.asSequence()
@@ -13,9 +14,15 @@ public inline fun <T> Selection<T>.selectAll(
                 node as Element
                 Group(
                     node,
-                    node.select(node.data as T, index, group.nodes)
+                    node.select(node.data as T, index, group)
                         .onEach { it.data = node.data }
                 )
             }
     }
 )
+
+public inline fun <T> Selection<T>.selectAllDescendents(
+    crossinline select: Element.() -> Boolean,
+): Selection<T> = selectAll { _, _, _ ->
+    descendents.filter { it.select() }.toList()
+}

--- a/selection/src/commonMain/kotlin/SelectAll.kt
+++ b/selection/src/commonMain/kotlin/SelectAll.kt
@@ -2,12 +2,12 @@ package com.juul.krayon.selection
 
 import com.juul.krayon.element.Element
 import com.juul.krayon.element.TypeSelector
-import com.juul.krayon.element.descendents
+import com.juul.krayon.element.descendants
 
 /** See analogous [d3 function](https://github.com/d3/d3-selection#selection_selectAll). */
 public fun <E1 : Element, E2 : Element, D> Selection<E1, D>.selectAll(
     selector: TypeSelector<E2>,
-): Selection<E2, D> = selectAll { descendents.mapNotNull { selector.trySelect(it) } }
+): Selection<E2, D> = selectAll { descendants.mapNotNull { selector.trySelect(it) } }
 
 /** See analogous [d3 function](https://github.com/d3/d3-selection#selection_selectAll). */
 public inline fun <E1 : Element, E2 : Element, D> Selection<E1, D>.selectAll(

--- a/selection/src/commonMain/kotlin/Selection.kt
+++ b/selection/src/commonMain/kotlin/Selection.kt
@@ -20,5 +20,9 @@ public class ExitSelection<E : Element, D>(
     groups: List<Group<E, D>>,
 ) : Selection<E, D>(groups)
 
+/**
+ * See analogous [d3 function](https://github.com/d3/d3-selection#selection). Note that an
+ * explicit root must be specified, because there's no global document object here.
+ */
 public fun <E : Element> E.asSelection(): Selection<E, Nothing?> =
     Selection(listOf(Group(null, listOf(this))))

--- a/selection/src/commonMain/kotlin/Selection.kt
+++ b/selection/src/commonMain/kotlin/Selection.kt
@@ -1,5 +1,6 @@
 package com.juul.krayon.selection
 
+import com.juul.krayon.element.Element
 import com.juul.krayon.element.RootElement
 
 public open class Selection<T>(
@@ -20,5 +21,5 @@ public class ExitSelection<T>(
     groups: List<Group<T>>
 ) : Selection<T>(groups)
 
-public fun RootElement.selection(): Selection<Nothing?> =
+public fun Element.asSelection(): Selection<Nothing?> =
     Selection(listOf(Group(null, listOf(this))))

--- a/selection/src/commonMain/kotlin/Selection.kt
+++ b/selection/src/commonMain/kotlin/Selection.kt
@@ -2,23 +2,23 @@ package com.juul.krayon.selection
 
 import com.juul.krayon.element.Element
 
-public open class Selection<E: Element, D>(
-    public val groups: List<Group<E, D>>
+public open class Selection<E : Element, D>(
+    public val groups: List<Group<E, D>>,
 )
 
-public class UpdateSelection<E: Element, D>(
+public class UpdateSelection<E : Element, D>(
     groups: List<Group<E, D>>,
     public val enter: EnterSelection<D>,
-    public val exit: ExitSelection<E, D>
+    public val exit: ExitSelection<E, D>,
 ) : Selection<E, D>(groups)
 
 public class EnterSelection<D>(
-    groups: List<Group<EnterElement, D>>
+    groups: List<Group<EnterElement, D>>,
 ) : Selection<EnterElement, D>(groups)
 
-public class ExitSelection<E: Element, D>(
-    groups: List<Group<E, D>>
+public class ExitSelection<E : Element, D>(
+    groups: List<Group<E, D>>,
 ) : Selection<E, D>(groups)
 
-public fun <E: Element> E.asSelection(): Selection<E, Nothing?> =
+public fun <E : Element> E.asSelection(): Selection<E, Nothing?> =
     Selection(listOf(Group(null, listOf(this))))

--- a/selection/src/commonMain/kotlin/Selection.kt
+++ b/selection/src/commonMain/kotlin/Selection.kt
@@ -1,25 +1,24 @@
 package com.juul.krayon.selection
 
 import com.juul.krayon.element.Element
-import com.juul.krayon.element.RootElement
 
-public open class Selection<T>(
-    public val groups: List<Group<T>>
+public open class Selection<E: Element, D>(
+    public val groups: List<Group<E, D>>
 )
 
-public class UpdateSelection<T>(
-    groups: List<Group<T>>,
-    public val enter: EnterSelection<T>,
-    public val exit: ExitSelection<T>
-) : Selection<T>(groups)
+public class UpdateSelection<E: Element, D>(
+    groups: List<Group<E, D>>,
+    public val enter: EnterSelection<D>,
+    public val exit: ExitSelection<E, D>
+) : Selection<E, D>(groups)
 
-public class EnterSelection<T>(
-    groups: List<Group<T>>
-) : Selection<T>(groups)
+public class EnterSelection<D>(
+    groups: List<Group<EnterElement, D>>
+) : Selection<EnterElement, D>(groups)
 
-public class ExitSelection<T>(
-    groups: List<Group<T>>
-) : Selection<T>(groups)
+public class ExitSelection<E: Element, D>(
+    groups: List<Group<E, D>>
+) : Selection<E, D>(groups)
 
-public fun Element.asSelection(): Selection<Nothing?> =
+public fun <E: Element> E.asSelection(): Selection<E, Nothing?> =
     Selection(listOf(Group(null, listOf(this))))

--- a/selection/src/commonMain/kotlin/Selection.kt
+++ b/selection/src/commonMain/kotlin/Selection.kt
@@ -1,0 +1,24 @@
+package com.juul.krayon.selection
+
+import com.juul.krayon.element.RootElement
+
+public open class Selection<T>(
+    public val groups: List<Group<T>>
+)
+
+public class UpdateSelection<T>(
+    groups: List<Group<T>>,
+    public val enter: EnterSelection<T>,
+    public val exit: ExitSelection<T>
+) : Selection<T>(groups)
+
+public class EnterSelection<T>(
+    groups: List<Group<T>>
+) : Selection<T>(groups)
+
+public class ExitSelection<T>(
+    groups: List<Group<T>>
+) : Selection<T>(groups)
+
+public fun RootElement.selection(): Selection<Nothing?> =
+    Selection(listOf(Group(null, listOf(this))))

--- a/selection/src/commonTest/kotlin/Samples.kt
+++ b/selection/src/commonTest/kotlin/Samples.kt
@@ -17,7 +17,7 @@ class Samples {
         val canvas = SvgKanvas(width = 500f, height = 100f)
         val root = RootElement()
         val update = root.asSelection()
-            .selectAllDescendents { this is CircleElement }
+            .selectAll(CircleElement)
             .data(listOf(100f, 250f, 400f))
         update.enter.append { datum, _, _ -> CircleElement(centerX = datum, centerY = 50f, radius = 1f) }
         root.applyTo(canvas)

--- a/selection/src/commonTest/kotlin/Samples.kt
+++ b/selection/src/commonTest/kotlin/Samples.kt
@@ -1,0 +1,36 @@
+package com.juul.krayon.selection
+
+import com.juul.krayon.color.black
+import com.juul.krayon.element.CircleElement
+import com.juul.krayon.element.RootElement
+import com.juul.krayon.element.descendents
+import com.juul.krayon.kanvas.Paint
+import com.juul.krayon.kanvas.svg.SvgKanvas
+import com.juul.krayon.kanvas.xml.ScientificFormatter
+import com.juul.tuulbox.test.runTest
+import kotlin.test.Test
+
+class Samples {
+
+    @Test
+    fun svgTest() = runTest {
+        val canvas = SvgKanvas(width = 500f, height = 100f)
+        val root = RootElement()
+        root.selection()
+            .selectAll { _, _, _ -> descendents.filter { it is CircleElement }.toList() }
+            .data(listOf(100, 250, 400))
+            .enter.select { datum, index, nodes ->
+                CircleElement(
+                    centerX = datum.toFloat(),
+                    centerY = 50f,
+                    radius = 1f,
+                    paint = Paint.Fill(black)
+                ).also { circle ->
+                    appendChild(circle)
+                }
+            }
+        root.applyTo(canvas)
+        val svg = canvas.build()
+        println(svg)
+    }
+}

--- a/selection/src/commonTest/kotlin/Samples.kt
+++ b/selection/src/commonTest/kotlin/Samples.kt
@@ -6,9 +6,9 @@ import com.juul.krayon.element.RootElement
 import com.juul.krayon.element.descendents
 import com.juul.krayon.kanvas.Paint
 import com.juul.krayon.kanvas.svg.SvgKanvas
-import com.juul.krayon.kanvas.xml.ScientificFormatter
 import com.juul.tuulbox.test.runTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class Samples {
 
@@ -16,21 +16,20 @@ class Samples {
     fun svgTest() = runTest {
         val canvas = SvgKanvas(width = 500f, height = 100f)
         val root = RootElement()
-        root.selection()
-            .selectAll { _, _, _ -> descendents.filter { it is CircleElement }.toList() }
-            .data(listOf(100, 250, 400))
-            .enter.select { datum, index, nodes ->
-                CircleElement(
-                    centerX = datum.toFloat(),
-                    centerY = 50f,
-                    radius = 1f,
-                    paint = Paint.Fill(black)
-                ).also { circle ->
-                    appendChild(circle)
-                }
-            }
+        val update = root.asSelection()
+            .selectAllDescendents { this is CircleElement }
+            .data(listOf(100f, 250f, 400f))
+        update.enter.append { datum, _, _ -> CircleElement(centerX = datum, centerY = 50f, radius = 1f) }
         root.applyTo(canvas)
-        val svg = canvas.build()
-        println(svg)
+        assertEquals(
+            """
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500.0 100.0">
+              <circle cx="100.0" cy="50.0" r="1.0" fill="#000000" />
+              <circle cx="250.0" cy="50.0" r="1.0" fill="#000000" />
+              <circle cx="400.0" cy="50.0" r="1.0" fill="#000000" />
+            </svg>
+            """.trimIndent(),
+            canvas.build()
+        )
     }
 }

--- a/selection/src/commonTest/kotlin/Samples.kt
+++ b/selection/src/commonTest/kotlin/Samples.kt
@@ -23,7 +23,7 @@ class Samples {
                         .each { radius = 1f }
                 },
             ).each { (datum) -> centerX = datum }
-        root.applyTo(canvas)
+        root.draw(canvas)
         assertEquals(
             """
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500.0 100.0">

--- a/selection/src/commonTest/kotlin/Samples.kt
+++ b/selection/src/commonTest/kotlin/Samples.kt
@@ -1,10 +1,7 @@
 package com.juul.krayon.selection
 
-import com.juul.krayon.color.black
 import com.juul.krayon.element.CircleElement
 import com.juul.krayon.element.RootElement
-import com.juul.krayon.element.descendents
-import com.juul.krayon.kanvas.Paint
 import com.juul.krayon.kanvas.svg.SvgKanvas
 import com.juul.tuulbox.test.runTest
 import kotlin.test.Test
@@ -16,10 +13,16 @@ class Samples {
     fun svgTest() = runTest {
         val canvas = SvgKanvas(width = 500f, height = 100f)
         val root = RootElement()
-        val update = root.asSelection()
+        root.asSelection()
             .selectAll(CircleElement)
             .data(listOf(100f, 250f, 400f))
-        update.enter.append { datum, _, _ -> CircleElement(centerX = datum, centerY = 50f, radius = 1f) }
+            .join(
+                onEnter = {
+                    append(CircleElement)
+                        .each { centerY = 50f }
+                        .each { radius = 1f }
+                },
+            ).each { (datum) -> centerX = datum }
         root.applyTo(canvas)
         assertEquals(
             """

--- a/selection/src/commonTest/kotlin/Samples.kt
+++ b/selection/src/commonTest/kotlin/Samples.kt
@@ -3,6 +3,7 @@ package com.juul.krayon.selection
 import com.juul.krayon.element.CircleElement
 import com.juul.krayon.element.RootElement
 import com.juul.krayon.kanvas.svg.SvgKanvas
+import com.juul.krayon.kanvas.xml.ScientificFormatter
 import com.juul.tuulbox.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -11,7 +12,7 @@ class Samples {
 
     @Test
     fun svgTest() = runTest {
-        val canvas = SvgKanvas(width = 500f, height = 100f)
+        val canvas = SvgKanvas(width = 500f, height = 100f, formatter = ScientificFormatter(4))
         val root = RootElement()
         root.asSelection()
             .selectAll(CircleElement)
@@ -26,10 +27,10 @@ class Samples {
         root.draw(canvas)
         assertEquals(
             """
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500.0 100.0">
-              <circle cx="100.0" cy="50.0" r="1.0" fill="#000000" />
-              <circle cx="250.0" cy="50.0" r="1.0" fill="#000000" />
-              <circle cx="400.0" cy="50.0" r="1.0" fill="#000000" />
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 5e2 1e2">
+              <circle cx="1e2" cy="5e1" r="1" fill="#000000" />
+              <circle cx="2.5e2" cy="5e1" r="1" fill="#000000" />
+              <circle cx="4e2" cy="5e1" r="1" fill="#000000" />
             </svg>
             """.trimIndent(),
             canvas.build()

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -27,5 +27,5 @@ include(
     "element",
     "kanvas",
     "sample",
-    "selection"
+    "selection",
 )

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -24,6 +24,8 @@ pluginManagement {
 include(
     "chart",
     "color",
+    "element",
     "kanvas",
-    "sample"
+    "sample",
+    "selection"
 )


### PR DESCRIPTION
# Required Readings: https://bost.ocks.org/mike/selection/, https://bost.ocks.org/mike/nest/
Documentation hasn't been done yet. For now, it should be possible to lean on https://github.com/d3/d3-selection for the basics, since this API is largely derived from it. There's a few notable differences:
- We can't rely on a pre-existing DOM, so I've implemented a simple `element` package where elements mirror our `Kanvas` drawing API (not all primatives exist yet, this is just enough for proof of concept).
    - This means no table support for now. Implementing a table would be blocked on text measuring.
    - A side effect of this is that the DOM doesn't own the actual canvas it draws to, unlike in real D3 where an `<svg>` is an element. A `RootElement` per drawing must instead be manually instantiated, selections derived from that, and then an explicit call to draw it to a canvas.
- Strongly typed via generics. This makes many of the implementing functions messy, but the goal here was preserving the library consumer API.
- No `attr` and `style` functions, instead use `each` and a strongly typed property of the selected element type.
- Selection keys are not yet implemented.

Some other changes:
- IR compiler is getting mad on some function references in tests now
- Android's lint now fails on app compat 1.3, which forced the upgrade to app compat 1.4, which itself forced a change to our compile sdk