### PR TITLE
Add Renovate configuration to combine Kotlin and Compose upgrades

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base",
+    ":disableRateLimiting"
+  ],
+  "packageRules": [
+    {
+      "groupName": "Kotlin, KSP and Compose",
+      "matchPackagePrefixes": [
+        "org.jetbrains.kotlin:",
+        "org.jetbrains.kotlin.",
+        "org.jetbrains.compose.compiler"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adds Renovate configuration which groups upgrades for Kotlin and Compose compiler into a single PR (as those dependencies are often tightly coupled together).

Inspired by [PaulWoitaschek/Voice/renovate.json](https://github.com/PaulWoitaschek/Voice/blob/08ddf39bb0283df92cdcb4ae14828aa1573a753a/renovate.json).

Example of Renovate PR created with grouping: https://github.com/PaulWoitaschek/Voice/pull/1832