### PR TITLE
Give GitHub pages workflow `contents` write permission

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -5,7 +5,7 @@ on:
       - main
 
 permissions:
-  contents: read
+  contents: write
   pages: write
   id-token: write
 


### PR DESCRIPTION
According to [github-pages-deploy-action] documentation, `write` permission is necessary:

<img width="851" alt="Screenshot 2024-01-09 at 3 05 33 PM" src="https://github.com/JuulLabs/krayon/assets/98017/3370c41a-f8e4-44b0-81da-6428da286852">

...should hopefully resolve failing [GitHub pages deployment](https://github.com/JuulLabs/krayon/actions/runs/7467024581/job/20319652791)s.

[github-pages-deploy-action]: https://github.com/JamesIves/github-pages-deploy-action