### PR TITLE
Use `latest` version of GitHub virtual environments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
       - uses: gradle/wrapper-validation-action@v1

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -9,7 +9,7 @@ env:
 
 jobs:
   deploy:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: gradle/wrapper-validation-action@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   publish:
-    runs-on: macos-12
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
       - uses: gradle/wrapper-validation-action@v1


### PR DESCRIPTION
These version bumps have been reliable and having to manually bump the version(s) adds a bit of churn. I'd rather not waste our time w/ reviewing it, and on the unlikely chance that something breaks w/ `-latest`, I'm hopeful that the time invested to resolve it will remain less than review time for the version bumps. 🤞 