### PR TITLE
Fix logo URL when deployed

### DIFF
--- a/website/_includes/header.html
+++ b/website/_includes/header.html
@@ -4,7 +4,7 @@
         {%- assign default_paths = site.pages | map: "path" -%}
         {%- assign page_paths = site.header_pages | default: default_paths -%}
         {%- assign titles_size = site.pages | map: 'title' | join: '' | size -%}
-        <a class="site-title" rel="author" href="{{ "/" | relative_url }}"><img src="/assets/images/krayon.svg" height="35px" /></a>
+        <a class="site-title" rel="author" href="{{ "/" | relative_url }}"><img src="{{ "assets/images/krayon.svg" | relative_url }}" height="35px" /></a>
 
         {%- if titles_size > 0 -%}
         <nav class="site-nav">


### PR DESCRIPTION
The Krayon website's root URL starts at `/krayon/`; this makes it so that absolute URLs (e.g. `/assets/images/..`) don't work because the URL drops the `/krayon` root location.

This PR fixes the Krayon logo by passing the asset location to the `relative_url` Jekyll helper function.