### PR TITLE
Use `ResizeObserver` instead of `onresize` callback for JS Element-View Adapter

### DIFF
--- a/element-view/src/jsMain/kotlin/HTMLCanvasElement.kt
+++ b/element-view/src/jsMain/kotlin/HTMLCanvasElement.kt
@@ -1,19 +1,36 @@
 package com.juul.krayon.element.view
 
+import org.w3c.dom.Element
 import org.w3c.dom.HTMLCanvasElement
 
+private external class ResizeObserver(
+    callback: (entries: Array<ResizeObserverEntry>, observer: ResizeObserver) -> Unit
+) {
+    fun observe(target: Element)
+    fun unobserve(target: Element)
+}
+
+private external interface ResizeObserverEntry
+
 private var adapters = mutableMapOf<HTMLCanvasElement, ElementViewAdapter<*>>()
+private var observers = mutableMapOf<HTMLCanvasElement, ResizeObserver>()
 
 public fun HTMLCanvasElement.attachAdapter(
     adapter: ElementViewAdapter<*>
 ) {
     detachAdapter()
+    val observer = ResizeObserver { _, _ ->
+        width = offsetWidth
+        height = offsetHeight
+        adapter.onSizeChanged(width, height)
+    }
+    observers[this] = observer
+    observer.observe(this)
     adapters[this] = adapter
     adapter.onAttached(this)
-    onresize = { adapter.onSizeChanged(width, height) }
 }
 
 public fun HTMLCanvasElement.detachAdapter() {
+    observers.remove(this)?.unobserve(this)
     adapters.remove(this)?.onDetached()
-    onresize = null
 }


### PR DESCRIPTION
Fixes a bug where resize events weren't being captured.