### PR TITLE
Add `macosX64` target to `color` module

### DIFF
--- a/color/build.gradle.kts
+++ b/color/build.gradle.kts
@@ -17,6 +17,7 @@ kotlin {
 
     jvm()
     js().browser()
+    macosX64()
 
     sourceSets {
         val commonTest by getting {


### PR DESCRIPTION
Needed by an internal project.