### PR TITLE
Use `macos-11` for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - run: ./gradlew assemble
       - run: ./gradlew check jacocoTestReport
 
-      - uses: EnricoMi/publish-unit-test-result-action@v1
+      - uses: EnricoMi/publish-unit-test-result-action/composite@v1
         with:
           files: '**/build/test-results/**/*.xml'
           report_individual_runs: 'true'


### PR DESCRIPTION
Changing virtual environment to `macos-11` for CI runs so that we get coverage for all supported targets.

Prior to this PR, when running under Linux virtual environment:

```
Some Kotlin/Native targets cannot be built on this linux_x64 machine and are disabled:
    * In project ':axis':
        * targets 'macosArm64', 'macosX64' (can be built with one of the hosts: macos_x64, macos_arm64)
    * In project ':box':
        * targets 'macosArm64', 'macosX64' (can be built with one of the hosts: macos_x64, macos_arm64)
    * In project ':color':
        * targets 'macosX64', 'macosArm64', 'iosArm64' (can be built with one of the hosts: macos_x64, macos_arm64)
    * In project ':element':
        * targets 'macosArm64', 'macosX64' (can be built with one of the hosts: macos_x64, macos_arm64)
    * In project ':hierarchy':
        * targets 'macosArm64', 'macosX64' (can be built with one of the hosts: macos_x64, macos_arm64)
    * In project ':interpolate':
        * targets 'macosArm64', 'macosX64' (can be built with one of the hosts: macos_x64, macos_arm64)
    * In project ':kanvas':
        * targets 'macosArm64', 'macosX64' (can be built with one of the hosts: macos_x64, macos_arm64)
    * In project ':scale':
        * targets 'macosArm64', 'macosX64' (can be built with one of the hosts: macos_x64, macos_arm64)
    * In project ':selection':
        * targets 'macosArm64', 'macosX64' (can be built with one of the hosts: macos_x64, macos_arm64)
    * In project ':shape':
        * targets 'macosArm64', 'macosX64' (can be built with one of the hosts: macos_x64, macos_arm64)
    * In project ':time':
        * targets 'macosArm64', 'macosX64' (can be built with one of the hosts: macos_x64, macos_arm64)
```