### PR TITLE
Simplify `binary-compatibility-validator` setup

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,6 @@ plugins {
     alias(libs.plugins.kotlin.multiplatform) apply false
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.library) apply false
-    alias(libs.plugins.atomicfu) apply false
     alias(libs.plugins.compose) apply false
     alias(libs.plugins.kotlinter) apply false
     alias(libs.plugins.dokka)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
     alias(libs.plugins.kotlinter) apply false
     alias(libs.plugins.dokka)
     alias(libs.plugins.maven.publish) apply false
-    alias(libs.plugins.validator)
+    alias(libs.plugins.api)
 }
 
 apiValidation {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,7 +25,6 @@ robolectric = { module = "org.robolectric:robolectric", version = "4.11.1" }
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
-atomicfu = { id = "kotlinx-atomicfu", version = "0.21.0" }
 compose = { id = "org.jetbrains.compose", version.ref = "compose" }
 dokka = { id = "org.jetbrains.dokka", version = "1.9.20" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,9 +25,9 @@ robolectric = { module = "org.robolectric:robolectric", version = "4.11.1" }
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
+api = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version = "0.14.0" }
 compose = { id = "org.jetbrains.compose", version.ref = "compose" }
 dokka = { id = "org.jetbrains.dokka", version = "1.9.20" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlinter = { id = "org.jmailen.kotlinter", version = "4.2.0" }
 maven-publish = { id = "com.vanniktech.maven.publish", version = "0.27.0" }
-validator = { id = "binary-compatibility-validator", version = "0.14.0" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,9 +13,6 @@ pluginManagement {
                 "binary-compatibility-validator" ->
                     useModule("org.jetbrains.kotlinx:binary-compatibility-validator:${requested.version}")
 
-                "kotlinx-atomicfu" ->
-                    useModule("org.jetbrains.kotlinx:atomicfu-gradle-plugin:${requested.version}")
-
                 else -> when (requested.id.namespace) {
                     "com.android" ->
                         useModule("com.android.tools.build:gradle:${requested.version}")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,20 +6,6 @@ pluginManagement {
         gradlePluginPortal()
         mavenCentral()
     }
-
-    resolutionStrategy {
-        eachPlugin {
-            when (requested.id.id) {
-                "binary-compatibility-validator" ->
-                    useModule("org.jetbrains.kotlinx:binary-compatibility-validator:${requested.version}")
-
-                else -> when (requested.id.namespace) {
-                    "com.android" ->
-                        useModule("com.android.tools.build:gradle:${requested.version}")
-                }
-            }
-        }
-    }
 }
 
 include(


### PR DESCRIPTION
Updates configuration to more closely match [official setup instructions](https://github.com/Kotlin/binary-compatibility-validator?tab=readme-ov-file#setup) (by not configuring/using a shorthand name for the plugin — in other words: no longer using `resolutionStrategy`).