### PR TITLE
Drop usage of explicit Webpack version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -30,5 +30,4 @@ POM_DEVELOPER_ID=cedrickcooke
 POM_DEVELOPER_NAME=Cedrick Cooke
 POM_DEVELOPER_URL=https://github.com/cedrickcooke
 
-kotlin.js.webpack.major.version=5
 kotlin.js.compiler=IR


### PR DESCRIPTION
Rather than specifying a version, we should use the default.