### PR TITLE
Scale width and height of compose canvas correctly

### DIFF
--- a/compose/src/commonMain/kotlin/ComposeKanvas.kt
+++ b/compose/src/commonMain/kotlin/ComposeKanvas.kt
@@ -20,8 +20,8 @@ public class ComposeKanvas internal constructor(
     internal val resourceCache: ResourceCache
 ) : Kanvas<ComposePath> {
 
-    override val width: Float get() = scope.size.width
-    override val height: Float get() = scope.size.height
+    override val width: Float = scope.size.width / scope.density
+    override val height: Float = scope.size.height / scope.density
 
     init {
         scope.drawContext.transform.scale(scope.density, pivot = Offset.Zero)


### PR DESCRIPTION
Fixes a bug in `ComposeKanvas`. This wasn't spotted earlier because `ElementView` doesn't directly use the `width`/`height` properties due to its deferred rendering logic.