### PR TITLE
Fix JS font fallback

### DIFF
--- a/kanvas/src/jsMain/kotlin/HtmlCanvas.kt
+++ b/kanvas/src/jsMain/kotlin/HtmlCanvas.kt
@@ -28,6 +28,8 @@ private fun shouldFill(paint: Paint): Boolean =
 private fun shouldStroke(paint: Paint): Boolean =
     paint is Paint.Stroke || paint is Paint.FillAndStroke || paint is Paint.GradientAndStroke
 
+private val WHITESPACE = Regex("\\s")
+
 public class HtmlCanvas(
     element: HTMLCanvasElement,
 ) : Kanvas<Path2D> {
@@ -274,7 +276,11 @@ public class HtmlCanvas(
             Paint.Text.Alignment.Center -> CanvasTextAlign.CENTER
             Paint.Text.Alignment.Right -> CanvasTextAlign.RIGHT
         }
-        context.font = "${paint.size}px ${paint.font.names.joinToString { "\"$it\"" }}"
+        val size = "${paint.size}px"
+        val name = paint.font.names.joinToString { font ->
+            if (WHITESPACE in font) "\"$font\"" else font
+        }
+        context.font = "$size $name"
     }
 }
 


### PR DESCRIPTION
It turns out that CSS fonts don't handle quoting the built-ins of `serif`, `sans-serif`, and `monospace`. We can handle this by quoting only font names that contain whitespace, which is probably the right thing to do anyways.