### PR TITLE
Remove JetBrains Maven repository

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,6 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        maven("https://maven.pkg.jetbrains.space/public/p/compose/dev") // Compose pre-release versions
     }
 
     tasks.withType<Test>().configureEach {


### PR DESCRIPTION
We no longer use pre-release Compose versions.