### PR TITLE
Update `publish-unit-test-result-action` GitHub action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           arguments: check jacocoTestReport
 
-      - uses: EnricoMi/publish-unit-test-result-action/composite@v2
+      - uses: EnricoMi/publish-unit-test-result-action/macos@v2
         with:
           junit_files: '**/build/test-results/**/*.xml'
           report_individual_runs: 'true'


### PR DESCRIPTION
Should fix the following (which we're seeing in CI workflow runs):

> Warning: Running this action via 'uses: EnricoMi/publish-unit-test-result-action/composite@v2 is deprecated! For details, see: https://github.com/EnricoMi/publish-unit-test-result-action/tree/v2#running-as-a-composite-action