### PR TITLE
Add 'nice' function from d3

### DIFF
--- a/scale/api/scale.api
+++ b/scale/api/scale.api
@@ -69,6 +69,11 @@ public final class com/juul/krayon/scale/MinKt {
 	public static final fun min (Ljava/lang/Iterable;Lkotlin/jvm/functions/Function1;)Ljava/lang/Comparable;
 }
 
+public final class com/juul/krayon/scale/NiceKt {
+	public static final fun nice (DDI)Ljava/util/List;
+	public static final fun nice (FFI)Ljava/util/List;
+}
+
 public abstract interface class com/juul/krayon/scale/Scale {
 	public abstract fun scale (Ljava/lang/Object;)Ljava/lang/Object;
 }

--- a/scale/src/commonMain/kotlin/Nice.kt
+++ b/scale/src/commonMain/kotlin/Nice.kt
@@ -1,0 +1,28 @@
+package com.juul.krayon.scale
+
+import kotlin.math.ceil
+import kotlin.math.floor
+
+/** See equivalent [d3 function](https://github.com/d3/d3-array#nice). */
+public fun nice(start: Float, stop: Float, count: Int): List<Float> =
+    nice(start.toDouble(), stop.toDouble(), count).map { it.toFloat() }
+
+/** See equivalent [d3 function](https://github.com/d3/d3-array#nice). */
+public fun nice(start: Double, stop: Double, count: Int): List<Double> {
+    var nextStart = start
+    var nextStop = stop
+    var previousIncrement: Int? = null
+    while (true) {
+        val increment = tickIncrement(nextStart, nextStop, count)
+        if (increment == previousIncrement || increment == 0) {
+            return listOf(nextStart, nextStop)
+        } else if (increment > 0) {
+            nextStart = floor(nextStart / increment) * increment
+            nextStop = ceil(nextStop / increment) * increment
+        } else {
+            nextStart = ceil(nextStart * increment) / increment
+            nextStop = floor(nextStop * increment) / increment
+        }
+        previousIncrement = increment
+    }
+}


### PR DESCRIPTION
Previously, krayon was missing the `nice` function from d3 for generating intervals. This should allow us to do so