### PR TITLE
Skip `gh-pages` and `release-drafter` workflows on forks

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -15,6 +15,7 @@ env:
 
 jobs:
   deploy:
+    if: github.repository_owner == 'JuulLabs'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   update_release_draft:
+    if: github.repository_owner == 'JuulLabs'
     permissions:
       contents: write
       pull-requests: read


### PR DESCRIPTION
On forks (without GitHub pages setup — which is default) documentation deployment will fail (i.e. when fast-forwarding their `main` branch).

<details>
<summary>Example failure</summary>

![Screenshot 2024-04-24 at 2 08 39 AM](https://github.com/JuulLabs/krayon/assets/98017/274e53ad-aed5-4542-9c05-66778de54660)
</details>

Release drafting is also unnecessary for forks.