### PR TITLE
Globally configure Maven `group`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,6 +27,8 @@ apiValidation {
 }
 
 allprojects {
+    group = "com.juul.krayon"
+
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
This is necessary to properly pull in Krayon as a [Gradle composite build](https://docs.gradle.org/current/userguide/composite_builds.html).