### PR TITLE
Bump Android compile to `37`

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 agp = "9.2.1"
-android-compile = "36"
+android-compile = "37"
 android-min = "23"
 android-target = "36"
 compose = "1.11.1"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single-version-catalog change affecting compile-time APIs only; no runtime or target-SDK changes.
> 
> **Overview**
> Raises the shared **Android compile SDK** version from **36** to **37** in `gradle/libs.versions.toml` (`android-compile`). That value drives `compileSdk` for Kotlin Multiplatform Android library modules via build conventions; **min SDK** and **target SDK** are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfcacd634ba55ff11d05483c2714147d9e80537b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->