### PR TITLE
Fix: `SkiaIsPointInPath` should not mutate the Path buffer

### DIFF
--- a/compose/src/skiaMain/kotlin/SkiaIsPointInPath.kt
+++ b/compose/src/skiaMain/kotlin/SkiaIsPointInPath.kt
@@ -1,5 +1,7 @@
 package com.juul.krayon.compose
 
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Matrix
 import androidx.compose.ui.graphics.asSkiaPath
 import com.juul.krayon.kanvas.IsPointInPath
 import com.juul.krayon.kanvas.Path
@@ -9,37 +11,49 @@ import com.juul.krayon.kanvas.Transform.Rotate
 import com.juul.krayon.kanvas.Transform.Scale
 import com.juul.krayon.kanvas.Transform.Skew
 import com.juul.krayon.kanvas.Transform.Translate
-import org.jetbrains.skia.Matrix33
+import com.juul.krayon.kanvas.split
 
 internal actual fun isPointInPath(): IsPointInPath = SkiaIsPointInPath()
 
 public class SkiaIsPointInPath : IsPointInPath {
     override fun isPointInPath(transform: Transform, path: Path, x: Float, y: Float): Boolean {
+        val inverseMatrix = transform.asMatrix().apply { invert() }
+        val transformedPoint = inverseMatrix.map(Offset(x, y))
         val skiaPath = path.get(ComposePathMarker).asSkiaPath()
-        skiaPath.transform(transform.asMatrix())
-        return skiaPath.contains(x, y)
+        return skiaPath.contains(transformedPoint.x, transformedPoint.y)
     }
 }
 
-private fun Transform.asMatrix(): Matrix33 = when (this) {
-    is InOrder -> {
-        var buffer = Matrix33.IDENTITY
-        transformations.forEach { transform ->
-            buffer = buffer.makeConcat(transform.asMatrix())
+private fun Transform.asMatrix(): Matrix {
+    val buffer = Matrix()
+    applyTo(buffer)
+    return buffer
+}
+
+private tailrec fun Transform.applyTo(matrix: Matrix) {
+    when (this) {
+        is InOrder -> transformations.forEach { transform ->
+            @Suppress("NON_TAIL_RECURSIVE_CALL")
+            transform.applyTo(matrix)
         }
-        buffer
+
+        is Rotate -> if (pivotX == 0f && pivotY == 0f) {
+            matrix.rotateX(degrees)
+        } else {
+            split().applyTo(matrix)
+        }
+
+        is Scale -> if (pivotX == 0f && pivotY == 0f) {
+            matrix.scale(horizontal, vertical)
+        } else {
+            split().applyTo(matrix)
+        }
+
+        is Skew -> {
+            matrix.values[Matrix.SkewX] = horizontal
+            matrix.values[Matrix.SkewY] = vertical
+        }
+
+        is Translate -> matrix.translate(horizontal, vertical)
     }
-    is Scale -> if (pivotX == 0f && pivotY == 0f) {
-        Matrix33.makeScale(horizontal, vertical)
-    } else {
-        InOrder(Translate(pivotX, pivotY), Scale(horizontal, vertical), Translate(-pivotX, -pivotY)).asMatrix()
-    }
-    is Rotate -> if (pivotX == 0f && pivotY == 0f) {
-        Matrix33.makeRotate(degrees)
-    } else {
-        Matrix33.makeRotate(degrees, pivotX, pivotY)
-    }
-    is Translate -> Matrix33.makeTranslate(horizontal, vertical)
-    is Skew -> Matrix33.makeSkew(horizontal, vertical)
-    else -> error("Unreachable.")
 }


### PR DESCRIPTION
`SkiaIsPointInPath` incorrectly mutated the cached path when hit testing points. 

This could have been solved less-invasively by just copying the skia path to a new buffer. But that introduces yet-another inefficiency on an already pretty inefficient function. Instead, I'm taking this opportunity to apply two optimizations:
1. Avoid allocating multiple matrices for `InOrder` transformation chains
2. Only apply the (inverse) transformation to the test-point instead of transforming the whole path