### PR TITLE
Add Native targets missing in tier 1

### DIFF
--- a/axis/build.gradle.kts
+++ b/axis/build.gradle.kts
@@ -17,6 +17,8 @@ kotlin {
     jvmToolchain(libs.versions.jvm.toolchain.get().toInt())
 
     iosArm64()
+    iosSimulatorArm64()
+    iosX64()
     js().browser()
     jvm()
     macosArm64()

--- a/axis/build.gradle.kts
+++ b/axis/build.gradle.kts
@@ -16,11 +16,11 @@ kotlin {
     explicitApi()
     jvmToolchain(libs.versions.jvm.toolchain.get().toInt())
 
-    jvm()
+    iosArm64()
     js().browser()
+    jvm()
     macosArm64()
     macosX64()
-    iosArm64()
 
     sourceSets {
         commonMain.dependencies {

--- a/box/build.gradle.kts
+++ b/box/build.gradle.kts
@@ -10,6 +10,8 @@ kotlin {
 
     androidTarget().publishAllLibraryVariants()
     iosArm64()
+    iosSimulatorArm64()
+    iosX64()
     js().browser()
     jvm()
     macosArm64()

--- a/box/build.gradle.kts
+++ b/box/build.gradle.kts
@@ -9,11 +9,11 @@ kotlin {
     jvmToolchain(libs.versions.jvm.toolchain.get().toInt())
 
     androidTarget().publishAllLibraryVariants()
-    jvm()
+    iosArm64()
     js().browser()
+    jvm()
     macosArm64()
     macosX64()
-    iosArm64()
 
     sourceSets {
         commonMain.dependencies {

--- a/color/build.gradle.kts
+++ b/color/build.gradle.kts
@@ -16,12 +16,11 @@ kotlin {
     explicitApi()
     jvmToolchain(libs.versions.jvm.toolchain.get().toInt())
 
-    jvm()
-    js().browser()
-
-    macosX64()
-    macosArm64()
     iosArm64()
+    js().browser()
+    jvm()
+    macosArm64()
+    macosX64()
 
     sourceSets {
         commonTest.dependencies {

--- a/color/build.gradle.kts
+++ b/color/build.gradle.kts
@@ -17,6 +17,8 @@ kotlin {
     jvmToolchain(libs.versions.jvm.toolchain.get().toInt())
 
     iosArm64()
+    iosSimulatorArm64()
+    iosX64()
     js().browser()
     jvm()
     macosArm64()

--- a/element/build.gradle.kts
+++ b/element/build.gradle.kts
@@ -17,6 +17,8 @@ kotlin {
     jvmToolchain(libs.versions.jvm.toolchain.get().toInt())
 
     iosArm64()
+    iosSimulatorArm64()
+    iosX64()
     js().browser()
     jvm()
     macosArm64()

--- a/element/build.gradle.kts
+++ b/element/build.gradle.kts
@@ -16,11 +16,11 @@ kotlin {
     explicitApi()
     jvmToolchain(libs.versions.jvm.toolchain.get().toInt())
 
-    jvm()
+    iosArm64()
     js().browser()
+    jvm()
     macosArm64()
     macosX64()
-    iosArm64()
 
     sourceSets {
         commonMain.dependencies {

--- a/hierarchy/build.gradle.kts
+++ b/hierarchy/build.gradle.kts
@@ -16,11 +16,11 @@ kotlin {
     explicitApi()
     jvmToolchain(libs.versions.jvm.toolchain.get().toInt())
 
-    jvm()
+    iosArm64()
     js().browser()
+    jvm()
     macosArm64()
     macosX64()
-    iosArm64()
 
     sourceSets {
         commonTest.dependencies {

--- a/hierarchy/build.gradle.kts
+++ b/hierarchy/build.gradle.kts
@@ -17,6 +17,8 @@ kotlin {
     jvmToolchain(libs.versions.jvm.toolchain.get().toInt())
 
     iosArm64()
+    iosSimulatorArm64()
+    iosX64()
     js().browser()
     jvm()
     macosArm64()

--- a/interpolate/build.gradle.kts
+++ b/interpolate/build.gradle.kts
@@ -17,6 +17,8 @@ kotlin {
     jvmToolchain(libs.versions.jvm.toolchain.get().toInt())
 
     iosArm64()
+    iosSimulatorArm64()
+    iosX64()
     js().browser()
     jvm()
     macosArm64()

--- a/interpolate/build.gradle.kts
+++ b/interpolate/build.gradle.kts
@@ -16,11 +16,11 @@ kotlin {
     explicitApi()
     jvmToolchain(libs.versions.jvm.toolchain.get().toInt())
 
-    jvm()
+    iosArm64()
     js().browser()
+    jvm()
     macosArm64()
     macosX64()
-    iosArm64()
 
     sourceSets {
         commonMain.dependencies {

--- a/kanvas/build.gradle.kts
+++ b/kanvas/build.gradle.kts
@@ -18,9 +18,9 @@ kotlin {
     jvmToolchain(libs.versions.jvm.toolchain.get().toInt())
 
     androidTarget().publishAllLibraryVariants()
-    jvm()
-    js().browser()
     iosArm64()
+    js().browser()
+    jvm()
     macosArm64()
     macosX64()
 

--- a/kanvas/build.gradle.kts
+++ b/kanvas/build.gradle.kts
@@ -19,6 +19,8 @@ kotlin {
 
     androidTarget().publishAllLibraryVariants()
     iosArm64()
+    iosSimulatorArm64()
+    iosX64()
     js().browser()
     jvm()
     macosArm64()

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -11,11 +11,11 @@ kotlin {
     jvmToolchain(libs.versions.jvm.toolchain.get().toInt())
 
     androidTarget()
-    jvm("desktop")
     js {
         browser()
         binaries.executable()
     }
+    jvm("desktop")
 
     sourceSets {
         commonMain.dependencies {

--- a/scale/build.gradle.kts
+++ b/scale/build.gradle.kts
@@ -17,6 +17,8 @@ kotlin {
     jvmToolchain(libs.versions.jvm.toolchain.get().toInt())
 
     iosArm64()
+    iosSimulatorArm64()
+    iosX64()
     js().browser()
     jvm()
     macosArm64()

--- a/scale/build.gradle.kts
+++ b/scale/build.gradle.kts
@@ -16,11 +16,11 @@ kotlin {
     explicitApi()
     jvmToolchain(libs.versions.jvm.toolchain.get().toInt())
 
-    jvm()
+    iosArm64()
     js().browser()
+    jvm()
     macosArm64()
     macosX64()
-    iosArm64()
 
     sourceSets {
         commonMain.dependencies {

--- a/selection/build.gradle.kts
+++ b/selection/build.gradle.kts
@@ -17,6 +17,8 @@ kotlin {
     jvmToolchain(libs.versions.jvm.toolchain.get().toInt())
 
     iosArm64()
+    iosSimulatorArm64()
+    iosX64()
     js().browser()
     jvm()
     macosArm64()

--- a/selection/build.gradle.kts
+++ b/selection/build.gradle.kts
@@ -16,11 +16,11 @@ kotlin {
     explicitApi()
     jvmToolchain(libs.versions.jvm.toolchain.get().toInt())
 
-    jvm()
+    iosArm64()
     js().browser()
+    jvm()
     macosArm64()
     macosX64()
-    iosArm64()
 
     sourceSets {
         commonMain.dependencies {

--- a/shape/build.gradle.kts
+++ b/shape/build.gradle.kts
@@ -17,6 +17,8 @@ kotlin {
     jvmToolchain(libs.versions.jvm.toolchain.get().toInt())
 
     iosArm64()
+    iosSimulatorArm64()
+    iosX64()
     js().browser()
     jvm()
     macosArm64()

--- a/shape/build.gradle.kts
+++ b/shape/build.gradle.kts
@@ -16,11 +16,11 @@ kotlin {
     explicitApi()
     jvmToolchain(libs.versions.jvm.toolchain.get().toInt())
 
-    jvm()
+    iosArm64()
     js().browser()
+    jvm()
     macosArm64()
     macosX64()
-    iosArm64()
 
     sourceSets {
         commonMain.dependencies {

--- a/time/build.gradle.kts
+++ b/time/build.gradle.kts
@@ -17,6 +17,8 @@ kotlin {
     jvmToolchain(libs.versions.jvm.toolchain.get().toInt())
 
     iosArm64()
+    iosSimulatorArm64()
+    iosX64()
     js().browser()
     jvm()
     macosArm64()

--- a/time/build.gradle.kts
+++ b/time/build.gradle.kts
@@ -16,11 +16,11 @@ kotlin {
     explicitApi()
     jvmToolchain(libs.versions.jvm.toolchain.get().toInt())
 
-    jvm()
+    iosArm64()
     js().browser()
+    jvm()
     macosArm64()
     macosX64()
-    iosArm64()
 
     sourceSets {
         commonMain.dependencies {


### PR DESCRIPTION
Per [Kotlin/Native target support], the following targets fall under [tier 1]:

- `macosX64`
- `macosArm64`
- `iosSimulatorArm64`
- `iosX64`

This PR adds any missing tier 1 targets to any modules that had Native targets.
Also, sorted the targets while I was making changes.

[Kotlin/Native target support]: https://kotlinlang.org/docs/native-target-support.html
[tier 1]: https://kotlinlang.org/docs/native-target-support.html#tier-1