### PR TITLE
Add a text measurement API

### DIFF
--- a/compose/api/compose.klib.api
+++ b/compose/api/compose.klib.api
@@ -6,7 +6,7 @@
 // - Show declarations: true
 
 // Library unique name: <com.juul.krayon:compose>
-final class com.juul.krayon.compose/ComposeKanvas : com.juul.krayon.kanvas/Kanvas { // com.juul.krayon.compose/ComposeKanvas|null[0]
+final class com.juul.krayon.compose/ComposeKanvas : com.juul.krayon.kanvas/Kanvas, com.juul.krayon.kanvas/MeasureText { // com.juul.krayon.compose/ComposeKanvas|null[0]
     final val height // com.juul.krayon.compose/ComposeKanvas.height|{}height[0]
         final fun <get-height>(): kotlin/Float // com.juul.krayon.compose/ComposeKanvas.height.<get-height>|<get-height>(){}[0]
     final val width // com.juul.krayon.compose/ComposeKanvas.width|{}width[0]
@@ -20,6 +20,7 @@ final class com.juul.krayon.compose/ComposeKanvas : com.juul.krayon.kanvas/Kanva
     final fun drawPath(com.juul.krayon.kanvas/Path, com.juul.krayon.kanvas/Paint) // com.juul.krayon.compose/ComposeKanvas.drawPath|drawPath(com.juul.krayon.kanvas.Path;com.juul.krayon.kanvas.Paint){}[0]
     final fun drawRect(kotlin/Float, kotlin/Float, kotlin/Float, kotlin/Float, com.juul.krayon.kanvas/Paint) // com.juul.krayon.compose/ComposeKanvas.drawRect|drawRect(kotlin.Float;kotlin.Float;kotlin.Float;kotlin.Float;com.juul.krayon.kanvas.Paint){}[0]
     final fun drawText(kotlin/CharSequence, kotlin/Float, kotlin/Float, com.juul.krayon.kanvas/Paint) // com.juul.krayon.compose/ComposeKanvas.drawText|drawText(kotlin.CharSequence;kotlin.Float;kotlin.Float;com.juul.krayon.kanvas.Paint){}[0]
+    final fun measureText(kotlin/CharSequence, com.juul.krayon.kanvas/Paint.Text): com.juul.krayon.kanvas/TextMetrics // com.juul.krayon.compose/ComposeKanvas.measureText|measureText(kotlin.CharSequence;com.juul.krayon.kanvas.Paint.Text){}[0]
     final fun pop() // com.juul.krayon.compose/ComposeKanvas.pop|pop(){}[0]
     final fun pushClip(com.juul.krayon.kanvas/Clip) // com.juul.krayon.compose/ComposeKanvas.pushClip|pushClip(com.juul.krayon.kanvas.Clip){}[0]
     final fun pushTransform(com.juul.krayon.kanvas/Transform) // com.juul.krayon.compose/ComposeKanvas.pushTransform|pushTransform(com.juul.krayon.kanvas.Transform){}[0]
@@ -49,4 +50,5 @@ final fun com.juul.krayon.compose/Kanvas(androidx.compose.ui/Modifier, kotlin/Fu
 final fun com.juul.krayon.compose/com_juul_krayon_compose_ComposeKanvas$stableprop_getter(): kotlin/Int // com.juul.krayon.compose/com_juul_krayon_compose_ComposeKanvas$stableprop_getter|com_juul_krayon_compose_ComposeKanvas$stableprop_getter(){}[0]
 final fun com.juul.krayon.compose/com_juul_krayon_compose_ComposePathMarker$stableprop_getter(): kotlin/Int // com.juul.krayon.compose/com_juul_krayon_compose_ComposePathMarker$stableprop_getter|com_juul_krayon_compose_ComposePathMarker$stableprop_getter(){}[0]
 final fun com.juul.krayon.compose/com_juul_krayon_compose_SkiaIsPointInPath$stableprop_getter(): kotlin/Int // com.juul.krayon.compose/com_juul_krayon_compose_SkiaIsPointInPath$stableprop_getter|com_juul_krayon_compose_SkiaIsPointInPath$stableprop_getter(){}[0]
+final fun com.juul.krayon.compose/textMeasurement(): com.juul.krayon.kanvas/MeasureText // com.juul.krayon.compose/textMeasurement|textMeasurement(){}[0]
 final suspend fun (com.juul.krayon.core/Krayon).com.juul.krayon.compose/addFontAssociation(kotlin/String, org.jetbrains.compose.resources/FontResource, org.jetbrains.compose.resources/ResourceEnvironment) // com.juul.krayon.compose/addFontAssociation|addFontAssociation@com.juul.krayon.core.Krayon(kotlin.String;org.jetbrains.compose.resources.FontResource;org.jetbrains.compose.resources.ResourceEnvironment){}[0]

--- a/compose/api/jvm/compose.api
+++ b/compose/api/jvm/compose.api
@@ -1,4 +1,4 @@
-public final class com/juul/krayon/compose/ComposeKanvas : com/juul/krayon/kanvas/Kanvas {
+public final class com/juul/krayon/compose/ComposeKanvas : com/juul/krayon/kanvas/Kanvas, com/juul/krayon/kanvas/MeasureText {
 	public static final field $stable I
 	public fun drawArc (FFFFFFLcom/juul/krayon/kanvas/Paint;)V
 	public fun drawCircle (FFFLcom/juul/krayon/kanvas/Paint;)V
@@ -10,6 +10,7 @@ public final class com/juul/krayon/compose/ComposeKanvas : com/juul/krayon/kanva
 	public fun drawText (Ljava/lang/CharSequence;FFLcom/juul/krayon/kanvas/Paint;)V
 	public fun getHeight ()F
 	public fun getWidth ()F
+	public fun measureText (Ljava/lang/CharSequence;Lcom/juul/krayon/kanvas/Paint$Text;)Lcom/juul/krayon/kanvas/TextMetrics;
 	public fun pop ()V
 	public fun pushClip (Lcom/juul/krayon/kanvas/Clip;)V
 	public fun pushTransform (Lcom/juul/krayon/kanvas/Transform;)V
@@ -38,6 +39,10 @@ public final class com/juul/krayon/compose/KanvasKt {
 
 public final class com/juul/krayon/compose/KrayonExtensionsKt {
 	public static final fun addFontAssociation (Lcom/juul/krayon/core/Krayon;Ljava/lang/String;Lorg/jetbrains/compose/resources/FontResource;Lorg/jetbrains/compose/resources/ResourceEnvironment;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/juul/krayon/compose/MeasureTextKt {
+	public static final fun textMeasurement ()Lcom/juul/krayon/kanvas/MeasureText;
 }
 
 public final class com/juul/krayon/compose/SkiaIsPointInPath : com/juul/krayon/kanvas/IsPointInPath {

--- a/compose/build.gradle.kts
+++ b/compose/build.gradle.kts
@@ -40,6 +40,15 @@ kotlin {
         val wasmJsMain by getting {
             dependsOn(skiaMain)
         }
+
+        getByName("jvmTest").dependencies {
+            implementation(compose.desktop.currentOs)
+        }
+
+        getByName("androidHostTest").dependencies {
+            implementation(libs.androidx.test)
+            implementation(libs.robolectric)
+        }
     }
 }
 

--- a/compose/src/androidHostTest/kotlin/AndroidMeasureTextTests.kt
+++ b/compose/src/androidHostTest/kotlin/AndroidMeasureTextTests.kt
@@ -1,0 +1,51 @@
+package com.juul.krayon.compose
+
+import com.juul.krayon.color.black
+import com.juul.krayon.kanvas.Font
+import com.juul.krayon.kanvas.Paint
+import com.juul.krayon.kanvas.sansSerif
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@RunWith(RobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(manifest = Config.NONE, sdk = [35])
+class AndroidMeasureTextTests {
+
+    private val measurement = textMeasurement()
+    private val paint = Paint.Text(black, size = 24f, Paint.Text.Alignment.Left, Font(sansSerif))
+
+    @Test
+    fun emptyString_hasZeroWidth() {
+        assertEquals(0f, measurement.measureText("", paint).width)
+    }
+
+    @Test
+    fun nonEmptyString_hasPositiveSize() {
+        val metrics = measurement.measureText("Hello", paint)
+        assertTrue(metrics.width > 0f, "expected positive width, was ${metrics.width}")
+        assertTrue(metrics.ascent > 0f, "expected positive ascent, was ${metrics.ascent}")
+        assertTrue(metrics.descent > 0f, "expected positive descent, was ${metrics.descent}")
+        assertEquals(metrics.ascent + metrics.descent, metrics.height)
+    }
+
+    @Test
+    fun longerString_isWider() {
+        val short = measurement.measureText("i", paint).width
+        val long = measurement.measureText("iiiiiiiiii", paint).width
+        assertTrue(long > short, "expected '$long' > '$short'")
+    }
+
+    @Test
+    fun verticalMetrics_areIndependentOfText() {
+        val a = measurement.measureText("a", paint)
+        val b = measurement.measureText("longer text", paint)
+        assertEquals(a.ascent, b.ascent)
+        assertEquals(a.descent, b.descent)
+    }
+}

--- a/compose/src/androidMain/kotlin/DrawText.kt
+++ b/compose/src/androidMain/kotlin/DrawText.kt
@@ -9,7 +9,7 @@ internal actual fun drawText(kanvas: ComposeKanvas, text: CharSequence, x: Float
     canvas.drawText(text.toString(), x, y, androidPaint(paint))
 }
 
-private fun androidPaint(source: Paint.Text) = AndroidPaint().apply {
+internal fun androidPaint(source: Paint.Text) = AndroidPaint().apply {
     style = AndroidPaint.Style.FILL
     isAntiAlias = true
     color = source.color.argb

--- a/compose/src/androidMain/kotlin/MeasureText.android.kt
+++ b/compose/src/androidMain/kotlin/MeasureText.android.kt
@@ -1,0 +1,15 @@
+package com.juul.krayon.compose
+
+import com.juul.krayon.kanvas.Paint
+import com.juul.krayon.kanvas.TextMetrics
+
+internal actual fun measureText(text: CharSequence, paint: Paint.Text): TextMetrics {
+    val nativePaint = androidPaint(paint)
+    val width = nativePaint.measureText(text, 0, text.length)
+    val fontMetrics = nativePaint.fontMetrics
+    return TextMetrics(
+        width = width,
+        ascent = -fontMetrics.ascent,
+        descent = fontMetrics.descent,
+    )
+}

--- a/compose/src/commonMain/kotlin/ComposeKanvas.kt
+++ b/compose/src/commonMain/kotlin/ComposeKanvas.kt
@@ -9,13 +9,15 @@ import androidx.compose.ui.graphics.drawscope.scale
 import com.juul.krayon.color.Color
 import com.juul.krayon.kanvas.Clip
 import com.juul.krayon.kanvas.Kanvas
+import com.juul.krayon.kanvas.MeasureText
 import com.juul.krayon.kanvas.Paint
 import com.juul.krayon.kanvas.Path
+import com.juul.krayon.kanvas.TextMetrics
 import com.juul.krayon.kanvas.Transform
 
 public class ComposeKanvas internal constructor(
     internal val scope: DrawScope,
-) : Kanvas {
+) : Kanvas, MeasureText {
 
     override val width: Float = scope.size.width / scope.density
     override val height: Float = scope.size.height / scope.density
@@ -100,6 +102,9 @@ public class ComposeKanvas internal constructor(
         // Delegate to expect/actual function
         drawText(this, text, x, y, paint)
     }
+
+    override fun measureText(text: CharSequence, paint: Paint.Text): TextMetrics =
+        com.juul.krayon.compose.measureText(text, paint)
 
     override fun pushClip(clip: Clip) {
         scope.drawContext.canvas.save()

--- a/compose/src/commonMain/kotlin/MeasureText.kt
+++ b/compose/src/commonMain/kotlin/MeasureText.kt
@@ -1,0 +1,16 @@
+package com.juul.krayon.compose
+
+import com.juul.krayon.kanvas.MeasureText
+import com.juul.krayon.kanvas.Paint
+import com.juul.krayon.kanvas.TextMetrics
+
+internal expect fun measureText(text: CharSequence, paint: Paint.Text): TextMetrics
+
+/**
+ * A [MeasureText] backed by the same native text rendering Compose uses to draw. This allows chart
+ * layout code to measure text without a [ComposeKanvas].
+ *
+ * Fonts registered via [Krayon.addFontAssociation][com.juul.krayon.compose.addFontAssociation] are
+ * honored, just as they are when drawing.
+ */
+public fun textMeasurement(): MeasureText = MeasureText(::measureText)

--- a/compose/src/jvmTest/kotlin/SkiaMeasureTextTests.kt
+++ b/compose/src/jvmTest/kotlin/SkiaMeasureTextTests.kt
@@ -1,0 +1,44 @@
+package com.juul.krayon.compose
+
+import com.juul.krayon.color.black
+import com.juul.krayon.kanvas.Font
+import com.juul.krayon.kanvas.Paint
+import com.juul.krayon.kanvas.sansSerif
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class SkiaMeasureTextTests {
+
+    private val measurement = textMeasurement()
+    private val paint = Paint.Text(black, size = 24f, Paint.Text.Alignment.Left, Font(sansSerif))
+
+    @Test
+    fun emptyString_hasZeroWidth() {
+        assertEquals(0f, measurement.measureText("", paint).width)
+    }
+
+    @Test
+    fun nonEmptyString_hasPositiveSize() {
+        val metrics = measurement.measureText("Hello", paint)
+        assertTrue(metrics.width > 0f, "expected positive width, was ${metrics.width}")
+        assertTrue(metrics.ascent > 0f, "expected positive ascent, was ${metrics.ascent}")
+        assertTrue(metrics.descent > 0f, "expected positive descent, was ${metrics.descent}")
+        assertEquals(metrics.ascent + metrics.descent, metrics.height)
+    }
+
+    @Test
+    fun longerString_isWider() {
+        val short = measurement.measureText("i", paint).width
+        val long = measurement.measureText("iiiiiiiiii", paint).width
+        assertTrue(long > short, "expected '$long' > '$short'")
+    }
+
+    @Test
+    fun verticalMetrics_areIndependentOfText() {
+        val a = measurement.measureText("a", paint)
+        val b = measurement.measureText("longer text", paint)
+        assertEquals(a.ascent, b.ascent)
+        assertEquals(a.descent, b.descent)
+    }
+}

--- a/compose/src/skiaMain/kotlin/DrawText.kt
+++ b/compose/src/skiaMain/kotlin/DrawText.kt
@@ -27,19 +27,19 @@ internal actual fun drawText(kanvas: ComposeKanvas, text: CharSequence, x: Float
     }
 }
 
-private fun Paint.Text.toSkiaFont(): SkiaFont {
+internal fun Paint.Text.toSkiaFont(): SkiaFont {
     val font = SkiaFont(font.toNativeTypeface(), size)
     font.isSubpixel = true
     return font
 }
 
-private fun Paint.Text.toSkiaPaint(): SkiaPaint {
+internal fun Paint.Text.toSkiaPaint(): SkiaPaint {
     val paint = SkiaPaint()
     paint.color = color.argb
     return paint
 }
 
-private fun measureTextWidth(text: String, font: SkiaFont, paint: SkiaPaint): Float {
+internal fun measureTextWidth(text: String, font: SkiaFont, paint: SkiaPaint): Float {
     // TODO: Figure out why `font.measureTextWidth(text, paint)` doesn't return the same thing every time.
     //       This appears to be a bug on web only, but causes really painful text jumpiness.
     val glyphs = font.getStringGlyphs(text)

--- a/compose/src/skiaMain/kotlin/MeasureText.skia.kt
+++ b/compose/src/skiaMain/kotlin/MeasureText.skia.kt
@@ -1,0 +1,25 @@
+package com.juul.krayon.compose
+
+import com.juul.krayon.kanvas.Paint
+import com.juul.krayon.kanvas.TextMetrics
+import org.jetbrains.skia.impl.use
+
+internal actual fun measureText(text: CharSequence, paint: Paint.Text): TextMetrics =
+    paint.toSkiaFont().use { font ->
+        val metrics = font.metrics
+        val width = if (text.isEmpty()) {
+            0f
+        } else {
+            val skiaPaint = paint.toSkiaPaint()
+            try {
+                measureTextWidth(text.toString(), font, skiaPaint)
+            } finally {
+                skiaPaint.close()
+            }
+        }
+        TextMetrics(
+            width = width,
+            ascent = -metrics.ascent,
+            descent = metrics.descent,
+        )
+    }

--- a/kanvas/README.md
+++ b/kanvas/README.md
@@ -136,6 +136,27 @@ Drawing to your Krayon canvas directly from Swift isn't recommend -- the API is 
 you should call a Kotlin function that handles drawing for you. As an example, using the `element`
 module, you might simply have `yourRootElement.draw(kanvas: kanvas)`.
 
+## Measuring Text
+
+Layout code often needs to know how large text will be before it is drawn (for example, to reserve
+space for axis labels). Backends that can measure text implement the `MeasureText` capability, which
+returns primitive, single-line `TextMetrics` (width plus baseline-relative `ascent`/`descent`, and a
+`height` convenience). This mirrors the `IsPointInPath` capability: the platform `Kanvas`
+implementations that can measure text also implement `MeasureText`, and standalone implementations
+exist for use where a `Kanvas` is not available (such as chart layout code). Line wrapping is not
+performed.
+
+```kotlin
+val paint = Paint.Text(black, size = 14f, Paint.Text.Alignment.Left, Font(sansSerif))
+
+// From any Kanvas that supports measurement (Android, HTML, Core Graphics, Compose):
+val metrics = (kanvas as MeasureText).measureText("Hello", paint)
+
+// Or, during layout, from a standalone measurer (no Kanvas required):
+val measurer: MeasureText = AndroidTextMeasurement(context) // HtmlTextMeasurement() / CoreTextMeasurement
+val width = measurer.measureText("Hello", paint).width
+```
+
 [badge-android]: http://img.shields.io/badge/platform-android-6EDB8D.svg?style=flat
 [badge-ios]: http://img.shields.io/badge/platform-ios-CDCDCD.svg?style=flat
 [badge-js]: http://img.shields.io/badge/platform-js-F8DB5D.svg?style=flat

--- a/kanvas/api/jvm/kanvas.api
+++ b/kanvas/api/jvm/kanvas.api
@@ -74,6 +74,10 @@ public final class com/juul/krayon/kanvas/KanvasKt {
 	public static final fun withTransform (Lcom/juul/krayon/kanvas/Kanvas;Lcom/juul/krayon/kanvas/Transform;Lkotlin/jvm/functions/Function1;)V
 }
 
+public abstract interface class com/juul/krayon/kanvas/MeasureText {
+	public abstract fun measureText (Ljava/lang/CharSequence;Lcom/juul/krayon/kanvas/Paint$Text;)Lcom/juul/krayon/kanvas/TextMetrics;
+}
+
 public abstract class com/juul/krayon/kanvas/Paint {
 }
 
@@ -346,6 +350,22 @@ public final class com/juul/krayon/kanvas/RelativePathBuilder$State {
 	public final fun getCloseToY ()F
 	public final fun getLastX ()F
 	public final fun getLastY ()F
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/juul/krayon/kanvas/TextMetrics {
+	public fun <init> (FFF)V
+	public final fun component1 ()F
+	public final fun component2 ()F
+	public final fun component3 ()F
+	public final fun copy (FFF)Lcom/juul/krayon/kanvas/TextMetrics;
+	public static synthetic fun copy$default (Lcom/juul/krayon/kanvas/TextMetrics;FFFILjava/lang/Object;)Lcom/juul/krayon/kanvas/TextMetrics;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAscent ()F
+	public final fun getDescent ()F
+	public final fun getHeight ()F
+	public final fun getWidth ()F
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/kanvas/api/kanvas.klib.api
+++ b/kanvas/api/kanvas.klib.api
@@ -7,6 +7,10 @@
 // - Show declarations: true
 
 // Library unique name: <com.juul.krayon:kanvas>
+abstract fun interface com.juul.krayon.kanvas/MeasureText { // com.juul.krayon.kanvas/MeasureText|null[0]
+    abstract fun measureText(kotlin/CharSequence, com.juul.krayon.kanvas/Paint.Text): com.juul.krayon.kanvas/TextMetrics // com.juul.krayon.kanvas/MeasureText.measureText|measureText(kotlin.CharSequence;com.juul.krayon.kanvas.Paint.Text){}[0]
+}
+
 abstract interface <#A: kotlin/Any> com.juul.krayon.kanvas/PathTypeMarker { // com.juul.krayon.kanvas/PathTypeMarker|null[0]
     abstract val builder // com.juul.krayon.kanvas/PathTypeMarker.builder|{}builder[0]
         abstract fun <get-builder>(): com.juul.krayon.kanvas/PathBuilder<#A> // com.juul.krayon.kanvas/PathTypeMarker.builder.<get-builder>|<get-builder>(){}[0]
@@ -170,6 +174,27 @@ final class com.juul.krayon.kanvas/Path { // com.juul.krayon.kanvas/Path|null[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.juul.krayon.kanvas/Path.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.juul.krayon.kanvas/Path.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.juul.krayon.kanvas/Path.toString|toString(){}[0]
+}
+
+final class com.juul.krayon.kanvas/TextMetrics { // com.juul.krayon.kanvas/TextMetrics|null[0]
+    constructor <init>(kotlin/Float, kotlin/Float, kotlin/Float) // com.juul.krayon.kanvas/TextMetrics.<init>|<init>(kotlin.Float;kotlin.Float;kotlin.Float){}[0]
+
+    final val ascent // com.juul.krayon.kanvas/TextMetrics.ascent|{}ascent[0]
+        final fun <get-ascent>(): kotlin/Float // com.juul.krayon.kanvas/TextMetrics.ascent.<get-ascent>|<get-ascent>(){}[0]
+    final val descent // com.juul.krayon.kanvas/TextMetrics.descent|{}descent[0]
+        final fun <get-descent>(): kotlin/Float // com.juul.krayon.kanvas/TextMetrics.descent.<get-descent>|<get-descent>(){}[0]
+    final val height // com.juul.krayon.kanvas/TextMetrics.height|{}height[0]
+        final fun <get-height>(): kotlin/Float // com.juul.krayon.kanvas/TextMetrics.height.<get-height>|<get-height>(){}[0]
+    final val width // com.juul.krayon.kanvas/TextMetrics.width|{}width[0]
+        final fun <get-width>(): kotlin/Float // com.juul.krayon.kanvas/TextMetrics.width.<get-width>|<get-width>(){}[0]
+
+    final fun component1(): kotlin/Float // com.juul.krayon.kanvas/TextMetrics.component1|component1(){}[0]
+    final fun component2(): kotlin/Float // com.juul.krayon.kanvas/TextMetrics.component2|component2(){}[0]
+    final fun component3(): kotlin/Float // com.juul.krayon.kanvas/TextMetrics.component3|component3(){}[0]
+    final fun copy(kotlin/Float = ..., kotlin/Float = ..., kotlin/Float = ...): com.juul.krayon.kanvas/TextMetrics // com.juul.krayon.kanvas/TextMetrics.copy|copy(kotlin.Float;kotlin.Float;kotlin.Float){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.juul.krayon.kanvas/TextMetrics.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.juul.krayon.kanvas/TextMetrics.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.juul.krayon.kanvas/TextMetrics.toString|toString(){}[0]
 }
 
 final value class com.juul.krayon.kanvas.svg/PathString { // com.juul.krayon.kanvas.svg/PathString|null[0]
@@ -584,7 +609,7 @@ final inline fun (com.juul.krayon.kanvas/Kanvas).com.juul.krayon.kanvas/withClip
 final inline fun (com.juul.krayon.kanvas/Kanvas).com.juul.krayon.kanvas/withTransform(com.juul.krayon.kanvas/Transform, kotlin/Function1<com.juul.krayon.kanvas/Kanvas, kotlin/Unit>) // com.juul.krayon.kanvas/withTransform|withTransform@com.juul.krayon.kanvas.Kanvas(com.juul.krayon.kanvas.Transform;kotlin.Function1<com.juul.krayon.kanvas.Kanvas,kotlin.Unit>){}[0]
 
 // Targets: [apple]
-final class com.juul.krayon.kanvas/CGContextKanvas : com.juul.krayon.kanvas/Kanvas { // com.juul.krayon.kanvas/CGContextKanvas|null[0]
+final class com.juul.krayon.kanvas/CGContextKanvas : com.juul.krayon.kanvas/Kanvas, com.juul.krayon.kanvas/MeasureText { // com.juul.krayon.kanvas/CGContextKanvas|null[0]
     constructor <init>(kotlinx.cinterop/CPointer<cnames.structs/CGContext>, kotlin/Double, kotlin/Double) // com.juul.krayon.kanvas/CGContextKanvas.<init>|<init>(kotlinx.cinterop.CPointer<cnames.structs.CGContext>;kotlin.Double;kotlin.Double){}[0]
     constructor <init>(kotlinx.cinterop/CPointerVarOf<kotlinx.cinterop/CPointer<cnames.structs/CGContext>>, kotlin/Double, kotlin/Double) // com.juul.krayon.kanvas/CGContextKanvas.<init>|<init>(kotlinx.cinterop.CPointerVarOf<kotlinx.cinterop.CPointer<cnames.structs.CGContext>>;kotlin.Double;kotlin.Double){}[0]
 
@@ -601,9 +626,15 @@ final class com.juul.krayon.kanvas/CGContextKanvas : com.juul.krayon.kanvas/Kanv
     final fun drawPath(com.juul.krayon.kanvas/Path, com.juul.krayon.kanvas/Paint) // com.juul.krayon.kanvas/CGContextKanvas.drawPath|drawPath(com.juul.krayon.kanvas.Path;com.juul.krayon.kanvas.Paint){}[0]
     final fun drawRect(kotlin/Float, kotlin/Float, kotlin/Float, kotlin/Float, com.juul.krayon.kanvas/Paint) // com.juul.krayon.kanvas/CGContextKanvas.drawRect|drawRect(kotlin.Float;kotlin.Float;kotlin.Float;kotlin.Float;com.juul.krayon.kanvas.Paint){}[0]
     final fun drawText(kotlin/CharSequence, kotlin/Float, kotlin/Float, com.juul.krayon.kanvas/Paint) // com.juul.krayon.kanvas/CGContextKanvas.drawText|drawText(kotlin.CharSequence;kotlin.Float;kotlin.Float;com.juul.krayon.kanvas.Paint){}[0]
+    final fun measureText(kotlin/CharSequence, com.juul.krayon.kanvas/Paint.Text): com.juul.krayon.kanvas/TextMetrics // com.juul.krayon.kanvas/CGContextKanvas.measureText|measureText(kotlin.CharSequence;com.juul.krayon.kanvas.Paint.Text){}[0]
     final fun pop() // com.juul.krayon.kanvas/CGContextKanvas.pop|pop(){}[0]
     final fun pushClip(com.juul.krayon.kanvas/Clip) // com.juul.krayon.kanvas/CGContextKanvas.pushClip|pushClip(com.juul.krayon.kanvas.Clip){}[0]
     final fun pushTransform(com.juul.krayon.kanvas/Transform) // com.juul.krayon.kanvas/CGContextKanvas.pushTransform|pushTransform(com.juul.krayon.kanvas.Transform){}[0]
+}
+
+// Targets: [apple]
+final object com.juul.krayon.kanvas/CoreTextMeasurement : com.juul.krayon.kanvas/MeasureText { // com.juul.krayon.kanvas/CoreTextMeasurement|null[0]
+    final fun measureText(kotlin/CharSequence, com.juul.krayon.kanvas/Paint.Text): com.juul.krayon.kanvas/TextMetrics // com.juul.krayon.kanvas/CoreTextMeasurement.measureText|measureText(kotlin.CharSequence;com.juul.krayon.kanvas.Paint.Text){}[0]
 }
 
 // Targets: [apple]
@@ -612,7 +643,7 @@ final object com.juul.krayon.kanvas/IsPointInCGPath : com.juul.krayon.kanvas/IsP
 }
 
 // Targets: [js]
-final class com.juul.krayon.kanvas/HtmlKanvas : com.juul.krayon.kanvas/IsPointInPath, com.juul.krayon.kanvas/Kanvas { // com.juul.krayon.kanvas/HtmlKanvas|null[0]
+final class com.juul.krayon.kanvas/HtmlKanvas : com.juul.krayon.kanvas/IsPointInPath, com.juul.krayon.kanvas/Kanvas, com.juul.krayon.kanvas/MeasureText { // com.juul.krayon.kanvas/HtmlKanvas|null[0]
     constructor <init>(org.w3c.dom/HTMLCanvasElement, kotlin/Float = ...) // com.juul.krayon.kanvas/HtmlKanvas.<init>|<init>(org.w3c.dom.HTMLCanvasElement;kotlin.Float){}[0]
 
     final val context // com.juul.krayon.kanvas/HtmlKanvas.context|{}context[0]
@@ -631,9 +662,17 @@ final class com.juul.krayon.kanvas/HtmlKanvas : com.juul.krayon.kanvas/IsPointIn
     final fun drawRect(kotlin/Float, kotlin/Float, kotlin/Float, kotlin/Float, com.juul.krayon.kanvas/Paint) // com.juul.krayon.kanvas/HtmlKanvas.drawRect|drawRect(kotlin.Float;kotlin.Float;kotlin.Float;kotlin.Float;com.juul.krayon.kanvas.Paint){}[0]
     final fun drawText(kotlin/CharSequence, kotlin/Float, kotlin/Float, com.juul.krayon.kanvas/Paint) // com.juul.krayon.kanvas/HtmlKanvas.drawText|drawText(kotlin.CharSequence;kotlin.Float;kotlin.Float;com.juul.krayon.kanvas.Paint){}[0]
     final fun isPointInPath(com.juul.krayon.kanvas/Transform, com.juul.krayon.kanvas/Path, kotlin/Float, kotlin/Float): kotlin/Boolean // com.juul.krayon.kanvas/HtmlKanvas.isPointInPath|isPointInPath(com.juul.krayon.kanvas.Transform;com.juul.krayon.kanvas.Path;kotlin.Float;kotlin.Float){}[0]
+    final fun measureText(kotlin/CharSequence, com.juul.krayon.kanvas/Paint.Text): com.juul.krayon.kanvas/TextMetrics // com.juul.krayon.kanvas/HtmlKanvas.measureText|measureText(kotlin.CharSequence;com.juul.krayon.kanvas.Paint.Text){}[0]
     final fun pop() // com.juul.krayon.kanvas/HtmlKanvas.pop|pop(){}[0]
     final fun pushClip(com.juul.krayon.kanvas/Clip) // com.juul.krayon.kanvas/HtmlKanvas.pushClip|pushClip(com.juul.krayon.kanvas.Clip){}[0]
     final fun pushTransform(com.juul.krayon.kanvas/Transform) // com.juul.krayon.kanvas/HtmlKanvas.pushTransform|pushTransform(com.juul.krayon.kanvas.Transform){}[0]
+}
+
+// Targets: [js]
+final class com.juul.krayon.kanvas/HtmlTextMeasurement : com.juul.krayon.kanvas/MeasureText { // com.juul.krayon.kanvas/HtmlTextMeasurement|null[0]
+    constructor <init>() // com.juul.krayon.kanvas/HtmlTextMeasurement.<init>|<init>(){}[0]
+
+    final fun measureText(kotlin/CharSequence, com.juul.krayon.kanvas/Paint.Text): com.juul.krayon.kanvas/TextMetrics // com.juul.krayon.kanvas/HtmlTextMeasurement.measureText|measureText(kotlin.CharSequence;com.juul.krayon.kanvas.Paint.Text){}[0]
 }
 
 // Targets: [js]

--- a/kanvas/src/androidHostTest/kotlin/AndroidTextMeasurementTests.kt
+++ b/kanvas/src/androidHostTest/kotlin/AndroidTextMeasurementTests.kt
@@ -1,0 +1,49 @@
+package com.juul.krayon.kanvas
+
+import androidx.test.core.app.ApplicationProvider
+import com.juul.krayon.color.black
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@RunWith(RobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(manifest = Config.NONE, sdk = [35])
+class AndroidTextMeasurementTests {
+
+    private val measurement = AndroidTextMeasurement(ApplicationProvider.getApplicationContext())
+    private val paint = Paint.Text(black, size = 24f, Paint.Text.Alignment.Left, Font(sansSerif))
+
+    @Test
+    fun emptyString_hasZeroWidth() {
+        assertEquals(0f, measurement.measureText("", paint).width)
+    }
+
+    @Test
+    fun nonEmptyString_hasPositiveSize() {
+        val metrics = measurement.measureText("Hello", paint)
+        assertTrue(metrics.width > 0f, "expected positive width, was ${metrics.width}")
+        assertTrue(metrics.ascent > 0f, "expected positive ascent, was ${metrics.ascent}")
+        assertTrue(metrics.descent > 0f, "expected positive descent, was ${metrics.descent}")
+        assertEquals(metrics.ascent + metrics.descent, metrics.height)
+    }
+
+    @Test
+    fun longerString_isWider() {
+        val short = measurement.measureText("i", paint).width
+        val long = measurement.measureText("iiiiiiiiii", paint).width
+        assertTrue(long > short, "expected '$long' > '$short'")
+    }
+
+    @Test
+    fun verticalMetrics_areIndependentOfText() {
+        val a = measurement.measureText("a", paint)
+        val b = measurement.measureText("longer text", paint)
+        assertEquals(a.ascent, b.ascent)
+        assertEquals(a.descent, b.descent)
+    }
+}

--- a/kanvas/src/androidMain/kotlin/AndroidKanvas.kt
+++ b/kanvas/src/androidMain/kotlin/AndroidKanvas.kt
@@ -25,7 +25,9 @@ public class AndroidKanvas internal constructor(
     private var canvas: Canvas?,
     private val scalingFactor: Float = 1f,
     private val paintCache: PaintCache = PaintCache(context),
-) : Kanvas {
+) : Kanvas, MeasureText {
+
+    private val textMeasurement = AndroidTextMeasurement(context, paintCache)
 
     private val preTransform = Transform.Scale(horizontal = scalingFactor, vertical = scalingFactor)
 
@@ -111,6 +113,9 @@ public class AndroidKanvas internal constructor(
         require(paint is Paint.Text)
         withPaint(paint) { drawText(text, 0, text.length, x, y, it) }
     }
+
+    override fun measureText(text: CharSequence, paint: Paint.Text): TextMetrics =
+        textMeasurement.measureText(text, paint)
 
     @Suppress("DEPRECATION")
     override fun pushClip(clip: Clip) {

--- a/kanvas/src/androidMain/kotlin/AndroidTextMeasurement.kt
+++ b/kanvas/src/androidMain/kotlin/AndroidTextMeasurement.kt
@@ -1,0 +1,27 @@
+package com.juul.krayon.kanvas
+
+import android.content.Context
+
+/**
+ * Standalone [MeasureText] implementation backed by Android's native text rendering. Useful for
+ * measuring text during layout, when an [AndroidKanvas] is not available.
+ *
+ * Reuses [PaintCache] so that measurements account for the same font, size, and user font-scaling
+ * that [AndroidKanvas] applies when drawing.
+ */
+public class AndroidTextMeasurement(
+    context: Context,
+    private val paintCache: PaintCache = PaintCache(context),
+) : MeasureText {
+
+    override fun measureText(text: CharSequence, paint: Paint.Text): TextMetrics {
+        val nativePaint = paintCache[paint]
+        val width = nativePaint.measureText(text, 0, text.length)
+        val fontMetrics = nativePaint.fontMetrics
+        return TextMetrics(
+            width = width,
+            ascent = -fontMetrics.ascent,
+            descent = fontMetrics.descent,
+        )
+    }
+}

--- a/kanvas/src/appleMain/kotlin/CGContextKanvas.kt
+++ b/kanvas/src/appleMain/kotlin/CGContextKanvas.kt
@@ -23,7 +23,7 @@ public class CGContextKanvas(
     private val unmanagedContext: CGContextRef,
     width: Double,
     height: Double,
-) : Kanvas {
+) : Kanvas, MeasureText {
 
     /** When calling from Swift, use `&yourCgContext`. */
     public constructor(
@@ -94,6 +94,9 @@ public class CGContextKanvas(
         // Manually adjust by doing `height - y` and calling it a day.
         drawText(unmanagedContext, text.toString(), x.toDouble(), (height - y).toDouble(), paint)
     }
+
+    override fun measureText(text: CharSequence, paint: Paint.Text): TextMetrics =
+        CoreTextMeasurement.measureText(text, paint)
 
     override fun pushClip(clip: Clip) {
         CGContextSaveGState(unmanagedContext)

--- a/kanvas/src/appleMain/kotlin/CoreTextMeasurement.kt
+++ b/kanvas/src/appleMain/kotlin/CoreTextMeasurement.kt
@@ -1,0 +1,37 @@
+package com.juul.krayon.kanvas
+
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.value
+import platform.CoreFoundation.CFRelease
+import platform.CoreGraphics.CGFloatVar
+import platform.CoreText.CTLineCreateWithAttributedString
+import platform.CoreText.CTLineGetTypographicBounds
+import platform.CoreText.kCTFontAttributeName
+
+/**
+ * Standalone [MeasureText] implementation backed by Core Text. Useful for measuring text during
+ * layout, when a [CGContextKanvas] is not available.
+ */
+public object CoreTextMeasurement : MeasureText {
+
+    override fun measureText(text: CharSequence, paint: Paint.Text): TextMetrics {
+        val line = withCFAttributedString(text.toString()) { attributedString ->
+            attributedString[kCTFontAttributeName] = paint.ctFont
+            CTLineCreateWithAttributedString(attributedString)
+        }
+        return memScoped {
+            val ascent = alloc<CGFloatVar>()
+            val descent = alloc<CGFloatVar>()
+            val leading = alloc<CGFloatVar>()
+            val width = CTLineGetTypographicBounds(line, ascent.ptr, descent.ptr, leading.ptr)
+            CFRelease(line)
+            TextMetrics(
+                width = width.toFloat(),
+                ascent = ascent.value.toFloat(),
+                descent = descent.value.toFloat(),
+            )
+        }
+    }
+}

--- a/kanvas/src/appleMain/kotlin/Text.kt
+++ b/kanvas/src/appleMain/kotlin/Text.kt
@@ -35,7 +35,7 @@ internal fun drawText(context: CGContextRef, text: String, x: Double, y: Double,
     CFRelease(line)
 }
 
-private val Paint.Text.ctFont: CTFontRef
+internal val Paint.Text.ctFont: CTFontRef
     get() = font.names.asSequence()
         .map { name -> FontCache[name, size] }
         .filterNotNull()

--- a/kanvas/src/appleTest/kotlin/CoreTextMeasurementTests.kt
+++ b/kanvas/src/appleTest/kotlin/CoreTextMeasurementTests.kt
@@ -1,0 +1,40 @@
+package com.juul.krayon.kanvas
+
+import com.juul.krayon.color.black
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class CoreTextMeasurementTests {
+
+    private val paint = Paint.Text(black, size = 24f, Paint.Text.Alignment.Left, Font(sansSerif))
+
+    @Test
+    fun emptyString_hasZeroWidth() {
+        assertEquals(0f, CoreTextMeasurement.measureText("", paint).width)
+    }
+
+    @Test
+    fun nonEmptyString_hasPositiveSize() {
+        val metrics = CoreTextMeasurement.measureText("Hello", paint)
+        assertTrue(metrics.width > 0f, "expected positive width, was ${metrics.width}")
+        assertTrue(metrics.ascent > 0f, "expected positive ascent, was ${metrics.ascent}")
+        assertTrue(metrics.descent > 0f, "expected positive descent, was ${metrics.descent}")
+        assertEquals(metrics.ascent + metrics.descent, metrics.height)
+    }
+
+    @Test
+    fun longerString_isWider() {
+        val short = CoreTextMeasurement.measureText("i", paint).width
+        val long = CoreTextMeasurement.measureText("iiiiiiiiii", paint).width
+        assertTrue(long > short, "expected '$long' > '$short'")
+    }
+
+    @Test
+    fun verticalMetrics_areIndependentOfText() {
+        val a = CoreTextMeasurement.measureText("a", paint)
+        val b = CoreTextMeasurement.measureText("longer text", paint)
+        assertEquals(a.ascent, b.ascent)
+        assertEquals(a.descent, b.descent)
+    }
+}

--- a/kanvas/src/commonMain/kotlin/MeasureText.kt
+++ b/kanvas/src/commonMain/kotlin/MeasureText.kt
@@ -1,0 +1,19 @@
+package com.juul.krayon.kanvas
+
+/**
+ * Capability for measuring text without drawing it, enabling layout that is aware of how large text
+ * will be.
+ *
+ * This mirrors [IsPointInPath]: rendering backends that are able to measure text implement this
+ * interface (for example, the platform [Kanvas] implementations), and standalone implementations
+ * exist for use where a [Kanvas] is not available, such as chart layout code. Backends that have no
+ * font engine, like [com.juul.krayon.kanvas.svg.SvgKanvas], do not support measurement.
+ */
+public fun interface MeasureText {
+
+    /**
+     * Measures [text] as it would be drawn with [paint]. See [TextMetrics] for the meaning and units
+     * of the returned values.
+     */
+    public fun measureText(text: CharSequence, paint: Paint.Text): TextMetrics
+}

--- a/kanvas/src/commonMain/kotlin/TextMetrics.kt
+++ b/kanvas/src/commonMain/kotlin/TextMetrics.kt
@@ -1,0 +1,20 @@
+package com.juul.krayon.kanvas
+
+/**
+ * The measured size of a string for a given [Paint.Text].
+ *
+ * All values use the same units as the [Paint.Text.size] passed to measurement, which are the same
+ * units used when drawing. This is a primitive, single-line measurement: no line wrapping is
+ * performed and newline characters are not treated specially.
+ */
+public data class TextMetrics(
+    /** Horizontal advance width of the text. */
+    public val width: Float,
+    /** Distance from the text baseline to the top of the text, measured upward (non-negative). */
+    public val ascent: Float,
+    /** Distance from the text baseline to the bottom of the text, measured downward (non-negative). */
+    public val descent: Float,
+) {
+    /** Total vertical extent of the text, equal to [ascent] + [descent]. */
+    public val height: Float get() = ascent + descent
+}

--- a/kanvas/src/commonTest/kotlin/MeasureTextTests.kt
+++ b/kanvas/src/commonTest/kotlin/MeasureTextTests.kt
@@ -1,0 +1,34 @@
+package com.juul.krayon.kanvas
+
+import com.juul.krayon.color.black
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class MeasureTextTests {
+
+    private val paint = Paint.Text(black, size = 12f, Paint.Text.Alignment.Left, Font(sansSerif))
+
+    @Test
+    fun height_isSumOfAscentAndDescent() {
+        val metrics = TextMetrics(width = 40f, ascent = 9f, descent = 3f)
+        assertEquals(12f, metrics.height)
+    }
+
+    @Test
+    fun measureText_funInterface_isInvokedWithArguments() {
+        var seenText: CharSequence? = null
+        var seenPaint: Paint.Text? = null
+        val measurer = MeasureText { text, textPaint ->
+            seenText = text
+            seenPaint = textPaint
+            TextMetrics(width = text.length.toFloat(), ascent = 1f, descent = 1f)
+        }
+
+        val result = measurer.measureText("hello", paint)
+
+        assertEquals("hello", seenText)
+        assertEquals(paint, seenPaint)
+        assertEquals(5f, result.width)
+        assertEquals(2f, result.height)
+    }
+}

--- a/kanvas/src/jsMain/kotlin/HtmlKanvas.kt
+++ b/kanvas/src/jsMain/kotlin/HtmlKanvas.kt
@@ -16,15 +16,15 @@ import org.w3c.dom.ROUND
 import org.w3c.dom.SQUARE
 import kotlin.math.PI
 
-private val WHITESPACE = Regex("\\s")
-
 public class HtmlKanvas(
     element: HTMLCanvasElement,
     private val scalingFactor: Float = 1f,
-) : Kanvas, IsPointInPath {
+) : Kanvas, IsPointInPath, MeasureText {
 
     /** The raw HTMLCanvas's 2d rendering context. */
     public val context: CanvasRenderingContext2D = element.getContext("2d") as CanvasRenderingContext2D
+
+    private val textMeasurement = HtmlTextMeasurement()
 
     override val width: Float
         get() = context.canvas.width / scalingFactor
@@ -110,6 +110,9 @@ public class HtmlKanvas(
         applyStyle(paint)
         context.fillText(text.toString(), x.toDouble(), y.toDouble())
     }
+
+    override fun measureText(text: CharSequence, paint: Paint.Text): TextMetrics =
+        textMeasurement.measureText(text, paint)
 
     override fun pushClip(clip: Clip) {
         context.save()
@@ -269,11 +272,7 @@ public class HtmlKanvas(
             Paint.Text.Alignment.Center -> CanvasTextAlign.CENTER
             Paint.Text.Alignment.Right -> CanvasTextAlign.RIGHT
         }
-        val size = "${paint.size}px"
-        val name = paint.font.names.joinToString { font ->
-            if (WHITESPACE in font) "\"$font\"" else font
-        }
-        context.font = "$size $name"
+        context.font = paint.cssFont()
     }
 
     override fun isPointInPath(transform: Transform, path: Path, x: Float, y: Float): Boolean {

--- a/kanvas/src/jsMain/kotlin/HtmlTextMeasurement.kt
+++ b/kanvas/src/jsMain/kotlin/HtmlTextMeasurement.kt
@@ -1,0 +1,42 @@
+package com.juul.krayon.kanvas
+
+import kotlinx.browser.document
+import org.w3c.dom.CanvasRenderingContext2D
+import org.w3c.dom.HTMLCanvasElement
+
+private val WHITESPACE = Regex("\\s")
+
+/** The CSS `font` shorthand string that draws/measures this [Paint.Text]. */
+internal fun Paint.Text.cssFont(): String {
+    val size = "${size}px"
+    val name = font.names.joinToString { family ->
+        if (WHITESPACE in family) "\"$family\"" else family
+    }
+    return "$size $name"
+}
+
+/**
+ * Standalone [MeasureText] implementation backed by an offscreen HTML canvas. Useful for measuring
+ * text during layout, when an [HtmlKanvas] is not available.
+ *
+ * A dedicated offscreen rendering context is used so that measurement never mutates the state of any
+ * canvas being drawn to.
+ */
+public class HtmlTextMeasurement : MeasureText {
+
+    private val context: CanvasRenderingContext2D =
+        (document.createElement("canvas") as HTMLCanvasElement).getContext("2d") as CanvasRenderingContext2D
+
+    override fun measureText(text: CharSequence, paint: Paint.Text): TextMetrics {
+        context.font = paint.cssFont()
+        val metrics = context.measureText(text.toString())
+        val dynamic = metrics.asDynamic()
+        val ascent = (dynamic.fontBoundingBoxAscent ?: dynamic.actualBoundingBoxAscent ?: 0.0) as Double
+        val descent = (dynamic.fontBoundingBoxDescent ?: dynamic.actualBoundingBoxDescent ?: 0.0) as Double
+        return TextMetrics(
+            width = metrics.width.toFloat(),
+            ascent = ascent.toFloat(),
+            descent = descent.toFloat(),
+        )
+    }
+}

--- a/kanvas/src/jsTest/kotlin/HtmlTextMeasurementTests.kt
+++ b/kanvas/src/jsTest/kotlin/HtmlTextMeasurementTests.kt
@@ -1,0 +1,31 @@
+package com.juul.krayon.kanvas
+
+import com.juul.krayon.color.black
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class HtmlTextMeasurementTests {
+
+    private val measurement = HtmlTextMeasurement()
+    private val paint = Paint.Text(black, size = 24f, Paint.Text.Alignment.Left, Font(sansSerif))
+
+    @Test
+    fun emptyString_hasZeroWidth() {
+        assertEquals(0f, measurement.measureText("", paint).width)
+    }
+
+    @Test
+    fun nonEmptyString_hasPositiveWidth() {
+        val metrics = measurement.measureText("Hello", paint)
+        assertTrue(metrics.width > 0f, "expected positive width, was ${metrics.width}")
+        assertTrue(metrics.height >= 0f, "expected non-negative height, was ${metrics.height}")
+    }
+
+    @Test
+    fun longerString_isWider() {
+        val short = measurement.measureText("i", paint).width
+        val long = measurement.measureText("iiiiiiiiii", paint).width
+        assertTrue(long > short, "expected '$long' > '$short'")
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Krayon could draw text (`Kanvas.drawText`) but couldn't measure it, so layout code had no way to reserve space for labels ahead of time. This adds a **primitive, single-line** text-measurement API. Line wrapping is an explicit non-goal.

The design mirrors the existing `IsPointInPath` optional-capability paradigm:

- **`kanvas` common:**
  - `TextMetrics(width, ascent, descent)` with a `height` convenience. `ascent`/`descent` are baseline-relative (positive-up) font metrics; `width` is the string's advance.
  - `fun interface MeasureText { fun measureText(text: CharSequence, paint: Paint.Text): TextMetrics }`.
- **Concrete backends implement `MeasureText`:** `AndroidKanvas`, `HtmlKanvas`, `CGContextKanvas`, and `ComposeKanvas`. `SvgKanvas` deliberately does **not** (it has no font engine — same reason it doesn't implement `IsPointInPath`). The test `CallRecordingKanvas` is untouched since the capability is a separate interface.
- **Standalone measurers for layout-without-a-`Kanvas`** (chart code runs layout in `UpdateElement.update(...)` with no `Kanvas`, exactly like interaction uses standalone `IsPointInPath`s):
  - `AndroidTextMeasurement(context)`, `object CoreTextMeasurement` (Core Text), `HtmlTextMeasurement()` (offscreen canvas), and Compose's public `textMeasurement()` factory.
  - The platform `Kanvas` classes delegate to these to avoid duplicated font resolution.

Each implementation reuses the exact font resolution already used for drawing, so measurements match what gets rendered.

## Usage

```kotlin
val paint = Paint.Text(black, size = 14f, Paint.Text.Alignment.Left, Font(sansSerif))

// From a measuring Kanvas:
val metrics = (kanvas as MeasureText).measureText("Hello", paint)

// Or, during chart layout, from a standalone measurer (no Kanvas needed):
val measurer: MeasureText = AndroidTextMeasurement(context) // or HtmlTextMeasurement() / CoreTextMeasurement / compose textMeasurement()
val width = measurer.measureText("Hello", paint).width
```

## Testing

Per-platform tests cover every measurement implementation:

| Platform | Test | Where it runs |
|---|---|---|
| kanvas common | `MeasureTextTests` | every target |
| kanvas Android | `AndroidTextMeasurementTests` (Robolectric, native graphics) | JVM/CI |
| kanvas JS | `HtmlTextMeasurementTests` | ChromeHeadless (`jsBrowserTest`) |
| kanvas Apple | `CoreTextMeasurementTests` (`appleTest`) | macOS CI |
| compose skia | `SkiaMeasureTextTests` (via `textMeasurement()`) | JVM/CI |
| compose Android | `AndroidMeasureTextTests` (Robolectric, native graphics) | JVM/CI |

Each asserts real behavior: empty string → 0 width, non-empty → positive width/ascent/descent, longer strings measure wider, and vertical metrics are independent of the text.

Also verified: compiles on **all** targets (jvm, android, js, wasmJs, Apple macos/ios); `./gradlew apiCheck` (full project) and `lintKotlin` pass; API dumps regenerated for `kanvas` and `compose`.

## Notes / out of scope

- No line wrapping (explicit non-goal).
- `ContinuousAxis` is intentionally left behavior-stable; this API makes label auto-sizing *possible* as a follow-up.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e21d654a-4e14-4fbf-bd46-dfdbe8b81c67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e21d654a-4e14-4fbf-bd46-dfdbe8b81c67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

