### PR TITLE
Disable Android `GradleDependency` lint check

### DIFF
--- a/box/build.gradle.kts
+++ b/box/build.gradle.kts
@@ -68,5 +68,6 @@ android {
     lint {
         abortOnError = true
         warningsAsErrors = true
+        disable += "GradleDependency"
     }
 }

--- a/compose/build.gradle.kts
+++ b/compose/build.gradle.kts
@@ -65,5 +65,6 @@ android {
     lint {
         abortOnError = true
         warningsAsErrors = true
+        disable += "GradleDependency"
     }
 }

--- a/element-view/build.gradle.kts
+++ b/element-view/build.gradle.kts
@@ -45,5 +45,6 @@ android {
     lint {
         abortOnError = true
         warningsAsErrors = true
+        disable += "GradleDependency"
     }
 }

--- a/kanvas/build.gradle.kts
+++ b/kanvas/build.gradle.kts
@@ -61,5 +61,6 @@ android {
     lint {
         abortOnError = true
         warningsAsErrors = true
+        disable += "GradleDependency"
     }
 }

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -81,6 +81,7 @@ android {
         // False positives for some reason
         disable += "MissingClass"
         disable += "UnusedResources"
+        disable += "GradleDependency"
     }
 }
 


### PR DESCRIPTION
There is no need to fail builds/CI due to outdated dependencies.