### PR TITLE
Revert version bump

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,5 +26,5 @@ dokka = { id = "org.jetbrains.dokka", version = "1.6.10" }
 java8 = { id = "net.mbonnin.one.eight", version = "0.2" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlinter = { id = "org.jmailen.kotlinter", version = "3.9.0" }
-maven-publish = { id = "com.vanniktech.maven.publish", version = "0.19.0" }
+maven-publish = { id = "com.vanniktech.maven.publish", version = "0.18.0" }
 validator = { id = "binary-compatibility-validator", version = "0.8.0" }


### PR DESCRIPTION
If the publish test succeeds I'll merge this. If it fails I won't. 

Maven publication was failing because modules that generated both JVM and Android targets were missing JavaDoc jar on JVM. This failed sonatype validation preventing publishing.