### PR TITLE
Remove y-inversion in `CGContextKanvas`

### DIFF
--- a/kanvas/src/appleMain/kotlin/CGContextRef.kt
+++ b/kanvas/src/appleMain/kotlin/CGContextRef.kt
@@ -1,0 +1,10 @@
+package com.juul.krayon.kanvas
+
+import platform.CoreGraphics.CGContextRef
+import platform.CoreGraphics.CGContextScaleCTM
+import platform.CoreGraphics.CGContextTranslateCTM
+
+public fun CGContextRef.setCoordinatesInvertedVertically(height: Double) {
+    CGContextTranslateCTM(this, 0.0, height)
+    CGContextScaleCTM(this, 1.0, -1.0)
+}


### PR DESCRIPTION
> [!IMPORTANT]  
> Y-axis inversion done by Apple consumers (from UIKit) should be removed after this change goes in.

Per [Stackoverflow: Core Graphics coordinate system](https://stackoverflow.com/questions/10408786/core-graphics-coordinate-system):

> When you create a `CGContext` yourself, its coordinate system has the origin in the bottom-left. When UIKit creates the `CGContext` for drawing into a view, it helpfully flips the coordinate system

When consumers provide a `CGContext` from a view, the coordinate space will have the origin in the upper-left corner (y-down), making it match the other platforms. Therefore, we **shouldn't** perform y-axis inversion in `CGContextKanvas`.

Despite UIKit providing a y-down `CGContext`, text will still render upside-down. Fortunately, [`CGContextSetTextMatrix`](https://developer.apple.com/documentation/coregraphics/1455611-cgcontextsettextmatrix) can be used to perform a y-inversion on the text rendering.

> [!NOTE]  
> Per [CGContextSetTextMatrix discussion](https://developer.apple.com/documentation/coregraphics/1455611-cgcontextsettextmatrix#discussion): the text matrix is not a part of the graphics state—saving or restoring the graphics state has no effect on the text matrix.