### PR TITLE
Add JavaScript target to `compose` module

### DIFF
--- a/compose/build.gradle.kts
+++ b/compose/build.gradle.kts
@@ -17,6 +17,7 @@ kotlin {
     iosArm64()
     iosSimulatorArm64()
     iosX64()
+    js().browser()
     jvm("desktop")
 
     sourceSets {
@@ -44,6 +45,10 @@ kotlin {
         }
 
         val iosMain by getting {
+            dependsOn(skiaMain)
+        }
+
+        val jsMain by getting {
             dependsOn(skiaMain)
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,7 @@
 org.gradle.jvmargs=-Xmx2048m
 
+org.jetbrains.compose.experimental.jscanvas.enabled=true
+
 # Android Configuration
 android.useAndroidX=true
 


### PR DESCRIPTION
Allows composable `ElementView` to be used from JavaScript. 🎉 