### PR TITLE
Configure automatic JVM toolchain downloading

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,6 +8,12 @@ pluginManagement {
     }
 }
 
+plugins {
+    // Provides repositories for auto-downloading JVM toolchains.
+    // https://github.com/gradle/foojay-toolchains
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
+}
+
 include(
     "axis",
     "box",


### PR DESCRIPTION
Simplifies process of setting up project for contributors (JVM toolchain is automatically setup for project if not present on user's system).