### PR TITLE
Implement conic gradients for HTML/JS

### DIFF
--- a/sample/src/commonMain/kotlin/PieChart.kt
+++ b/sample/src/commonMain/kotlin/PieChart.kt
@@ -5,12 +5,15 @@ import com.juul.krayon.color.blue
 import com.juul.krayon.color.darkCyan
 import com.juul.krayon.color.darkMagenta
 import com.juul.krayon.color.green
+import com.juul.krayon.color.lerp
 import com.juul.krayon.color.olive
 import com.juul.krayon.color.red
+import com.juul.krayon.color.white
 import com.juul.krayon.element.PathElement
 import com.juul.krayon.element.RootElement
 import com.juul.krayon.element.TransformElement
 import com.juul.krayon.kanvas.Paint
+import com.juul.krayon.kanvas.Paint.Gradient.Stop
 import com.juul.krayon.kanvas.Transform
 import com.juul.krayon.selection.asSelection
 import com.juul.krayon.selection.data
@@ -20,8 +23,17 @@ import com.juul.krayon.selection.selectAll
 import com.juul.krayon.shape.arc
 import com.juul.krayon.shape.pie
 
-private val fillPaints = listOf(red, blue, green, darkMagenta, darkCyan, olive)
-    .map { Paint.Fill(it) }
+private val paints = listOf(red, blue, green, darkMagenta, darkCyan, olive)
+    .map { color ->
+        val gradient = Paint.Gradient.Sweep(
+            centerX = 0f,
+            centerY = 0f,
+            Stop(0f, lerp(color, white, 0.75f)),
+            Stop(1f, lerp(color, black, 0.25f))
+        )
+        val stroke = Paint.Stroke(black, 0.5f, join = Paint.Stroke.Join.Round)
+        Paint.GradientAndStroke(gradient, stroke)
+    }
 
 internal data class PieChart(
     val values: List<Float>,
@@ -52,7 +64,7 @@ internal fun pieChart(root: RootElement, width: Float, height: Float, data: PieC
         .data(pie(data.values))
         .join(PathElement)
         .each { (slice, index) ->
-            paint = Paint.FillAndStroke(fillPaints[index], Paint.Stroke(black, 0.5f, join = Paint.Stroke.Join.Round))
+            paint = paints[index]
             path = arc(slice)
         }
 }


### PR DESCRIPTION
Apparently conic ("sweep" in Android) gradients release in Chrome on March 1st this year, so let's support those.