### PR TITLE
Add JS Canvas Frame Pacing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build/
 /captures
 .externalNativeBuild
 .cxx
+/kotlin-js-store

--- a/element-view/api/element-view.api
+++ b/element-view/api/element-view.api
@@ -2,32 +2,15 @@ public final class com/juul/krayon/element/view/ElementView : android/view/View 
 	public fun <init> (Landroid/content/Context;)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
 	public synthetic fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun getAdapter ()Lcom/juul/krayon/element/view/ElementView$Adapter;
-	public final fun setAdapter (Lcom/juul/krayon/element/view/ElementView$Adapter;)V
+	public final fun getAdapter ()Lcom/juul/krayon/element/view/ElementViewAdapter;
+	public final fun setAdapter (Lcom/juul/krayon/element/view/ElementViewAdapter;)V
 }
 
-public final class com/juul/krayon/element/view/ElementView$Adapter {
-	public fun <init> (Lkotlinx/coroutines/flow/Flow;Lcom/juul/krayon/element/view/ElementView$Adapter$Updater;)V
+public final class com/juul/krayon/element/view/ElementViewAdapter {
+	public fun <init> (Lkotlinx/coroutines/flow/Flow;Lcom/juul/krayon/element/view/UpdateElement;)V
 }
 
-public final class com/juul/krayon/element/view/ElementView$Adapter$State {
-	public fun <init> (Lcom/juul/krayon/element/view/ElementView;Lcom/juul/krayon/element/RootElement;II)V
-	public final fun component1 ()Lcom/juul/krayon/element/view/ElementView;
-	public final fun component2 ()Lcom/juul/krayon/element/RootElement;
-	public final fun component3 ()I
-	public final fun component4 ()I
-	public final fun copy (Lcom/juul/krayon/element/view/ElementView;Lcom/juul/krayon/element/RootElement;II)Lcom/juul/krayon/element/view/ElementView$Adapter$State;
-	public static synthetic fun copy$default (Lcom/juul/krayon/element/view/ElementView$Adapter$State;Lcom/juul/krayon/element/view/ElementView;Lcom/juul/krayon/element/RootElement;IIILjava/lang/Object;)Lcom/juul/krayon/element/view/ElementView$Adapter$State;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getHeight ()I
-	public final fun getRoot ()Lcom/juul/krayon/element/RootElement;
-	public final fun getView ()Lcom/juul/krayon/element/view/ElementView;
-	public final fun getWidth ()I
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public abstract interface class com/juul/krayon/element/view/ElementView$Adapter$Updater {
+public abstract interface class com/juul/krayon/element/view/UpdateElement {
 	public abstract fun update (Lcom/juul/krayon/element/RootElement;FFLjava/lang/Object;)V
 }
 

--- a/element-view/build.gradle.kts
+++ b/element-view/build.gradle.kts
@@ -10,6 +10,7 @@ kotlin {
     explicitApi()
 
     android { publishAllLibraryVariants() }
+    js().browser()
 
     sourceSets {
         val commonMain by getting {
@@ -41,6 +42,12 @@ kotlin {
                 implementation(kotlin("test-junit"))
                 implementation(libs.androidx.test)
                 implementation(libs.robolectric)
+            }
+        }
+
+        val jsTest by getting {
+            dependencies {
+                implementation(kotlin("test-js"))
             }
         }
     }

--- a/element-view/src/androidMain/kotlin/ElementViewAdapter.kt
+++ b/element-view/src/androidMain/kotlin/ElementViewAdapter.kt
@@ -1,0 +1,88 @@
+package com.juul.krayon.element.view
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.util.TypedValue
+import com.juul.krayon.element.RootElement
+import com.juul.krayon.kanvas.AndroidKanvas
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import kotlin.coroutines.CoroutineContext
+
+private val EMPTY_STATE = AdapterState<ElementView>(null, RootElement(), 0, 0)
+
+public actual class ElementViewAdapter<T> actual constructor(
+    private val dataSource: Flow<T>,
+    private val updater: UpdateElement<T>,
+) {
+
+    private val state: MutableStateFlow<AdapterState<ElementView>> = MutableStateFlow(EMPTY_STATE)
+
+    /** Coroutine scope rendering occurs on. This scope is live between calls to [onAttached] and [onDetached]. */
+    private var renderScope: CoroutineScope? = null
+        set(value) {
+            if (field !== value) field?.cancel()
+            field = value
+        }
+
+    /** The most recent bitmap to finish rendering, if any. */
+    internal var bitmap: Bitmap? = null
+        private set
+
+    /**
+     * The view changed size, so we should re-render the bitmap. When this happens, the RootElement
+     * will be reset, so the render will have a clean slate.
+     */
+    internal fun onSizeChanged(width: Int, height: Int) {
+        state.value = state.value.copy(root = RootElement(), width = width, height = height)
+    }
+
+    /** Enqueue rendering in a new scope. */
+    internal fun onAttached(view: ElementView) {
+        state.value = AdapterState(view, RootElement(), view.width, view.height)
+        renderScope = object : CoroutineScope {
+            private val job = Job()
+            override val coroutineContext: CoroutineContext get() = job
+        }.also { launchRenderingIn(it) }
+    }
+
+    /** Detach this from a view (usually because the view was detached from a window). */
+    internal fun onDetached() {
+        renderScope = null
+        state.value = EMPTY_STATE
+    }
+
+    private fun launchRenderingIn(scope: CoroutineScope) {
+        val buffer = MutableSharedFlow<Bitmap>(extraBufferCapacity = 4, onBufferOverflow = BufferOverflow.SUSPEND)
+        val pool = BitmapPool()
+        scope.launch(Dispatchers.Main.immediate) {
+            buffer.collect { bitmap ->
+                this@ElementViewAdapter.bitmap?.let { pool.release(it) }
+                this@ElementViewAdapter.bitmap = bitmap
+                state.value.view?.invalidate()
+            }
+        }
+        scope.launch {
+            state.collectLatest { state ->
+                if (state.view == null) return@collectLatest
+                if (state.width == 0 || state.height == 0) return@collectLatest
+                val scalingFactor = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 1f, state.view.resources.displayMetrics)
+                dataSource.collect { data ->
+                    updater.update(state.root, state.width / scalingFactor, state.height / scalingFactor, data)
+                    val bitmap = pool.acquire(state.width, state.height)
+                    state.root.draw(AndroidKanvas(state.view.context, Canvas(bitmap), scalingFactor))
+                    buffer.emit(bitmap)
+                }
+            }
+        }
+    }
+}

--- a/element-view/src/commonMain/kotlin/AdapterState.kt
+++ b/element-view/src/commonMain/kotlin/AdapterState.kt
@@ -1,0 +1,10 @@
+package com.juul.krayon.element.view
+
+import com.juul.krayon.element.RootElement
+
+internal data class AdapterState<V : Any>(
+    val view: V?,
+    val root: RootElement,
+    val width: Int,
+    val height: Int,
+)

--- a/element-view/src/commonMain/kotlin/ElementViewAdapter.kt
+++ b/element-view/src/commonMain/kotlin/ElementViewAdapter.kt
@@ -1,0 +1,8 @@
+package com.juul.krayon.element.view
+
+import kotlinx.coroutines.flow.Flow
+
+public expect class ElementViewAdapter<T>(
+    dataSource: Flow<T>,
+    updater: UpdateElement<T>,
+)

--- a/element-view/src/commonMain/kotlin/UpdateElement.kt
+++ b/element-view/src/commonMain/kotlin/UpdateElement.kt
@@ -1,0 +1,7 @@
+package com.juul.krayon.element.view
+
+import com.juul.krayon.element.RootElement
+
+public fun interface UpdateElement<T> {
+    public fun update(root: RootElement, width: Float, height: Float, data: T)
+}

--- a/element-view/src/jsMain/kotlin/ElementViewAdapter.kt
+++ b/element-view/src/jsMain/kotlin/ElementViewAdapter.kt
@@ -1,0 +1,72 @@
+package com.juul.krayon.element.view
+
+import com.juul.krayon.element.RootElement
+import com.juul.krayon.kanvas.HtmlCanvas
+import kotlinx.browser.window
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.awaitAnimationFrame
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import org.w3c.dom.HTMLCanvasElement
+import kotlin.coroutines.CoroutineContext
+
+private val EMPTY_STATE = AdapterState<HTMLCanvasElement>(null, RootElement(), 0, 0)
+
+public actual class ElementViewAdapter<T> actual constructor(
+    private val dataSource: Flow<T>,
+    private val updater: UpdateElement<T>,
+) {
+
+    private val state: MutableStateFlow<AdapterState<HTMLCanvasElement>> = MutableStateFlow(EMPTY_STATE)
+
+    /** Coroutine scope rendering occurs on. This scope is live between calls to [onAttached] and [onDetached]. */
+    private var renderScope: CoroutineScope? = null
+        set(value) {
+            if (field !== value) field?.cancel()
+            field = value
+        }
+
+    /**
+     * The view changed size, so we should re-render the bitmap. When this happens, the RootElement
+     * will be reset, so the render will have a clean slate.
+     */
+    internal fun onSizeChanged(width: Int, height: Int) {
+        state.value = state.value.copy(root = RootElement(), width = width, height = height)
+    }
+
+    /** Enqueue rendering in a new scope. */
+    internal fun onAttached(view: HTMLCanvasElement) {
+        state.value = AdapterState(view, RootElement(), view.width, view.height)
+        renderScope = object : CoroutineScope {
+            private val job = Job()
+            override val coroutineContext: CoroutineContext get() = job
+        }.also { launchRenderingIn(it) }
+    }
+
+    /** Detach this from a view, usually because the HTML Canvas was removed from the DOM. */
+    internal fun onDetached() {
+        renderScope = null
+        state.value = EMPTY_STATE
+    }
+
+    private fun launchRenderingIn(scope: CoroutineScope) {
+        scope.launch {
+            state.collectLatest { state ->
+                if (state.view == null) return@collectLatest
+                if (state.width == 0 || state.height == 0) return@collectLatest
+                val canvas = HtmlCanvas(state.view)
+                dataSource.collect { data ->
+                    updater.update(state.root, state.width.toFloat(), state.height.toFloat(), data)
+                    window.awaitAnimationFrame()
+                    canvas.context.clearRect(0.0, 0.0, state.width.toDouble(), state.height.toDouble())
+                    state.root.draw(canvas)
+                }
+            }
+        }
+    }
+}

--- a/element-view/src/jsMain/kotlin/HTMLCanvasElement.kt
+++ b/element-view/src/jsMain/kotlin/HTMLCanvasElement.kt
@@ -1,0 +1,19 @@
+package com.juul.krayon.element.view
+
+import org.w3c.dom.HTMLCanvasElement
+
+private var adapters = mutableMapOf<HTMLCanvasElement, ElementViewAdapter<*>>()
+
+public fun HTMLCanvasElement.attachAdapter(
+    adapter: ElementViewAdapter<*>
+) {
+    detachAdapter()
+    adapters[this] = adapter
+    adapter.onAttached(this)
+    onresize = { adapter.onSizeChanged(width, height) }
+}
+
+public fun HTMLCanvasElement.detachAdapter() {
+    adapters.remove(this)?.onDetached()
+    onresize = null
+}

--- a/kanvas/src/jsMain/kotlin/HtmlCanvas.kt
+++ b/kanvas/src/jsMain/kotlin/HtmlCanvas.kt
@@ -29,7 +29,8 @@ public class HtmlCanvas(
     element: HTMLCanvasElement,
 ) : Kanvas<Path2D> {
 
-    private val context = element.getContext("2d") as CanvasRenderingContext2D
+    /** The raw HTMLCanvas's 2d rendering context. */
+    public val context: CanvasRenderingContext2D = element.getContext("2d") as CanvasRenderingContext2D
 
     override val width: Float
         get() = context.canvas.width.toFloat()

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -15,6 +15,7 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 implementation(project(":axis"))
+                implementation(project(":element-view"))
                 implementation(project(":selection"))
                 implementation(project(":scale"))
                 implementation(project(":shape"))
@@ -34,7 +35,6 @@ kotlin {
 
         val androidMain by getting {
             dependencies {
-                implementation(project(":element-view"))
                 implementation(libs.androidx.appcompat)
                 implementation(libs.androidx.lifecycle.runtime)
                 implementation(libs.kotlinx.coroutines.android)

--- a/sample/src/androidMain/kotlin/com/juul/krayon/sample/DemoActivity.kt
+++ b/sample/src/androidMain/kotlin/com/juul/krayon/sample/DemoActivity.kt
@@ -2,7 +2,7 @@ package com.juul.krayon.sample
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
-import com.juul.krayon.element.view.ElementView
+import com.juul.krayon.element.view.ElementViewAdapter
 import com.juul.krayon.sample.databinding.ActivityDemoBinding
 import kotlin.time.ExperimentalTime
 
@@ -14,7 +14,7 @@ class DemoActivity : AppCompatActivity() {
         val binding = ActivityDemoBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        binding.sineView.adapter = ElementView.Adapter(
+        binding.sineView.adapter = ElementViewAdapter(
             dataSource = movingSineWave(),
             updater = ::lineChart
         )

--- a/sample/src/jsMain/kotlin/Main.kt
+++ b/sample/src/jsMain/kotlin/Main.kt
@@ -1,29 +1,18 @@
 package com.juul.krayon.sample
 
-import com.juul.krayon.color.white
-import com.juul.krayon.element.RootElement
-import com.juul.krayon.kanvas.HtmlCanvas
+import com.juul.krayon.element.view.ElementViewAdapter
+import com.juul.krayon.element.view.attachAdapter
 import kotlinx.browser.document
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
 import org.w3c.dom.HTMLCanvasElement
-import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.ExperimentalTime
 
 @OptIn(ExperimentalTime::class)
 fun main() {
-    val kanvas = HtmlCanvas(document.getElementById("canvas") as HTMLCanvasElement)
-    val root = RootElement()
-
-    movingSineWave()
-        .onEach { data ->
-            lineChart(root, kanvas.width, kanvas.height, data)
-            kanvas.drawColor(white)
-            root.draw(kanvas)
-            // It's important to delay when consuming a tight-loop data source, or JS's
-            // dispatcher will hold onto the thread for too long and prevent rendering.
-            delay(1.milliseconds)
-        }.launchIn(GlobalScope)
+    val canvas = document.getElementById("canvas") as HTMLCanvasElement
+    canvas.attachAdapter(
+        ElementViewAdapter(
+            dataSource = movingSineWave(),
+            updater = ::lineChart
+        )
+    )
 }


### PR DESCRIPTION
Extract's `ElementView.Adapter` to a common `ElementViewAdapter` to allow a simpler JS display implementation with automatic frame pacing. Eliminates stuttering on Chrome (on my macbook, at least. ymmv)