### PR TITLE
Make codecov optional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,6 @@ jobs:
           report_individual_runs: 'true'
 
       - uses: codecov/codecov-action@v3
-        with:
-          fail_ci_if_error: true
 
       - run: |
           set -o xtrace


### PR DESCRIPTION
No longer fail CI check when codecov fails to upload.