### PR TITLE
Invert `CGAffineTransformRotate` rotation on iOS

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,6 +2,7 @@
 ij_kotlin_allow_trailing_comma = true
 ij_kotlin_allow_trailing_comma_on_call_site = true
 
+ktlint_standard_enum-entry-name-case = disabled
 ktlint_standard_function-naming = disabled
 ktlint_standard_function-signature = disabled
 ktlint_standard_no-blank-line-in-list = disabled

--- a/kanvas/src/appleMain/kotlin/CGAffineTransform.kt
+++ b/kanvas/src/appleMain/kotlin/CGAffineTransform.kt
@@ -1,5 +1,7 @@
 package com.juul.krayon.kanvas
 
+import com.juul.krayon.kanvas.OperatingSystem.iOS
+import com.juul.krayon.kanvas.OperatingSystem.macOS
 import kotlinx.cinterop.CValue
 import platform.CoreGraphics.CGAffineTransform
 import platform.CoreGraphics.CGAffineTransformConcat
@@ -52,6 +54,19 @@ internal fun CGContextSkewCTM(
     )
 }
 
+/**
+ * Per [CGAffineTransformRotate documentation](https://developer.apple.com/documentation/coregraphics/1455962-cgaffinetransformrotate#parameters):
+ *
+ * > The angle, in radians, by which to rotate the affine transform. In iOS, a positive value
+ * > specifies counterclockwise rotation and a negative value specifies clockwise rotation.
+ * > In macOS, a positive value specifies clockwise rotation and a negative value specifies
+ * > counterclockwise rotation.
+ */
+private val rotationModifier = when (currentOperatingSystem) {
+    iOS -> -1
+    macOS -> 1
+}
+
 internal fun Transform.asCGAffineTransform(): CValue<CGAffineTransform> {
     // While theoretically complete, this implementation is almost wholly untested.
     var buffer = CGAffineTransformMakeTranslation(0.0, 0.0)
@@ -69,7 +84,7 @@ internal fun Transform.asCGAffineTransform(): CValue<CGAffineTransform> {
             }
 
             is Transform.Rotate -> if (pivotX == 0f && pivotY == 0f) {
-                buffer = CGAffineTransformRotate(buffer, degrees * PI / 180)
+                buffer = CGAffineTransformRotate(buffer, rotationModifier * degrees * PI / 180)
             } else {
                 split().applyToBuffer()
             }

--- a/kanvas/src/appleMain/kotlin/OperatingSystem.kt
+++ b/kanvas/src/appleMain/kotlin/OperatingSystem.kt
@@ -1,0 +1,5 @@
+package com.juul.krayon.kanvas
+
+internal enum class OperatingSystem { macOS, iOS }
+
+internal expect val currentOperatingSystem: OperatingSystem

--- a/kanvas/src/iosMain/kotlin/OperatingSystem.kt
+++ b/kanvas/src/iosMain/kotlin/OperatingSystem.kt
@@ -1,0 +1,5 @@
+package com.juul.krayon.kanvas
+
+import com.juul.krayon.kanvas.OperatingSystem.iOS
+
+internal actual val currentOperatingSystem = iOS

--- a/kanvas/src/macosMain/kotlin/OperatingSystem.kt
+++ b/kanvas/src/macosMain/kotlin/OperatingSystem.kt
@@ -1,0 +1,5 @@
+package com.juul.krayon.kanvas
+
+import com.juul.krayon.kanvas.OperatingSystem.macOS
+
+internal actual val currentOperatingSystem = macOS


### PR DESCRIPTION
While I was debugging an issue with canvas rotation transformations, I noticed that the documentation for [`CGAffineTransformRotate`](https://developer.apple.com/documentation/coregraphics/1455962-cgaffinetransformrotate) states that rotations are inverted for iOS:

> The angle, in radians, by which to rotate the affine transform. In iOS, a positive value specifies counterclockwise rotation and a negative value specifies clockwise rotation. In macOS, a positive value specifies clockwise rotation and a negative value specifies counterclockwise rotation.