### PR TITLE
Add `min` and `max` operators

### DIFF
--- a/scale/api/scale.api
+++ b/scale/api/scale.api
@@ -61,6 +61,14 @@ public final class com/juul/krayon/scale/LocalDateTimeTicker : com/juul/krayon/s
 	public fun ticks (Lkotlinx/datetime/LocalDateTime;Lkotlinx/datetime/LocalDateTime;I)Ljava/util/List;
 }
 
+public final class com/juul/krayon/scale/MaxKt {
+	public static final fun max (Ljava/util/List;Lkotlin/jvm/functions/Function1;)Ljava/lang/Comparable;
+}
+
+public final class com/juul/krayon/scale/MinKt {
+	public static final fun min (Ljava/util/List;Lkotlin/jvm/functions/Function1;)Ljava/lang/Comparable;
+}
+
 public abstract interface class com/juul/krayon/scale/Scale {
 	public abstract fun scale (Ljava/lang/Object;)Ljava/lang/Object;
 }

--- a/scale/src/commonMain/kotlin/Max.kt
+++ b/scale/src/commonMain/kotlin/Max.kt
@@ -1,0 +1,12 @@
+package com.juul.krayon.scale
+
+public inline fun <I, O : Comparable<O>> List<I>.max(
+    crossinline selector: (I) -> O?,
+): O {
+    var max: O? = null
+    for (input in this) {
+        val output = selector(input) ?: continue
+        if (max == null || max < output) max = output
+    }
+    return checkNotNull(max)
+}

--- a/scale/src/commonMain/kotlin/Min.kt
+++ b/scale/src/commonMain/kotlin/Min.kt
@@ -1,0 +1,12 @@
+package com.juul.krayon.scale
+
+public inline fun <I, O : Comparable<O>> List<I>.min(
+    crossinline selector: (I) -> O?,
+): O {
+    var min: O? = null
+    for (input in this) {
+        val output = selector(input) ?: continue
+        if (min == null || min > output) min = output
+    }
+    return checkNotNull(min)
+}


### PR DESCRIPTION
Useful for computing the domain of data when the data contains multiple values that may influence the min or max.

For example, `max` is used in [Line plot with several groups](https://www.d3-graph-gallery.com/graph/line_several_group.html) for computing the y-axis domain:

![Screen Shot 2021-12-31 at 12 55 25 PM](https://user-images.githubusercontent.com/98017/147838850-3df2dae0-d2b0-4cc8-94aa-2ea64f00f8f7.png)

They were also used in https://github.com/JuulLabs/sensortag/pull/48.