### PR TITLE
Add AGENTS.md with Cursor Cloud development environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,39 @@
+# Krayon
+
+Kotlin Multiplatform drawing/charting library. See `README.md` for overview.
+
+## Cursor Cloud specific instructions
+
+### Prerequisites
+
+- **JDK 21** runs Gradle; **JDK 11** (`openjdk-11-jdk`) is required by the JVM toolchain (Gradle's foojay auto-download is blocked by egress restrictions).
+- **Android SDK** (platform 36) is needed because all library modules apply the `android-library` plugin. Set `ANDROID_HOME=/opt/android-sdk` and ensure `local.properties` contains `sdk.dir=/opt/android-sdk`.
+- **Mesa GL** (`libgl1-mesa-dri`, `libglx-mesa0`, `libegl-mesa0`) is needed to run the Compose Desktop sample app.
+
+### Key Gradle tasks
+
+| Task | Purpose |
+|------|---------|
+| `./gradlew lintKotlin` | Kotlin style checks (kotlinter) |
+| `./gradlew jvmTest` | JVM unit tests |
+| `./gradlew apiCheck` | Binary API compatibility (kotlinx-bvc) |
+| `./gradlew :sample:run` | Run the Compose Desktop sample app |
+
+### Running the sample desktop app
+
+The sample app uses Skiko (Compose Desktop renderer). In headless/VM environments without GPU:
+
+```
+export DISPLAY=:1
+export LIBGL_ALWAYS_SOFTWARE=1
+export SKIKO_RENDER_API=SOFTWARE_FAST
+./gradlew :sample:run
+```
+
+All three environment variables are required for the app window to render. Without `SKIKO_RENDER_API=SOFTWARE_FAST`, Skiko fails with "Cannot create Linux GL context".
+
+### Notes
+
+- Kotlin/Native targets (iOS, macOS) are automatically disabled on Linux — the warnings are expected and harmless. Add `kotlin.native.ignoreDisabledTargets=true` to `gradle.properties` to suppress them.
+- The `local.properties` file is gitignored; it must exist with `sdk.dir` pointing to the Android SDK.
+- CI runs on `macos-15` with JDK 17. On Linux cloud VMs, JVM and JS/WasmJS targets are fully testable; native Apple targets are not.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with Cursor Cloud specific development environment instructions for the Krayon codebase.

## What's included

- Prerequisites documentation (JDK 11 toolchain, Android SDK, Mesa GL for software rendering)
- Key Gradle tasks reference table (lint, test, apiCheck, sample run)
- Instructions for running the Compose Desktop sample app in headless/VM environments (Skiko `SOFTWARE_FAST` renderer)
- Notes on Kotlin/Native target behavior on Linux and `local.properties` setup

## Demo

[krayon-sample-desktop-demo.mp4](https://cursor.com/agents/bc-0ed8923b-06db-4bea-b88a-0bc63821ebb8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fkrayon-sample-desktop-demo.mp4)

Sample desktop app running with line chart, interactive pie chart, and tree chart.

[Sample desktop charts after interaction](https://cursor.com/agents/bc-0ed8923b-06db-4bea-b88a-0bc63821ebb8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsample_desktop_charts.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0ed8923b-06db-4bea-b88a-0bc63821ebb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0ed8923b-06db-4bea-b88a-0bc63821ebb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

