### PR TITLE
Use explicit branch name for GitHub pages workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -2,7 +2,7 @@ name: GitHub Pages
 on:
   push:
     branches:
-      - $default-branch
+      - main
 
 permissions:
   contents: read


### PR DESCRIPTION
I had seen `$default-branch` used and it seemed like a flexible way to trigger on merges to the "main" (default) branch, but apparently it [only works for workflow templates](https://stackoverflow.com/a/65723433). 😢 

As a result, the GitHit Pages deployment has not been triggered since merge of #306. This PR restores the previous explicit (`main`) branch trigger.