### PR TITLE
Use Gradle type-safe project accessors

### DIFF
--- a/axis/build.gradle.kts
+++ b/axis/build.gradle.kts
@@ -24,8 +24,8 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                api(project(":scale"))
-                api(project(":selection"))
+                api(projects.scale)
+                api(projects.selection)
             }
         }
 

--- a/box/build.gradle.kts
+++ b/box/build.gradle.kts
@@ -17,16 +17,16 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                api(project(":axis"))
-                api(project(":color"))
-                api(project(":element"))
-                api(project(":hierarchy"))
-                api(project(":interpolate"))
-                api(project(":kanvas"))
-                api(project(":scale"))
-                api(project(":selection"))
-                api(project(":shape"))
-                api(project(":time"))
+                api(projects.axis)
+                api(projects.color)
+                api(projects.element)
+                api(projects.hierarchy)
+                api(projects.interpolate)
+                api(projects.kanvas)
+                api(projects.scale)
+                api(projects.selection)
+                api(projects.shape)
+                api(projects.time)
             }
         }
 
@@ -40,7 +40,7 @@ kotlin {
 
         val androidMain by getting {
             dependencies {
-                api(project(":element-view"))
+                api(projects.elementView)
             }
         }
 
@@ -60,7 +60,7 @@ kotlin {
 
         val jsMain by getting {
             dependencies {
-                api(project(":element-view"))
+                api(projects.elementView)
             }
         }
 

--- a/compose/build.gradle.kts
+++ b/compose/build.gradle.kts
@@ -19,8 +19,8 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                api(project(":kanvas"))
-                api(project(":element"))
+                api(projects.kanvas)
+                api(projects.element)
                 api(compose.runtime)
                 api(compose.foundation)
                 api(compose.material)

--- a/element-view/build.gradle.kts
+++ b/element-view/build.gradle.kts
@@ -15,7 +15,7 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                api(project(":element"))
+                api(projects.element)
                 api(libs.coroutines.core)
             }
         }

--- a/element/build.gradle.kts
+++ b/element/build.gradle.kts
@@ -24,7 +24,7 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                api(project(":kanvas"))
+                api(projects.kanvas)
             }
         }
 

--- a/interpolate/build.gradle.kts
+++ b/interpolate/build.gradle.kts
@@ -24,9 +24,9 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                api(project(":kanvas"))
+                api(projects.kanvas)
                 api(libs.datetime)
-                implementation(project(":time"))
+                implementation(projects.time)
             }
         }
 

--- a/kanvas/build.gradle.kts
+++ b/kanvas/build.gradle.kts
@@ -26,7 +26,7 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                api(project(":color"))
+                api(projects.color)
             }
         }
 

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -19,7 +19,7 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation(project(":box"))
+                implementation(projects.box)
                 implementation(kotlin("stdlib"))
                 implementation(libs.coroutines.core)
                 implementation(libs.datetime)
@@ -35,7 +35,7 @@ kotlin {
 
         val androidMain by getting {
             dependencies {
-                implementation(project(":compose"))
+                implementation(projects.compose)
                 implementation(libs.androidx.activity.compose)
                 implementation(libs.androidx.appcompat)
                 implementation(libs.androidx.lifecycle.runtime)
@@ -56,7 +56,7 @@ kotlin {
 
         val desktopMain by getting {
             dependencies {
-                implementation(project(":compose"))
+                implementation(projects.compose)
                 implementation(compose.desktop.currentOs)
                 implementation(compose.preview)
             }

--- a/scale/build.gradle.kts
+++ b/scale/build.gradle.kts
@@ -24,9 +24,9 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                api(project(":interpolate"))
-                api(project(":kanvas"))
-                api(project(":time"))
+                api(projects.interpolate)
+                api(projects.kanvas)
+                api(projects.time)
                 api(libs.datetime)
             }
         }

--- a/selection/build.gradle.kts
+++ b/selection/build.gradle.kts
@@ -24,7 +24,7 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                api(project(":element"))
+                api(projects.element)
             }
         }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,4 @@
-enableFeaturePreview("VERSION_CATALOGS")
+enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
 pluginManagement {
     repositories {

--- a/shape/build.gradle.kts
+++ b/shape/build.gradle.kts
@@ -24,7 +24,7 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                api(project(":kanvas"))
+                api(projects.kanvas)
             }
         }
 


### PR DESCRIPTION
Enables Gradle [type-safe project dependencies](https://docs.gradle.org/7.0/userguide/declaring_dependencies.html#sec:type-safe-project-accessors).

Special thanks to [Jake Wharton](https://twitter.com/JakeWharton/status/1491116447703375873?s=20&t=OSmqu1G4hGUUHSh2br5pSQ):

```zsh
find . -type f -name 'build.gradle*' -exec gsed -i -e "/project(/s/-[a-z]/\U&/g" -e "/project(/s/:/./g" -e "/project(/s/-//g" -E -e "s/project\((path\. ?)?('|\")([^'\"]+)\2\)/projects\3/" {} \;
```
