### PR TITLE
Publish using `macos` virtual environment

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ env:
 
 jobs:
   publish:
-    runs-on: ubuntu-20.04
+    runs-on: macos-11
     steps:
       - uses: actions/checkout@v3
       - uses: gradle/wrapper-validation-action@v1


### PR DESCRIPTION
`color-macosx64` Maven artifact is missing because the `macosX64` target is not compiled when using Ubuntu virtual environment:

![Screen Shot 2022-04-09 at 1 59 03 PM](https://user-images.githubusercontent.com/98017/162591445-413b1ff5-a559-439e-89c4-91fba7e9b3aa.png)

Switching to `macos` virtual environment should resolve the issue (and publish the `macosx64` artifacts).