### PR TITLE
shape: expand d3-shape port (curves, stack, symbols)

### DIFF
--- a/shape/api/jvm/shape.api
+++ b/shape/api/jvm/shape.api
@@ -90,6 +90,46 @@ public final class com/juul/krayon/shape/Point {
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class com/juul/krayon/shape/Series : java/util/List, kotlin/jvm/internal/markers/KMappedMarker {
+	public fun add (ILcom/juul/krayon/shape/StackPoint;)V
+	public synthetic fun add (ILjava/lang/Object;)V
+	public fun add (Lcom/juul/krayon/shape/StackPoint;)Z
+	public synthetic fun add (Ljava/lang/Object;)Z
+	public fun addAll (ILjava/util/Collection;)Z
+	public fun addAll (Ljava/util/Collection;)Z
+	public fun clear ()V
+	public fun contains (Lcom/juul/krayon/shape/StackPoint;)Z
+	public final fun contains (Ljava/lang/Object;)Z
+	public fun containsAll (Ljava/util/Collection;)Z
+	public fun get (I)Lcom/juul/krayon/shape/StackPoint;
+	public synthetic fun get (I)Ljava/lang/Object;
+	public final fun getIndex ()I
+	public final fun getKey ()Ljava/lang/Object;
+	public fun getSize ()I
+	public fun indexOf (Lcom/juul/krayon/shape/StackPoint;)I
+	public final fun indexOf (Ljava/lang/Object;)I
+	public fun isEmpty ()Z
+	public fun iterator ()Ljava/util/Iterator;
+	public fun lastIndexOf (Lcom/juul/krayon/shape/StackPoint;)I
+	public final fun lastIndexOf (Ljava/lang/Object;)I
+	public fun listIterator ()Ljava/util/ListIterator;
+	public fun listIterator (I)Ljava/util/ListIterator;
+	public fun remove (I)Lcom/juul/krayon/shape/StackPoint;
+	public synthetic fun remove (I)Ljava/lang/Object;
+	public fun remove (Ljava/lang/Object;)Z
+	public fun removeAll (Ljava/util/Collection;)Z
+	public fun replaceAll (Ljava/util/function/UnaryOperator;)V
+	public fun retainAll (Ljava/util/Collection;)Z
+	public fun set (ILcom/juul/krayon/shape/StackPoint;)Lcom/juul/krayon/shape/StackPoint;
+	public synthetic fun set (ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun size ()I
+	public fun sort (Ljava/util/Comparator;)V
+	public fun subList (II)Ljava/util/List;
+	public fun toArray ()[Ljava/lang/Object;
+	public fun toArray ([Ljava/lang/Object;)[Ljava/lang/Object;
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class com/juul/krayon/shape/Slice {
 	public fun <init> (Ljava/lang/Object;FIFFF)V
 	public final fun component1 ()Ljava/lang/Object;
@@ -108,6 +148,90 @@ public final class com/juul/krayon/shape/Slice {
 	public final fun getStartAngle ()F
 	public final fun getValue ()F
 	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/juul/krayon/shape/Stack {
+	public final fun invoke (Ljava/util/List;)Ljava/util/List;
+	public final fun keys (Ljava/util/List;)Lcom/juul/krayon/shape/Stack;
+	public final fun offset (Lcom/juul/krayon/shape/StackOffset;)Lcom/juul/krayon/shape/Stack;
+	public final fun order (Lcom/juul/krayon/shape/StackOrder;)Lcom/juul/krayon/shape/Stack;
+	public final fun value (Lkotlin/jvm/functions/Function2;)Lcom/juul/krayon/shape/Stack;
+}
+
+public final class com/juul/krayon/shape/StackKt {
+	public static final fun stack ()Lcom/juul/krayon/shape/Stack;
+}
+
+public abstract interface class com/juul/krayon/shape/StackOffset {
+	public abstract fun invoke (Ljava/util/List;[I)V
+}
+
+public final class com/juul/krayon/shape/StackOffsetDiverging : com/juul/krayon/shape/StackOffset {
+	public static final field INSTANCE Lcom/juul/krayon/shape/StackOffsetDiverging;
+	public fun invoke (Ljava/util/List;[I)V
+}
+
+public final class com/juul/krayon/shape/StackOffsetExpand : com/juul/krayon/shape/StackOffset {
+	public static final field INSTANCE Lcom/juul/krayon/shape/StackOffsetExpand;
+	public fun invoke (Ljava/util/List;[I)V
+}
+
+public final class com/juul/krayon/shape/StackOffsetNone : com/juul/krayon/shape/StackOffset {
+	public static final field INSTANCE Lcom/juul/krayon/shape/StackOffsetNone;
+	public fun invoke (Ljava/util/List;[I)V
+}
+
+public final class com/juul/krayon/shape/StackOffsetSilhouette : com/juul/krayon/shape/StackOffset {
+	public static final field INSTANCE Lcom/juul/krayon/shape/StackOffsetSilhouette;
+	public fun invoke (Ljava/util/List;[I)V
+}
+
+public final class com/juul/krayon/shape/StackOffsetWiggle : com/juul/krayon/shape/StackOffset {
+	public static final field INSTANCE Lcom/juul/krayon/shape/StackOffsetWiggle;
+	public fun invoke (Ljava/util/List;[I)V
+}
+
+public abstract interface class com/juul/krayon/shape/StackOrder {
+	public abstract fun invoke (Ljava/util/List;)[I
+}
+
+public final class com/juul/krayon/shape/StackOrderAppearance : com/juul/krayon/shape/StackOrder {
+	public static final field INSTANCE Lcom/juul/krayon/shape/StackOrderAppearance;
+	public fun invoke (Ljava/util/List;)[I
+}
+
+public final class com/juul/krayon/shape/StackOrderAscending : com/juul/krayon/shape/StackOrder {
+	public static final field INSTANCE Lcom/juul/krayon/shape/StackOrderAscending;
+	public fun invoke (Ljava/util/List;)[I
+}
+
+public final class com/juul/krayon/shape/StackOrderDescending : com/juul/krayon/shape/StackOrder {
+	public static final field INSTANCE Lcom/juul/krayon/shape/StackOrderDescending;
+	public fun invoke (Ljava/util/List;)[I
+}
+
+public final class com/juul/krayon/shape/StackOrderInsideOut : com/juul/krayon/shape/StackOrder {
+	public static final field INSTANCE Lcom/juul/krayon/shape/StackOrderInsideOut;
+	public fun invoke (Ljava/util/List;)[I
+}
+
+public final class com/juul/krayon/shape/StackOrderNone : com/juul/krayon/shape/StackOrder {
+	public static final field INSTANCE Lcom/juul/krayon/shape/StackOrderNone;
+	public fun invoke (Ljava/util/List;)[I
+}
+
+public final class com/juul/krayon/shape/StackOrderReverse : com/juul/krayon/shape/StackOrder {
+	public static final field INSTANCE Lcom/juul/krayon/shape/StackOrderReverse;
+	public fun invoke (Ljava/util/List;)[I
+}
+
+public final class com/juul/krayon/shape/StackPoint {
+	public final fun getData ()Ljava/lang/Object;
+	public final fun getHigh ()F
+	public final fun getLow ()F
+	public final fun setHigh (F)V
+	public final fun setLow (F)V
 	public fun toString ()Ljava/lang/String;
 }
 

--- a/shape/api/jvm/shape.api
+++ b/shape/api/jvm/shape.api
@@ -111,6 +111,117 @@ public final class com/juul/krayon/shape/Slice {
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class com/juul/krayon/shape/curve/Basis : com/juul/krayon/shape/curve/Curve {
+	public static final field INSTANCE Lcom/juul/krayon/shape/curve/Basis;
+	public fun endArea (Lcom/juul/krayon/kanvas/PathBuilder;)V
+	public fun endLine (Lcom/juul/krayon/kanvas/PathBuilder;)V
+	public fun point (Lcom/juul/krayon/kanvas/PathBuilder;FF)V
+	public fun startArea (Lcom/juul/krayon/kanvas/PathBuilder;)V
+	public fun startLine (Lcom/juul/krayon/kanvas/PathBuilder;)V
+}
+
+public final class com/juul/krayon/shape/curve/BasisClosed : com/juul/krayon/shape/curve/Curve {
+	public static final field INSTANCE Lcom/juul/krayon/shape/curve/BasisClosed;
+	public fun endArea (Lcom/juul/krayon/kanvas/PathBuilder;)V
+	public fun endLine (Lcom/juul/krayon/kanvas/PathBuilder;)V
+	public fun point (Lcom/juul/krayon/kanvas/PathBuilder;FF)V
+	public fun startArea (Lcom/juul/krayon/kanvas/PathBuilder;)V
+	public fun startLine (Lcom/juul/krayon/kanvas/PathBuilder;)V
+}
+
+public final class com/juul/krayon/shape/curve/BasisOpen : com/juul/krayon/shape/curve/Curve {
+	public static final field INSTANCE Lcom/juul/krayon/shape/curve/BasisOpen;
+	public fun endArea (Lcom/juul/krayon/kanvas/PathBuilder;)V
+	public fun endLine (Lcom/juul/krayon/kanvas/PathBuilder;)V
+	public fun point (Lcom/juul/krayon/kanvas/PathBuilder;FF)V
+	public fun startArea (Lcom/juul/krayon/kanvas/PathBuilder;)V
+	public fun startLine (Lcom/juul/krayon/kanvas/PathBuilder;)V
+}
+
+public final class com/juul/krayon/shape/curve/BumpX : com/juul/krayon/shape/curve/Curve {
+	public static final field INSTANCE Lcom/juul/krayon/shape/curve/BumpX;
+	public fun endArea (Lcom/juul/krayon/kanvas/PathBuilder;)V
+	public fun endLine (Lcom/juul/krayon/kanvas/PathBuilder;)V
+	public fun point (Lcom/juul/krayon/kanvas/PathBuilder;FF)V
+	public fun startArea (Lcom/juul/krayon/kanvas/PathBuilder;)V
+	public fun startLine (Lcom/juul/krayon/kanvas/PathBuilder;)V
+}
+
+public final class com/juul/krayon/shape/curve/BumpY : com/juul/krayon/shape/curve/Curve {
+	public static final field INSTANCE Lcom/juul/krayon/shape/curve/BumpY;
+	public fun endArea (Lcom/juul/krayon/kanvas/PathBuilder;)V
+	public fun endLine (Lcom/juul/krayon/kanvas/PathBuilder;)V
+	public fun point (Lcom/juul/krayon/kanvas/PathBuilder;FF)V
+	public fun startArea (Lcom/juul/krayon/kanvas/PathBuilder;)V
+	public fun startLine (Lcom/juul/krayon/kanvas/PathBuilder;)V
+}
+
+public final class com/juul/krayon/shape/curve/Cardinal : com/juul/krayon/shape/curve/Curve {
+	public fun <init> ()V
+	public fun <init> (F)V
+	public synthetic fun <init> (FILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun endArea (Lcom/juul/krayon/kanvas/PathBuilder;)V
+	public fun endLine (Lcom/juul/krayon/kanvas/PathBuilder;)V
+	public fun point (Lcom/juul/krayon/kanvas/PathBuilder;FF)V
+	public fun startArea (Lcom/juul/krayon/kanvas/PathBuilder;)V
+	public fun startLine (Lcom/juul/krayon/kanvas/PathBuilder;)V
+}
+
+public final class com/juul/krayon/shape/curve/CardinalClosed : com/juul/krayon/shape/curve/Curve {
+	public fun <init> ()V
+	public fun <init> (F)V
+	public synthetic fun <init> (FILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun endArea (Lcom/juul/krayon/kanvas/PathBuilder;)V
+	public fun endLine (Lcom/juul/krayon/kanvas/PathBuilder;)V
+	public fun point (Lcom/juul/krayon/kanvas/PathBuilder;FF)V
+	public fun startArea (Lcom/juul/krayon/kanvas/PathBuilder;)V
+	public fun startLine (Lcom/juul/krayon/kanvas/PathBuilder;)V
+}
+
+public final class com/juul/krayon/shape/curve/CardinalOpen : com/juul/krayon/shape/curve/Curve {
+	public fun <init> ()V
+	public fun <init> (F)V
+	public synthetic fun <init> (FILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun endArea (Lcom/juul/krayon/kanvas/PathBuilder;)V
+	public fun endLine (Lcom/juul/krayon/kanvas/PathBuilder;)V
+	public fun point (Lcom/juul/krayon/kanvas/PathBuilder;FF)V
+	public fun startArea (Lcom/juul/krayon/kanvas/PathBuilder;)V
+	public fun startLine (Lcom/juul/krayon/kanvas/PathBuilder;)V
+}
+
+public final class com/juul/krayon/shape/curve/CatmullRom : com/juul/krayon/shape/curve/Curve {
+	public fun <init> ()V
+	public fun <init> (F)V
+	public synthetic fun <init> (FILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun endArea (Lcom/juul/krayon/kanvas/PathBuilder;)V
+	public fun endLine (Lcom/juul/krayon/kanvas/PathBuilder;)V
+	public fun point (Lcom/juul/krayon/kanvas/PathBuilder;FF)V
+	public fun startArea (Lcom/juul/krayon/kanvas/PathBuilder;)V
+	public fun startLine (Lcom/juul/krayon/kanvas/PathBuilder;)V
+}
+
+public final class com/juul/krayon/shape/curve/CatmullRomClosed : com/juul/krayon/shape/curve/Curve {
+	public fun <init> ()V
+	public fun <init> (F)V
+	public synthetic fun <init> (FILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun endArea (Lcom/juul/krayon/kanvas/PathBuilder;)V
+	public fun endLine (Lcom/juul/krayon/kanvas/PathBuilder;)V
+	public fun point (Lcom/juul/krayon/kanvas/PathBuilder;FF)V
+	public fun startArea (Lcom/juul/krayon/kanvas/PathBuilder;)V
+	public fun startLine (Lcom/juul/krayon/kanvas/PathBuilder;)V
+}
+
+public final class com/juul/krayon/shape/curve/CatmullRomOpen : com/juul/krayon/shape/curve/Curve {
+	public fun <init> ()V
+	public fun <init> (F)V
+	public synthetic fun <init> (FILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun endArea (Lcom/juul/krayon/kanvas/PathBuilder;)V
+	public fun endLine (Lcom/juul/krayon/kanvas/PathBuilder;)V
+	public fun point (Lcom/juul/krayon/kanvas/PathBuilder;FF)V
+	public fun startArea (Lcom/juul/krayon/kanvas/PathBuilder;)V
+	public fun startLine (Lcom/juul/krayon/kanvas/PathBuilder;)V
+}
+
 public abstract interface class com/juul/krayon/shape/curve/Curve {
 	public abstract fun endArea (Lcom/juul/krayon/kanvas/PathBuilder;)V
 	public abstract fun endLine (Lcom/juul/krayon/kanvas/PathBuilder;)V
@@ -121,6 +232,69 @@ public abstract interface class com/juul/krayon/shape/curve/Curve {
 
 public final class com/juul/krayon/shape/curve/Linear : com/juul/krayon/shape/curve/Curve {
 	public static final field INSTANCE Lcom/juul/krayon/shape/curve/Linear;
+	public fun endArea (Lcom/juul/krayon/kanvas/PathBuilder;)V
+	public fun endLine (Lcom/juul/krayon/kanvas/PathBuilder;)V
+	public fun point (Lcom/juul/krayon/kanvas/PathBuilder;FF)V
+	public fun startArea (Lcom/juul/krayon/kanvas/PathBuilder;)V
+	public fun startLine (Lcom/juul/krayon/kanvas/PathBuilder;)V
+}
+
+public final class com/juul/krayon/shape/curve/LinearClosed : com/juul/krayon/shape/curve/Curve {
+	public static final field INSTANCE Lcom/juul/krayon/shape/curve/LinearClosed;
+	public fun endArea (Lcom/juul/krayon/kanvas/PathBuilder;)V
+	public fun endLine (Lcom/juul/krayon/kanvas/PathBuilder;)V
+	public fun point (Lcom/juul/krayon/kanvas/PathBuilder;FF)V
+	public fun startArea (Lcom/juul/krayon/kanvas/PathBuilder;)V
+	public fun startLine (Lcom/juul/krayon/kanvas/PathBuilder;)V
+}
+
+public final class com/juul/krayon/shape/curve/MonotoneX : com/juul/krayon/shape/curve/Curve {
+	public static final field INSTANCE Lcom/juul/krayon/shape/curve/MonotoneX;
+	public fun endArea (Lcom/juul/krayon/kanvas/PathBuilder;)V
+	public fun endLine (Lcom/juul/krayon/kanvas/PathBuilder;)V
+	public fun point (Lcom/juul/krayon/kanvas/PathBuilder;FF)V
+	public fun startArea (Lcom/juul/krayon/kanvas/PathBuilder;)V
+	public fun startLine (Lcom/juul/krayon/kanvas/PathBuilder;)V
+}
+
+public final class com/juul/krayon/shape/curve/MonotoneY : com/juul/krayon/shape/curve/Curve {
+	public static final field INSTANCE Lcom/juul/krayon/shape/curve/MonotoneY;
+	public fun endArea (Lcom/juul/krayon/kanvas/PathBuilder;)V
+	public fun endLine (Lcom/juul/krayon/kanvas/PathBuilder;)V
+	public fun point (Lcom/juul/krayon/kanvas/PathBuilder;FF)V
+	public fun startArea (Lcom/juul/krayon/kanvas/PathBuilder;)V
+	public fun startLine (Lcom/juul/krayon/kanvas/PathBuilder;)V
+}
+
+public final class com/juul/krayon/shape/curve/Natural : com/juul/krayon/shape/curve/Curve {
+	public static final field INSTANCE Lcom/juul/krayon/shape/curve/Natural;
+	public fun endArea (Lcom/juul/krayon/kanvas/PathBuilder;)V
+	public fun endLine (Lcom/juul/krayon/kanvas/PathBuilder;)V
+	public fun point (Lcom/juul/krayon/kanvas/PathBuilder;FF)V
+	public fun startArea (Lcom/juul/krayon/kanvas/PathBuilder;)V
+	public fun startLine (Lcom/juul/krayon/kanvas/PathBuilder;)V
+}
+
+public final class com/juul/krayon/shape/curve/Step : com/juul/krayon/shape/curve/Curve {
+	public static final field INSTANCE Lcom/juul/krayon/shape/curve/Step;
+	public fun endArea (Lcom/juul/krayon/kanvas/PathBuilder;)V
+	public fun endLine (Lcom/juul/krayon/kanvas/PathBuilder;)V
+	public fun point (Lcom/juul/krayon/kanvas/PathBuilder;FF)V
+	public fun startArea (Lcom/juul/krayon/kanvas/PathBuilder;)V
+	public fun startLine (Lcom/juul/krayon/kanvas/PathBuilder;)V
+}
+
+public final class com/juul/krayon/shape/curve/StepAfter : com/juul/krayon/shape/curve/Curve {
+	public static final field INSTANCE Lcom/juul/krayon/shape/curve/StepAfter;
+	public fun endArea (Lcom/juul/krayon/kanvas/PathBuilder;)V
+	public fun endLine (Lcom/juul/krayon/kanvas/PathBuilder;)V
+	public fun point (Lcom/juul/krayon/kanvas/PathBuilder;FF)V
+	public fun startArea (Lcom/juul/krayon/kanvas/PathBuilder;)V
+	public fun startLine (Lcom/juul/krayon/kanvas/PathBuilder;)V
+}
+
+public final class com/juul/krayon/shape/curve/StepBefore : com/juul/krayon/shape/curve/Curve {
+	public static final field INSTANCE Lcom/juul/krayon/shape/curve/StepBefore;
 	public fun endArea (Lcom/juul/krayon/kanvas/PathBuilder;)V
 	public fun endLine (Lcom/juul/krayon/kanvas/PathBuilder;)V
 	public fun point (Lcom/juul/krayon/kanvas/PathBuilder;FF)V

--- a/shape/api/jvm/shape.api
+++ b/shape/api/jvm/shape.api
@@ -47,6 +47,26 @@ public final class com/juul/krayon/shape/Arguments {
 	public final fun getIndex ()I
 }
 
+public final class com/juul/krayon/shape/Asterisk : com/juul/krayon/shape/SymbolType {
+	public static final field INSTANCE Lcom/juul/krayon/shape/Asterisk;
+	public fun draw (Lcom/juul/krayon/kanvas/PathBuilder;F)V
+}
+
+public final class com/juul/krayon/shape/Circle : com/juul/krayon/shape/SymbolType {
+	public static final field INSTANCE Lcom/juul/krayon/shape/Circle;
+	public fun draw (Lcom/juul/krayon/kanvas/PathBuilder;F)V
+}
+
+public final class com/juul/krayon/shape/Cross : com/juul/krayon/shape/SymbolType {
+	public static final field INSTANCE Lcom/juul/krayon/shape/Cross;
+	public fun draw (Lcom/juul/krayon/kanvas/PathBuilder;F)V
+}
+
+public final class com/juul/krayon/shape/Diamond : com/juul/krayon/shape/SymbolType {
+	public static final field INSTANCE Lcom/juul/krayon/shape/Diamond;
+	public fun draw (Lcom/juul/krayon/kanvas/PathBuilder;F)V
+}
+
 public final class com/juul/krayon/shape/Line {
 	public final fun curve (Lcom/juul/krayon/shape/curve/Curve;)Lcom/juul/krayon/shape/Line;
 	public final fun defined (Lkotlin/jvm/functions/Function1;)Lcom/juul/krayon/shape/Line;
@@ -75,6 +95,11 @@ public final class com/juul/krayon/shape/Pie {
 
 public final class com/juul/krayon/shape/PieKt {
 	public static final fun pie ()Lcom/juul/krayon/shape/Pie;
+}
+
+public final class com/juul/krayon/shape/Plus : com/juul/krayon/shape/SymbolType {
+	public static final field INSTANCE Lcom/juul/krayon/shape/Plus;
+	public fun draw (Lcom/juul/krayon/kanvas/PathBuilder;F)V
 }
 
 public final class com/juul/krayon/shape/Point {
@@ -149,6 +174,11 @@ public final class com/juul/krayon/shape/Slice {
 	public final fun getValue ()F
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/juul/krayon/shape/Square : com/juul/krayon/shape/SymbolType {
+	public static final field INSTANCE Lcom/juul/krayon/shape/Square;
+	public fun draw (Lcom/juul/krayon/kanvas/PathBuilder;F)V
 }
 
 public final class com/juul/krayon/shape/Stack {
@@ -233,6 +263,50 @@ public final class com/juul/krayon/shape/StackPoint {
 	public final fun setHigh (F)V
 	public final fun setLow (F)V
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/juul/krayon/shape/Star : com/juul/krayon/shape/SymbolType {
+	public static final field INSTANCE Lcom/juul/krayon/shape/Star;
+	public fun draw (Lcom/juul/krayon/kanvas/PathBuilder;F)V
+}
+
+public final class com/juul/krayon/shape/Symbol {
+	public final fun render (Ljava/lang/Object;ILjava/util/List;)Lcom/juul/krayon/kanvas/Path;
+	public static synthetic fun render$default (Lcom/juul/krayon/shape/Symbol;Ljava/lang/Object;ILjava/util/List;ILjava/lang/Object;)Lcom/juul/krayon/kanvas/Path;
+	public final fun size (F)Lcom/juul/krayon/shape/Symbol;
+	public final fun size (Lkotlin/jvm/functions/Function1;)Lcom/juul/krayon/shape/Symbol;
+	public final fun type (Lcom/juul/krayon/shape/SymbolType;)Lcom/juul/krayon/shape/Symbol;
+	public final fun type (Lkotlin/jvm/functions/Function1;)Lcom/juul/krayon/shape/Symbol;
+}
+
+public final class com/juul/krayon/shape/SymbolKt {
+	public static final fun symbol ()Lcom/juul/krayon/shape/Symbol;
+}
+
+public abstract interface class com/juul/krayon/shape/SymbolType {
+	public abstract fun draw (Lcom/juul/krayon/kanvas/PathBuilder;F)V
+}
+
+public final class com/juul/krayon/shape/SymbolTypesKt {
+	public static final fun getSymbolsFill ()Ljava/util/List;
+	public static final fun getSymbolsStroke ()Ljava/util/List;
+	public static final fun render (Lcom/juul/krayon/shape/SymbolType;F)Lcom/juul/krayon/kanvas/Path;
+	public static synthetic fun render$default (Lcom/juul/krayon/shape/SymbolType;FILjava/lang/Object;)Lcom/juul/krayon/kanvas/Path;
+}
+
+public final class com/juul/krayon/shape/Times : com/juul/krayon/shape/SymbolType {
+	public static final field INSTANCE Lcom/juul/krayon/shape/Times;
+	public fun draw (Lcom/juul/krayon/kanvas/PathBuilder;F)V
+}
+
+public final class com/juul/krayon/shape/Triangle : com/juul/krayon/shape/SymbolType {
+	public static final field INSTANCE Lcom/juul/krayon/shape/Triangle;
+	public fun draw (Lcom/juul/krayon/kanvas/PathBuilder;F)V
+}
+
+public final class com/juul/krayon/shape/Wye : com/juul/krayon/shape/SymbolType {
+	public static final field INSTANCE Lcom/juul/krayon/shape/Wye;
+	public fun draw (Lcom/juul/krayon/kanvas/PathBuilder;F)V
 }
 
 public final class com/juul/krayon/shape/curve/Basis : com/juul/krayon/shape/curve/Curve {

--- a/shape/api/shape.klib.api
+++ b/shape/api/shape.klib.api
@@ -99,6 +99,66 @@ final class <#A: kotlin/Any?> com.juul.krayon.shape/Slice { // com.juul.krayon.s
     final fun toString(): kotlin/String // com.juul.krayon.shape/Slice.toString|toString(){}[0]
 }
 
+final class com.juul.krayon.shape.curve/Cardinal : com.juul.krayon.shape.curve/Curve { // com.juul.krayon.shape.curve/Cardinal|null[0]
+    constructor <init>(kotlin/Float = ...) // com.juul.krayon.shape.curve/Cardinal.<init>|<init>(kotlin.Float){}[0]
+
+    final fun endArea(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/Cardinal.endArea|endArea(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+    final fun endLine(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/Cardinal.endLine|endLine(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+    final fun point(com.juul.krayon.kanvas/PathBuilder<*>, kotlin/Float, kotlin/Float) // com.juul.krayon.shape.curve/Cardinal.point|point(com.juul.krayon.kanvas.PathBuilder<*>;kotlin.Float;kotlin.Float){}[0]
+    final fun startArea(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/Cardinal.startArea|startArea(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+    final fun startLine(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/Cardinal.startLine|startLine(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+}
+
+final class com.juul.krayon.shape.curve/CardinalClosed : com.juul.krayon.shape.curve/Curve { // com.juul.krayon.shape.curve/CardinalClosed|null[0]
+    constructor <init>(kotlin/Float = ...) // com.juul.krayon.shape.curve/CardinalClosed.<init>|<init>(kotlin.Float){}[0]
+
+    final fun endArea(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/CardinalClosed.endArea|endArea(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+    final fun endLine(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/CardinalClosed.endLine|endLine(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+    final fun point(com.juul.krayon.kanvas/PathBuilder<*>, kotlin/Float, kotlin/Float) // com.juul.krayon.shape.curve/CardinalClosed.point|point(com.juul.krayon.kanvas.PathBuilder<*>;kotlin.Float;kotlin.Float){}[0]
+    final fun startArea(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/CardinalClosed.startArea|startArea(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+    final fun startLine(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/CardinalClosed.startLine|startLine(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+}
+
+final class com.juul.krayon.shape.curve/CardinalOpen : com.juul.krayon.shape.curve/Curve { // com.juul.krayon.shape.curve/CardinalOpen|null[0]
+    constructor <init>(kotlin/Float = ...) // com.juul.krayon.shape.curve/CardinalOpen.<init>|<init>(kotlin.Float){}[0]
+
+    final fun endArea(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/CardinalOpen.endArea|endArea(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+    final fun endLine(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/CardinalOpen.endLine|endLine(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+    final fun point(com.juul.krayon.kanvas/PathBuilder<*>, kotlin/Float, kotlin/Float) // com.juul.krayon.shape.curve/CardinalOpen.point|point(com.juul.krayon.kanvas.PathBuilder<*>;kotlin.Float;kotlin.Float){}[0]
+    final fun startArea(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/CardinalOpen.startArea|startArea(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+    final fun startLine(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/CardinalOpen.startLine|startLine(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+}
+
+final class com.juul.krayon.shape.curve/CatmullRom : com.juul.krayon.shape.curve/Curve { // com.juul.krayon.shape.curve/CatmullRom|null[0]
+    constructor <init>(kotlin/Float = ...) // com.juul.krayon.shape.curve/CatmullRom.<init>|<init>(kotlin.Float){}[0]
+
+    final fun endArea(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/CatmullRom.endArea|endArea(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+    final fun endLine(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/CatmullRom.endLine|endLine(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+    final fun point(com.juul.krayon.kanvas/PathBuilder<*>, kotlin/Float, kotlin/Float) // com.juul.krayon.shape.curve/CatmullRom.point|point(com.juul.krayon.kanvas.PathBuilder<*>;kotlin.Float;kotlin.Float){}[0]
+    final fun startArea(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/CatmullRom.startArea|startArea(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+    final fun startLine(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/CatmullRom.startLine|startLine(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+}
+
+final class com.juul.krayon.shape.curve/CatmullRomClosed : com.juul.krayon.shape.curve/Curve { // com.juul.krayon.shape.curve/CatmullRomClosed|null[0]
+    constructor <init>(kotlin/Float = ...) // com.juul.krayon.shape.curve/CatmullRomClosed.<init>|<init>(kotlin.Float){}[0]
+
+    final fun endArea(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/CatmullRomClosed.endArea|endArea(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+    final fun endLine(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/CatmullRomClosed.endLine|endLine(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+    final fun point(com.juul.krayon.kanvas/PathBuilder<*>, kotlin/Float, kotlin/Float) // com.juul.krayon.shape.curve/CatmullRomClosed.point|point(com.juul.krayon.kanvas.PathBuilder<*>;kotlin.Float;kotlin.Float){}[0]
+    final fun startArea(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/CatmullRomClosed.startArea|startArea(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+    final fun startLine(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/CatmullRomClosed.startLine|startLine(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+}
+
+final class com.juul.krayon.shape.curve/CatmullRomOpen : com.juul.krayon.shape.curve/Curve { // com.juul.krayon.shape.curve/CatmullRomOpen|null[0]
+    constructor <init>(kotlin/Float = ...) // com.juul.krayon.shape.curve/CatmullRomOpen.<init>|<init>(kotlin.Float){}[0]
+
+    final fun endArea(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/CatmullRomOpen.endArea|endArea(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+    final fun endLine(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/CatmullRomOpen.endLine|endLine(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+    final fun point(com.juul.krayon.kanvas/PathBuilder<*>, kotlin/Float, kotlin/Float) // com.juul.krayon.shape.curve/CatmullRomOpen.point|point(com.juul.krayon.kanvas.PathBuilder<*>;kotlin.Float;kotlin.Float){}[0]
+    final fun startArea(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/CatmullRomOpen.startArea|startArea(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+    final fun startLine(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/CatmullRomOpen.startLine|startLine(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+}
+
 final class com.juul.krayon.shape/Arc { // com.juul.krayon.shape/Arc|null[0]
     final var cornerRadius // com.juul.krayon.shape/Arc.cornerRadius|{}cornerRadius[0]
         final fun <get-cornerRadius>(): kotlin/Float // com.juul.krayon.shape/Arc.cornerRadius.<get-cornerRadius>|<get-cornerRadius>(){}[0]
@@ -133,12 +193,108 @@ final class com.juul.krayon.shape/Point { // com.juul.krayon.shape/Point|null[0]
     final fun toString(): kotlin/String // com.juul.krayon.shape/Point.toString|toString(){}[0]
 }
 
+final object com.juul.krayon.shape.curve/Basis : com.juul.krayon.shape.curve/Curve { // com.juul.krayon.shape.curve/Basis|null[0]
+    final fun endArea(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/Basis.endArea|endArea(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+    final fun endLine(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/Basis.endLine|endLine(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+    final fun point(com.juul.krayon.kanvas/PathBuilder<*>, kotlin/Float, kotlin/Float) // com.juul.krayon.shape.curve/Basis.point|point(com.juul.krayon.kanvas.PathBuilder<*>;kotlin.Float;kotlin.Float){}[0]
+    final fun startArea(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/Basis.startArea|startArea(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+    final fun startLine(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/Basis.startLine|startLine(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+}
+
+final object com.juul.krayon.shape.curve/BasisClosed : com.juul.krayon.shape.curve/Curve { // com.juul.krayon.shape.curve/BasisClosed|null[0]
+    final fun endArea(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/BasisClosed.endArea|endArea(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+    final fun endLine(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/BasisClosed.endLine|endLine(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+    final fun point(com.juul.krayon.kanvas/PathBuilder<*>, kotlin/Float, kotlin/Float) // com.juul.krayon.shape.curve/BasisClosed.point|point(com.juul.krayon.kanvas.PathBuilder<*>;kotlin.Float;kotlin.Float){}[0]
+    final fun startArea(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/BasisClosed.startArea|startArea(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+    final fun startLine(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/BasisClosed.startLine|startLine(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+}
+
+final object com.juul.krayon.shape.curve/BasisOpen : com.juul.krayon.shape.curve/Curve { // com.juul.krayon.shape.curve/BasisOpen|null[0]
+    final fun endArea(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/BasisOpen.endArea|endArea(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+    final fun endLine(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/BasisOpen.endLine|endLine(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+    final fun point(com.juul.krayon.kanvas/PathBuilder<*>, kotlin/Float, kotlin/Float) // com.juul.krayon.shape.curve/BasisOpen.point|point(com.juul.krayon.kanvas.PathBuilder<*>;kotlin.Float;kotlin.Float){}[0]
+    final fun startArea(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/BasisOpen.startArea|startArea(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+    final fun startLine(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/BasisOpen.startLine|startLine(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+}
+
+final object com.juul.krayon.shape.curve/BumpX : com.juul.krayon.shape.curve/Curve { // com.juul.krayon.shape.curve/BumpX|null[0]
+    final fun endArea(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/BumpX.endArea|endArea(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+    final fun endLine(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/BumpX.endLine|endLine(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+    final fun point(com.juul.krayon.kanvas/PathBuilder<*>, kotlin/Float, kotlin/Float) // com.juul.krayon.shape.curve/BumpX.point|point(com.juul.krayon.kanvas.PathBuilder<*>;kotlin.Float;kotlin.Float){}[0]
+    final fun startArea(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/BumpX.startArea|startArea(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+    final fun startLine(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/BumpX.startLine|startLine(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+}
+
+final object com.juul.krayon.shape.curve/BumpY : com.juul.krayon.shape.curve/Curve { // com.juul.krayon.shape.curve/BumpY|null[0]
+    final fun endArea(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/BumpY.endArea|endArea(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+    final fun endLine(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/BumpY.endLine|endLine(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+    final fun point(com.juul.krayon.kanvas/PathBuilder<*>, kotlin/Float, kotlin/Float) // com.juul.krayon.shape.curve/BumpY.point|point(com.juul.krayon.kanvas.PathBuilder<*>;kotlin.Float;kotlin.Float){}[0]
+    final fun startArea(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/BumpY.startArea|startArea(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+    final fun startLine(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/BumpY.startLine|startLine(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+}
+
 final object com.juul.krayon.shape.curve/Linear : com.juul.krayon.shape.curve/Curve { // com.juul.krayon.shape.curve/Linear|null[0]
     final fun endArea(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/Linear.endArea|endArea(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
     final fun endLine(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/Linear.endLine|endLine(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
     final fun point(com.juul.krayon.kanvas/PathBuilder<*>, kotlin/Float, kotlin/Float) // com.juul.krayon.shape.curve/Linear.point|point(com.juul.krayon.kanvas.PathBuilder<*>;kotlin.Float;kotlin.Float){}[0]
     final fun startArea(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/Linear.startArea|startArea(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
     final fun startLine(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/Linear.startLine|startLine(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+}
+
+final object com.juul.krayon.shape.curve/LinearClosed : com.juul.krayon.shape.curve/Curve { // com.juul.krayon.shape.curve/LinearClosed|null[0]
+    final fun endArea(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/LinearClosed.endArea|endArea(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+    final fun endLine(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/LinearClosed.endLine|endLine(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+    final fun point(com.juul.krayon.kanvas/PathBuilder<*>, kotlin/Float, kotlin/Float) // com.juul.krayon.shape.curve/LinearClosed.point|point(com.juul.krayon.kanvas.PathBuilder<*>;kotlin.Float;kotlin.Float){}[0]
+    final fun startArea(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/LinearClosed.startArea|startArea(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+    final fun startLine(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/LinearClosed.startLine|startLine(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+}
+
+final object com.juul.krayon.shape.curve/MonotoneX : com.juul.krayon.shape.curve/Curve { // com.juul.krayon.shape.curve/MonotoneX|null[0]
+    final fun endArea(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/MonotoneX.endArea|endArea(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+    final fun endLine(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/MonotoneX.endLine|endLine(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+    final fun point(com.juul.krayon.kanvas/PathBuilder<*>, kotlin/Float, kotlin/Float) // com.juul.krayon.shape.curve/MonotoneX.point|point(com.juul.krayon.kanvas.PathBuilder<*>;kotlin.Float;kotlin.Float){}[0]
+    final fun startArea(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/MonotoneX.startArea|startArea(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+    final fun startLine(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/MonotoneX.startLine|startLine(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+}
+
+final object com.juul.krayon.shape.curve/MonotoneY : com.juul.krayon.shape.curve/Curve { // com.juul.krayon.shape.curve/MonotoneY|null[0]
+    final fun endArea(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/MonotoneY.endArea|endArea(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+    final fun endLine(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/MonotoneY.endLine|endLine(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+    final fun point(com.juul.krayon.kanvas/PathBuilder<*>, kotlin/Float, kotlin/Float) // com.juul.krayon.shape.curve/MonotoneY.point|point(com.juul.krayon.kanvas.PathBuilder<*>;kotlin.Float;kotlin.Float){}[0]
+    final fun startArea(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/MonotoneY.startArea|startArea(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+    final fun startLine(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/MonotoneY.startLine|startLine(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+}
+
+final object com.juul.krayon.shape.curve/Natural : com.juul.krayon.shape.curve/Curve { // com.juul.krayon.shape.curve/Natural|null[0]
+    final fun endArea(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/Natural.endArea|endArea(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+    final fun endLine(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/Natural.endLine|endLine(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+    final fun point(com.juul.krayon.kanvas/PathBuilder<*>, kotlin/Float, kotlin/Float) // com.juul.krayon.shape.curve/Natural.point|point(com.juul.krayon.kanvas.PathBuilder<*>;kotlin.Float;kotlin.Float){}[0]
+    final fun startArea(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/Natural.startArea|startArea(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+    final fun startLine(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/Natural.startLine|startLine(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+}
+
+final object com.juul.krayon.shape.curve/Step : com.juul.krayon.shape.curve/Curve { // com.juul.krayon.shape.curve/Step|null[0]
+    final fun endArea(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/Step.endArea|endArea(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+    final fun endLine(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/Step.endLine|endLine(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+    final fun point(com.juul.krayon.kanvas/PathBuilder<*>, kotlin/Float, kotlin/Float) // com.juul.krayon.shape.curve/Step.point|point(com.juul.krayon.kanvas.PathBuilder<*>;kotlin.Float;kotlin.Float){}[0]
+    final fun startArea(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/Step.startArea|startArea(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+    final fun startLine(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/Step.startLine|startLine(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+}
+
+final object com.juul.krayon.shape.curve/StepAfter : com.juul.krayon.shape.curve/Curve { // com.juul.krayon.shape.curve/StepAfter|null[0]
+    final fun endArea(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/StepAfter.endArea|endArea(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+    final fun endLine(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/StepAfter.endLine|endLine(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+    final fun point(com.juul.krayon.kanvas/PathBuilder<*>, kotlin/Float, kotlin/Float) // com.juul.krayon.shape.curve/StepAfter.point|point(com.juul.krayon.kanvas.PathBuilder<*>;kotlin.Float;kotlin.Float){}[0]
+    final fun startArea(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/StepAfter.startArea|startArea(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+    final fun startLine(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/StepAfter.startLine|startLine(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+}
+
+final object com.juul.krayon.shape.curve/StepBefore : com.juul.krayon.shape.curve/Curve { // com.juul.krayon.shape.curve/StepBefore|null[0]
+    final fun endArea(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/StepBefore.endArea|endArea(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+    final fun endLine(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/StepBefore.endLine|endLine(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+    final fun point(com.juul.krayon.kanvas/PathBuilder<*>, kotlin/Float, kotlin/Float) // com.juul.krayon.shape.curve/StepBefore.point|point(com.juul.krayon.kanvas.PathBuilder<*>;kotlin.Float;kotlin.Float){}[0]
+    final fun startArea(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/StepBefore.startArea|startArea(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
+    final fun startLine(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/StepBefore.startLine|startLine(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
 }
 
 final fun <#A: kotlin/Any> com.juul.krayon.shape/area(): com.juul.krayon.shape/Area<#A> // com.juul.krayon.shape/area|area(){0§<kotlin.Any>}[0]

--- a/shape/api/shape.klib.api
+++ b/shape/api/shape.klib.api
@@ -6,6 +6,14 @@
 // - Show declarations: true
 
 // Library unique name: <com.juul.krayon:shape>
+abstract fun interface com.juul.krayon.shape/StackOffset { // com.juul.krayon.shape/StackOffset|null[0]
+    abstract fun invoke(kotlin.collections/List<com.juul.krayon.shape/Series<*, *>>, kotlin/IntArray) // com.juul.krayon.shape/StackOffset.invoke|invoke(kotlin.collections.List<com.juul.krayon.shape.Series<*,*>>;kotlin.IntArray){}[0]
+}
+
+abstract fun interface com.juul.krayon.shape/StackOrder { // com.juul.krayon.shape/StackOrder|null[0]
+    abstract fun invoke(kotlin.collections/List<com.juul.krayon.shape/Series<*, *>>): kotlin/IntArray // com.juul.krayon.shape/StackOrder.invoke|invoke(kotlin.collections.List<com.juul.krayon.shape.Series<*,*>>){}[0]
+}
+
 abstract interface com.juul.krayon.shape.curve/Curve { // com.juul.krayon.shape.curve/Curve|null[0]
     abstract fun endArea(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/Curve.endArea|endArea(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
     abstract fun endLine(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/Curve.endLine|endLine(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
@@ -55,6 +63,14 @@ final class <#A: kotlin/Any> com.juul.krayon.shape/Line { // com.juul.krayon.sha
     final fun y(kotlin/Function1<com.juul.krayon.shape/Arguments<#A>, kotlin/Float>): com.juul.krayon.shape/Line<#A> // com.juul.krayon.shape/Line.y|y(kotlin.Function1<com.juul.krayon.shape.Arguments<1:0>,kotlin.Float>){}[0]
 }
 
+final class <#A: kotlin/Any?, #B: kotlin/Any?> com.juul.krayon.shape/Stack { // com.juul.krayon.shape/Stack|null[0]
+    final fun invoke(kotlin.collections/List<#A>): kotlin.collections/List<com.juul.krayon.shape/Series<#A, #B>> // com.juul.krayon.shape/Stack.invoke|invoke(kotlin.collections.List<1:0>){}[0]
+    final fun keys(kotlin.collections/List<#B>): com.juul.krayon.shape/Stack<#A, #B> // com.juul.krayon.shape/Stack.keys|keys(kotlin.collections.List<1:1>){}[0]
+    final fun offset(com.juul.krayon.shape/StackOffset): com.juul.krayon.shape/Stack<#A, #B> // com.juul.krayon.shape/Stack.offset|offset(com.juul.krayon.shape.StackOffset){}[0]
+    final fun order(com.juul.krayon.shape/StackOrder): com.juul.krayon.shape/Stack<#A, #B> // com.juul.krayon.shape/Stack.order|order(com.juul.krayon.shape.StackOrder){}[0]
+    final fun value(kotlin/Function2<#A, #B, kotlin/Float>): com.juul.krayon.shape/Stack<#A, #B> // com.juul.krayon.shape/Stack.value|value(kotlin.Function2<1:0,1:1,kotlin.Float>){}[0]
+}
+
 final class <#A: kotlin/Any?> com.juul.krayon.shape/Pie { // com.juul.krayon.shape/Pie|null[0]
     final var endAngle // com.juul.krayon.shape/Pie.endAngle|{}endAngle[0]
         final fun <get-endAngle>(): kotlin/Float // com.juul.krayon.shape/Pie.endAngle.<get-endAngle>|<get-endAngle>(){}[0]
@@ -97,6 +113,45 @@ final class <#A: kotlin/Any?> com.juul.krayon.shape/Slice { // com.juul.krayon.s
     final fun equals(kotlin/Any?): kotlin/Boolean // com.juul.krayon.shape/Slice.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.juul.krayon.shape/Slice.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.juul.krayon.shape/Slice.toString|toString(){}[0]
+}
+
+final class <#A: out kotlin/Any?, #B: out kotlin/Any?> com.juul.krayon.shape/Series : kotlin.collections/List<com.juul.krayon.shape/StackPoint<#A>> { // com.juul.krayon.shape/Series|null[0]
+    final val key // com.juul.krayon.shape/Series.key|{}key[0]
+        final fun <get-key>(): #B // com.juul.krayon.shape/Series.key.<get-key>|<get-key>(){}[0]
+    final val size // com.juul.krayon.shape/Series.size|{}size[0]
+        final fun <get-size>(): kotlin/Int // com.juul.krayon.shape/Series.size.<get-size>|<get-size>(){}[0]
+
+    final var index // com.juul.krayon.shape/Series.index|{}index[0]
+        final fun <get-index>(): kotlin/Int // com.juul.krayon.shape/Series.index.<get-index>|<get-index>(){}[0]
+
+    final fun contains(com.juul.krayon.shape/StackPoint<#A>): kotlin/Boolean // com.juul.krayon.shape/Series.contains|contains(com.juul.krayon.shape.StackPoint<1:0>){}[0]
+    final fun containsAll(kotlin.collections/Collection<com.juul.krayon.shape/StackPoint<#A>>): kotlin/Boolean // com.juul.krayon.shape/Series.containsAll|containsAll(kotlin.collections.Collection<com.juul.krayon.shape.StackPoint<1:0>>){}[0]
+    final fun get(kotlin/Int): com.juul.krayon.shape/StackPoint<#A> // com.juul.krayon.shape/Series.get|get(kotlin.Int){}[0]
+    final fun indexOf(com.juul.krayon.shape/StackPoint<#A>): kotlin/Int // com.juul.krayon.shape/Series.indexOf|indexOf(com.juul.krayon.shape.StackPoint<1:0>){}[0]
+    final fun isEmpty(): kotlin/Boolean // com.juul.krayon.shape/Series.isEmpty|isEmpty(){}[0]
+    final fun iterator(): kotlin.collections/Iterator<com.juul.krayon.shape/StackPoint<#A>> // com.juul.krayon.shape/Series.iterator|iterator(){}[0]
+    final fun lastIndexOf(com.juul.krayon.shape/StackPoint<#A>): kotlin/Int // com.juul.krayon.shape/Series.lastIndexOf|lastIndexOf(com.juul.krayon.shape.StackPoint<1:0>){}[0]
+    final fun listIterator(): kotlin.collections/ListIterator<com.juul.krayon.shape/StackPoint<#A>> // com.juul.krayon.shape/Series.listIterator|listIterator(){}[0]
+    final fun listIterator(kotlin/Int): kotlin.collections/ListIterator<com.juul.krayon.shape/StackPoint<#A>> // com.juul.krayon.shape/Series.listIterator|listIterator(kotlin.Int){}[0]
+    final fun subList(kotlin/Int, kotlin/Int): kotlin.collections/List<com.juul.krayon.shape/StackPoint<#A>> // com.juul.krayon.shape/Series.subList|subList(kotlin.Int;kotlin.Int){}[0]
+    final fun toString(): kotlin/String // com.juul.krayon.shape/Series.toString|toString(){}[0]
+
+    // Targets: [js]
+    final fun asJsReadonlyArrayView(): kotlin.js.collections/JsReadonlyArray<com.juul.krayon.shape/StackPoint<#A>> // com.juul.krayon.shape/Series.asJsReadonlyArrayView|asJsReadonlyArrayView(){}[0]
+}
+
+final class <#A: out kotlin/Any?> com.juul.krayon.shape/StackPoint { // com.juul.krayon.shape/StackPoint|null[0]
+    final val data // com.juul.krayon.shape/StackPoint.data|{}data[0]
+        final fun <get-data>(): #A // com.juul.krayon.shape/StackPoint.data.<get-data>|<get-data>(){}[0]
+
+    final var high // com.juul.krayon.shape/StackPoint.high|{}high[0]
+        final fun <get-high>(): kotlin/Float // com.juul.krayon.shape/StackPoint.high.<get-high>|<get-high>(){}[0]
+        final fun <set-high>(kotlin/Float) // com.juul.krayon.shape/StackPoint.high.<set-high>|<set-high>(kotlin.Float){}[0]
+    final var low // com.juul.krayon.shape/StackPoint.low|{}low[0]
+        final fun <get-low>(): kotlin/Float // com.juul.krayon.shape/StackPoint.low.<get-low>|<get-low>(){}[0]
+        final fun <set-low>(kotlin/Float) // com.juul.krayon.shape/StackPoint.low.<set-low>|<set-low>(kotlin.Float){}[0]
+
+    final fun toString(): kotlin/String // com.juul.krayon.shape/StackPoint.toString|toString(){}[0]
 }
 
 final class com.juul.krayon.shape.curve/Cardinal : com.juul.krayon.shape.curve/Curve { // com.juul.krayon.shape.curve/Cardinal|null[0]
@@ -297,7 +352,52 @@ final object com.juul.krayon.shape.curve/StepBefore : com.juul.krayon.shape.curv
     final fun startLine(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/StepBefore.startLine|startLine(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
 }
 
+final object com.juul.krayon.shape/StackOffsetDiverging : com.juul.krayon.shape/StackOffset { // com.juul.krayon.shape/StackOffsetDiverging|null[0]
+    final fun invoke(kotlin.collections/List<com.juul.krayon.shape/Series<*, *>>, kotlin/IntArray) // com.juul.krayon.shape/StackOffsetDiverging.invoke|invoke(kotlin.collections.List<com.juul.krayon.shape.Series<*,*>>;kotlin.IntArray){}[0]
+}
+
+final object com.juul.krayon.shape/StackOffsetExpand : com.juul.krayon.shape/StackOffset { // com.juul.krayon.shape/StackOffsetExpand|null[0]
+    final fun invoke(kotlin.collections/List<com.juul.krayon.shape/Series<*, *>>, kotlin/IntArray) // com.juul.krayon.shape/StackOffsetExpand.invoke|invoke(kotlin.collections.List<com.juul.krayon.shape.Series<*,*>>;kotlin.IntArray){}[0]
+}
+
+final object com.juul.krayon.shape/StackOffsetNone : com.juul.krayon.shape/StackOffset { // com.juul.krayon.shape/StackOffsetNone|null[0]
+    final fun invoke(kotlin.collections/List<com.juul.krayon.shape/Series<*, *>>, kotlin/IntArray) // com.juul.krayon.shape/StackOffsetNone.invoke|invoke(kotlin.collections.List<com.juul.krayon.shape.Series<*,*>>;kotlin.IntArray){}[0]
+}
+
+final object com.juul.krayon.shape/StackOffsetSilhouette : com.juul.krayon.shape/StackOffset { // com.juul.krayon.shape/StackOffsetSilhouette|null[0]
+    final fun invoke(kotlin.collections/List<com.juul.krayon.shape/Series<*, *>>, kotlin/IntArray) // com.juul.krayon.shape/StackOffsetSilhouette.invoke|invoke(kotlin.collections.List<com.juul.krayon.shape.Series<*,*>>;kotlin.IntArray){}[0]
+}
+
+final object com.juul.krayon.shape/StackOffsetWiggle : com.juul.krayon.shape/StackOffset { // com.juul.krayon.shape/StackOffsetWiggle|null[0]
+    final fun invoke(kotlin.collections/List<com.juul.krayon.shape/Series<*, *>>, kotlin/IntArray) // com.juul.krayon.shape/StackOffsetWiggle.invoke|invoke(kotlin.collections.List<com.juul.krayon.shape.Series<*,*>>;kotlin.IntArray){}[0]
+}
+
+final object com.juul.krayon.shape/StackOrderAppearance : com.juul.krayon.shape/StackOrder { // com.juul.krayon.shape/StackOrderAppearance|null[0]
+    final fun invoke(kotlin.collections/List<com.juul.krayon.shape/Series<*, *>>): kotlin/IntArray // com.juul.krayon.shape/StackOrderAppearance.invoke|invoke(kotlin.collections.List<com.juul.krayon.shape.Series<*,*>>){}[0]
+}
+
+final object com.juul.krayon.shape/StackOrderAscending : com.juul.krayon.shape/StackOrder { // com.juul.krayon.shape/StackOrderAscending|null[0]
+    final fun invoke(kotlin.collections/List<com.juul.krayon.shape/Series<*, *>>): kotlin/IntArray // com.juul.krayon.shape/StackOrderAscending.invoke|invoke(kotlin.collections.List<com.juul.krayon.shape.Series<*,*>>){}[0]
+}
+
+final object com.juul.krayon.shape/StackOrderDescending : com.juul.krayon.shape/StackOrder { // com.juul.krayon.shape/StackOrderDescending|null[0]
+    final fun invoke(kotlin.collections/List<com.juul.krayon.shape/Series<*, *>>): kotlin/IntArray // com.juul.krayon.shape/StackOrderDescending.invoke|invoke(kotlin.collections.List<com.juul.krayon.shape.Series<*,*>>){}[0]
+}
+
+final object com.juul.krayon.shape/StackOrderInsideOut : com.juul.krayon.shape/StackOrder { // com.juul.krayon.shape/StackOrderInsideOut|null[0]
+    final fun invoke(kotlin.collections/List<com.juul.krayon.shape/Series<*, *>>): kotlin/IntArray // com.juul.krayon.shape/StackOrderInsideOut.invoke|invoke(kotlin.collections.List<com.juul.krayon.shape.Series<*,*>>){}[0]
+}
+
+final object com.juul.krayon.shape/StackOrderNone : com.juul.krayon.shape/StackOrder { // com.juul.krayon.shape/StackOrderNone|null[0]
+    final fun invoke(kotlin.collections/List<com.juul.krayon.shape/Series<*, *>>): kotlin/IntArray // com.juul.krayon.shape/StackOrderNone.invoke|invoke(kotlin.collections.List<com.juul.krayon.shape.Series<*,*>>){}[0]
+}
+
+final object com.juul.krayon.shape/StackOrderReverse : com.juul.krayon.shape/StackOrder { // com.juul.krayon.shape/StackOrderReverse|null[0]
+    final fun invoke(kotlin.collections/List<com.juul.krayon.shape/Series<*, *>>): kotlin/IntArray // com.juul.krayon.shape/StackOrderReverse.invoke|invoke(kotlin.collections.List<com.juul.krayon.shape.Series<*,*>>){}[0]
+}
+
 final fun <#A: kotlin/Any> com.juul.krayon.shape/area(): com.juul.krayon.shape/Area<#A> // com.juul.krayon.shape/area|area(){0§<kotlin.Any>}[0]
 final fun <#A: kotlin/Any> com.juul.krayon.shape/line(): com.juul.krayon.shape/Line<#A> // com.juul.krayon.shape/line|line(){0§<kotlin.Any>}[0]
+final fun <#A: kotlin/Any?, #B: kotlin/Any?> com.juul.krayon.shape/stack(): com.juul.krayon.shape/Stack<#A, #B> // com.juul.krayon.shape/stack|stack(){0§<kotlin.Any?>;1§<kotlin.Any?>}[0]
 final fun com.juul.krayon.shape/arc(kotlin/Float, kotlin/Float = ...): com.juul.krayon.shape/Arc // com.juul.krayon.shape/arc|arc(kotlin.Float;kotlin.Float){}[0]
 final fun com.juul.krayon.shape/pie(): com.juul.krayon.shape/Pie<kotlin/Float> // com.juul.krayon.shape/pie|pie(){}[0]

--- a/shape/api/shape.klib.api
+++ b/shape/api/shape.klib.api
@@ -22,6 +22,10 @@ abstract interface com.juul.krayon.shape.curve/Curve { // com.juul.krayon.shape.
     abstract fun startLine(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/Curve.startLine|startLine(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
 }
 
+abstract interface com.juul.krayon.shape/SymbolType { // com.juul.krayon.shape/SymbolType|null[0]
+    abstract fun draw(com.juul.krayon.kanvas/PathBuilder<*>, kotlin/Float) // com.juul.krayon.shape/SymbolType.draw|draw(com.juul.krayon.kanvas.PathBuilder<*>;kotlin.Float){}[0]
+}
+
 final class <#A: kotlin/Any> com.juul.krayon.shape/Area { // com.juul.krayon.shape/Area|null[0]
     final fun curve(com.juul.krayon.shape.curve/Curve): com.juul.krayon.shape/Area<#A> // com.juul.krayon.shape/Area.curve|curve(com.juul.krayon.shape.curve.Curve){}[0]
     final fun defined(kotlin/Function1<com.juul.krayon.shape/Arguments<#A>, kotlin/Boolean>): com.juul.krayon.shape/Area<#A> // com.juul.krayon.shape/Area.defined|defined(kotlin.Function1<com.juul.krayon.shape.Arguments<1:0>,kotlin.Boolean>){}[0]
@@ -61,6 +65,14 @@ final class <#A: kotlin/Any> com.juul.krayon.shape/Line { // com.juul.krayon.sha
     final fun x(kotlin/Function1<com.juul.krayon.shape/Arguments<#A>, kotlin/Float>): com.juul.krayon.shape/Line<#A> // com.juul.krayon.shape/Line.x|x(kotlin.Function1<com.juul.krayon.shape.Arguments<1:0>,kotlin.Float>){}[0]
     final fun y(kotlin/Float): com.juul.krayon.shape/Line<#A> // com.juul.krayon.shape/Line.y|y(kotlin.Float){}[0]
     final fun y(kotlin/Function1<com.juul.krayon.shape/Arguments<#A>, kotlin/Float>): com.juul.krayon.shape/Line<#A> // com.juul.krayon.shape/Line.y|y(kotlin.Function1<com.juul.krayon.shape.Arguments<1:0>,kotlin.Float>){}[0]
+}
+
+final class <#A: kotlin/Any> com.juul.krayon.shape/Symbol { // com.juul.krayon.shape/Symbol|null[0]
+    final fun render(#A, kotlin/Int = ..., kotlin.collections/List<#A?> = ...): com.juul.krayon.kanvas/Path // com.juul.krayon.shape/Symbol.render|render(1:0;kotlin.Int;kotlin.collections.List<1:0?>){}[0]
+    final fun size(kotlin/Float): com.juul.krayon.shape/Symbol<#A> // com.juul.krayon.shape/Symbol.size|size(kotlin.Float){}[0]
+    final fun size(kotlin/Function1<com.juul.krayon.shape/Arguments<#A>, kotlin/Float>): com.juul.krayon.shape/Symbol<#A> // com.juul.krayon.shape/Symbol.size|size(kotlin.Function1<com.juul.krayon.shape.Arguments<1:0>,kotlin.Float>){}[0]
+    final fun type(com.juul.krayon.shape/SymbolType): com.juul.krayon.shape/Symbol<#A> // com.juul.krayon.shape/Symbol.type|type(com.juul.krayon.shape.SymbolType){}[0]
+    final fun type(kotlin/Function1<com.juul.krayon.shape/Arguments<#A>, com.juul.krayon.shape/SymbolType>): com.juul.krayon.shape/Symbol<#A> // com.juul.krayon.shape/Symbol.type|type(kotlin.Function1<com.juul.krayon.shape.Arguments<1:0>,com.juul.krayon.shape.SymbolType>){}[0]
 }
 
 final class <#A: kotlin/Any?, #B: kotlin/Any?> com.juul.krayon.shape/Stack { // com.juul.krayon.shape/Stack|null[0]
@@ -352,6 +364,30 @@ final object com.juul.krayon.shape.curve/StepBefore : com.juul.krayon.shape.curv
     final fun startLine(com.juul.krayon.kanvas/PathBuilder<*>) // com.juul.krayon.shape.curve/StepBefore.startLine|startLine(com.juul.krayon.kanvas.PathBuilder<*>){}[0]
 }
 
+final object com.juul.krayon.shape/Asterisk : com.juul.krayon.shape/SymbolType { // com.juul.krayon.shape/Asterisk|null[0]
+    final fun draw(com.juul.krayon.kanvas/PathBuilder<*>, kotlin/Float) // com.juul.krayon.shape/Asterisk.draw|draw(com.juul.krayon.kanvas.PathBuilder<*>;kotlin.Float){}[0]
+}
+
+final object com.juul.krayon.shape/Circle : com.juul.krayon.shape/SymbolType { // com.juul.krayon.shape/Circle|null[0]
+    final fun draw(com.juul.krayon.kanvas/PathBuilder<*>, kotlin/Float) // com.juul.krayon.shape/Circle.draw|draw(com.juul.krayon.kanvas.PathBuilder<*>;kotlin.Float){}[0]
+}
+
+final object com.juul.krayon.shape/Cross : com.juul.krayon.shape/SymbolType { // com.juul.krayon.shape/Cross|null[0]
+    final fun draw(com.juul.krayon.kanvas/PathBuilder<*>, kotlin/Float) // com.juul.krayon.shape/Cross.draw|draw(com.juul.krayon.kanvas.PathBuilder<*>;kotlin.Float){}[0]
+}
+
+final object com.juul.krayon.shape/Diamond : com.juul.krayon.shape/SymbolType { // com.juul.krayon.shape/Diamond|null[0]
+    final fun draw(com.juul.krayon.kanvas/PathBuilder<*>, kotlin/Float) // com.juul.krayon.shape/Diamond.draw|draw(com.juul.krayon.kanvas.PathBuilder<*>;kotlin.Float){}[0]
+}
+
+final object com.juul.krayon.shape/Plus : com.juul.krayon.shape/SymbolType { // com.juul.krayon.shape/Plus|null[0]
+    final fun draw(com.juul.krayon.kanvas/PathBuilder<*>, kotlin/Float) // com.juul.krayon.shape/Plus.draw|draw(com.juul.krayon.kanvas.PathBuilder<*>;kotlin.Float){}[0]
+}
+
+final object com.juul.krayon.shape/Square : com.juul.krayon.shape/SymbolType { // com.juul.krayon.shape/Square|null[0]
+    final fun draw(com.juul.krayon.kanvas/PathBuilder<*>, kotlin/Float) // com.juul.krayon.shape/Square.draw|draw(com.juul.krayon.kanvas.PathBuilder<*>;kotlin.Float){}[0]
+}
+
 final object com.juul.krayon.shape/StackOffsetDiverging : com.juul.krayon.shape/StackOffset { // com.juul.krayon.shape/StackOffsetDiverging|null[0]
     final fun invoke(kotlin.collections/List<com.juul.krayon.shape/Series<*, *>>, kotlin/IntArray) // com.juul.krayon.shape/StackOffsetDiverging.invoke|invoke(kotlin.collections.List<com.juul.krayon.shape.Series<*,*>>;kotlin.IntArray){}[0]
 }
@@ -396,8 +432,31 @@ final object com.juul.krayon.shape/StackOrderReverse : com.juul.krayon.shape/Sta
     final fun invoke(kotlin.collections/List<com.juul.krayon.shape/Series<*, *>>): kotlin/IntArray // com.juul.krayon.shape/StackOrderReverse.invoke|invoke(kotlin.collections.List<com.juul.krayon.shape.Series<*,*>>){}[0]
 }
 
+final object com.juul.krayon.shape/Star : com.juul.krayon.shape/SymbolType { // com.juul.krayon.shape/Star|null[0]
+    final fun draw(com.juul.krayon.kanvas/PathBuilder<*>, kotlin/Float) // com.juul.krayon.shape/Star.draw|draw(com.juul.krayon.kanvas.PathBuilder<*>;kotlin.Float){}[0]
+}
+
+final object com.juul.krayon.shape/Times : com.juul.krayon.shape/SymbolType { // com.juul.krayon.shape/Times|null[0]
+    final fun draw(com.juul.krayon.kanvas/PathBuilder<*>, kotlin/Float) // com.juul.krayon.shape/Times.draw|draw(com.juul.krayon.kanvas.PathBuilder<*>;kotlin.Float){}[0]
+}
+
+final object com.juul.krayon.shape/Triangle : com.juul.krayon.shape/SymbolType { // com.juul.krayon.shape/Triangle|null[0]
+    final fun draw(com.juul.krayon.kanvas/PathBuilder<*>, kotlin/Float) // com.juul.krayon.shape/Triangle.draw|draw(com.juul.krayon.kanvas.PathBuilder<*>;kotlin.Float){}[0]
+}
+
+final object com.juul.krayon.shape/Wye : com.juul.krayon.shape/SymbolType { // com.juul.krayon.shape/Wye|null[0]
+    final fun draw(com.juul.krayon.kanvas/PathBuilder<*>, kotlin/Float) // com.juul.krayon.shape/Wye.draw|draw(com.juul.krayon.kanvas.PathBuilder<*>;kotlin.Float){}[0]
+}
+
+final val com.juul.krayon.shape/symbolsFill // com.juul.krayon.shape/symbolsFill|{}symbolsFill[0]
+    final fun <get-symbolsFill>(): kotlin.collections/List<com.juul.krayon.shape/SymbolType> // com.juul.krayon.shape/symbolsFill.<get-symbolsFill>|<get-symbolsFill>(){}[0]
+final val com.juul.krayon.shape/symbolsStroke // com.juul.krayon.shape/symbolsStroke|{}symbolsStroke[0]
+    final fun <get-symbolsStroke>(): kotlin.collections/List<com.juul.krayon.shape/SymbolType> // com.juul.krayon.shape/symbolsStroke.<get-symbolsStroke>|<get-symbolsStroke>(){}[0]
+
+final fun (com.juul.krayon.shape/SymbolType).com.juul.krayon.shape/render(kotlin/Float = ...): com.juul.krayon.kanvas/Path // com.juul.krayon.shape/render|render@com.juul.krayon.shape.SymbolType(kotlin.Float){}[0]
 final fun <#A: kotlin/Any> com.juul.krayon.shape/area(): com.juul.krayon.shape/Area<#A> // com.juul.krayon.shape/area|area(){0§<kotlin.Any>}[0]
 final fun <#A: kotlin/Any> com.juul.krayon.shape/line(): com.juul.krayon.shape/Line<#A> // com.juul.krayon.shape/line|line(){0§<kotlin.Any>}[0]
+final fun <#A: kotlin/Any> com.juul.krayon.shape/symbol(): com.juul.krayon.shape/Symbol<#A> // com.juul.krayon.shape/symbol|symbol(){0§<kotlin.Any>}[0]
 final fun <#A: kotlin/Any?, #B: kotlin/Any?> com.juul.krayon.shape/stack(): com.juul.krayon.shape/Stack<#A, #B> // com.juul.krayon.shape/stack|stack(){0§<kotlin.Any?>;1§<kotlin.Any?>}[0]
 final fun com.juul.krayon.shape/arc(kotlin/Float, kotlin/Float = ...): com.juul.krayon.shape/Arc // com.juul.krayon.shape/arc|arc(kotlin.Float;kotlin.Float){}[0]
 final fun com.juul.krayon.shape/pie(): com.juul.krayon.shape/Pie<kotlin/Float> // com.juul.krayon.shape/pie|pie(){}[0]

--- a/shape/src/commonMain/kotlin/Stack.kt
+++ b/shape/src/commonMain/kotlin/Stack.kt
@@ -1,0 +1,69 @@
+package com.juul.krayon.shape
+
+/**
+ * A single stacked point, spanning [low] (baseline) to [high] (topline) for its [data] datum.
+ * [low] and [high] are mutable so [StackOffset] implementations can reposition the stack.
+ */
+public class StackPoint<out D> internal constructor(
+    public val data: D,
+    low: Float,
+    high: Float,
+) {
+    public var low: Float = low
+
+    public var high: Float = high
+
+    override fun toString(): String = "StackPoint(data=$data, low=$low, high=$high)"
+}
+
+/** A stacked series for a single [key], usable as a `List` of [StackPoint] for feeding `area()`/`line()`. */
+public class Series<out D, out K> internal constructor(
+    public val key: K,
+    private val points: List<StackPoint<D>>,
+) : List<StackPoint<D>> by points {
+    public var index: Int = 0
+        internal set
+
+    override fun toString(): String = "Series(key=$key, index=$index, points=$points)"
+}
+
+public fun <D, K> stack(): Stack<D, K> = Stack()
+
+/**
+ * Computes a stacked layout, like [`d3.stack`](https://github.com/d3/d3-shape/blob/main/src/stack.js).
+ * Each of the [keys] produces a [Series]; the [value] accessor extracts a numeric value per key/datum.
+ */
+public class Stack<D, K> internal constructor() {
+
+    private var keys: List<K> = emptyList()
+    private var value: (datum: D, key: K) -> Float = defaultValue()
+    private var order: StackOrder = StackOrderNone
+    private var offset: StackOffset = StackOffsetNone
+
+    public fun keys(keys: List<K>): Stack<D, K> = apply { this.keys = keys.toList() }
+
+    public fun value(value: (datum: D, key: K) -> Float): Stack<D, K> = apply { this.value = value }
+
+    public fun order(order: StackOrder): Stack<D, K> = apply { this.order = order }
+
+    public fun offset(offset: StackOffset): Stack<D, K> = apply { this.offset = offset }
+
+    public operator fun invoke(data: List<D>): List<Series<D, K>> {
+        val n = keys.size
+        val series = keys.map { key ->
+            Series(key, data.map { datum -> StackPoint(datum, low = 0f, high = value(datum, key)) })
+        }
+        val order = this.order(series)
+        for (i in 0 until n) series[order[i]].index = i
+        offset(series, order)
+        return series
+    }
+}
+
+private fun <D, K> defaultValue(): (D, K) -> Float = { datum, key ->
+    when (datum) {
+        is Map<*, *> -> (datum[key] as Number).toFloat()
+        is List<*> -> (datum[key as Int] as Number).toFloat()
+        else -> error("No default stack value accessor for `$datum`; provide one via `value { datum, key -> ... }`.")
+    }
+}

--- a/shape/src/commonMain/kotlin/StackOffset.kt
+++ b/shape/src/commonMain/kotlin/StackOffset.kt
@@ -1,0 +1,134 @@
+package com.juul.krayon.shape
+
+/** Repositions the baselines/toplines of the stacked [series] in the given stacking [order]. */
+public fun interface StackOffset {
+    public operator fun invoke(series: List<Series<*, *>>, order: IntArray)
+}
+
+/** Applies a zero baseline; each series is stacked on top of the one below it. */
+public object StackOffsetNone : StackOffset {
+    override fun invoke(series: List<Series<*, *>>, order: IntArray) {
+        val n = series.size
+        if (n <= 1) return
+        val m = series[order[0]].size
+        var s1 = series[order[0]]
+        for (i in 1 until n) {
+            val s0 = s1
+            s1 = series[order[i]]
+            for (j in 0 until m) {
+                val below = if (s0[j].high.isNaN()) s0[j].low else s0[j].high
+                s1[j].low = below
+                s1[j].high += below
+            }
+        }
+    }
+}
+
+/** Normalizes each column to the range `[0, 1]`, useful for percentage-stacked charts. */
+public object StackOffsetExpand : StackOffset {
+    override fun invoke(series: List<Series<*, *>>, order: IntArray) {
+        val n = series.size
+        if (n <= 0) return
+        val m = series[0].size
+        for (j in 0 until m) {
+            var y = 0f
+            for (i in 0 until n) {
+                val value = series[i][j].high
+                if (!value.isNaN()) y += value
+            }
+            if (y != 0f) for (i in 0 until n) series[i][j].high /= y
+        }
+        StackOffsetNone(series, order)
+    }
+}
+
+/** Positive values are stacked above zero and negative values below, ignoring existing offsets. */
+public object StackOffsetDiverging : StackOffset {
+    override fun invoke(series: List<Series<*, *>>, order: IntArray) {
+        val n = series.size
+        if (n <= 0) return
+        val m = series[order[0]].size
+        for (j in 0 until m) {
+            var yp = 0f
+            var yn = 0f
+            for (i in 0 until n) {
+                val d = series[order[i]][j]
+                val dy = d.high - d.low
+                when {
+                    dy > 0f -> {
+                        d.low = yp
+                        yp += dy
+                        d.high = yp
+                    }
+                    dy < 0f -> {
+                        d.high = yn
+                        yn += dy
+                        d.low = yn
+                    }
+                    else -> {
+                        d.low = 0f
+                        d.high = dy
+                    }
+                }
+            }
+        }
+    }
+}
+
+/** Centers the stack around zero (streamgraph baseline). */
+public object StackOffsetSilhouette : StackOffset {
+    override fun invoke(series: List<Series<*, *>>, order: IntArray) {
+        val n = series.size
+        if (n <= 0) return
+        val s0 = series[order[0]]
+        val m = s0.size
+        for (j in 0 until m) {
+            var y = 0f
+            for (i in 0 until n) {
+                val value = series[i][j].high
+                if (!value.isNaN()) y += value
+            }
+            s0[j].low = -y / 2
+            s0[j].high += s0[j].low
+        }
+        StackOffsetNone(series, order)
+    }
+}
+
+/** Shifts the baseline to minimize the weighted wiggle of the layers (streamgraph). */
+public object StackOffsetWiggle : StackOffset {
+    override fun invoke(series: List<Series<*, *>>, order: IntArray) {
+        val n = series.size
+        if (n <= 0) return
+        val s0 = series[order[0]]
+        val m = s0.size
+        if (m <= 0) return
+        var y = 0f
+        var j = 1
+        while (j < m) {
+            var s1 = 0f
+            var s2 = 0f
+            for (i in 0 until n) {
+                val si = series[order[i]]
+                val sij0 = si[j].high.orZero()
+                val sij1 = si[j - 1].high.orZero()
+                var s3 = (sij0 - sij1) / 2
+                for (k in 0 until i) {
+                    val sk = series[order[k]]
+                    s3 += sk[j].high.orZero() - sk[j - 1].high.orZero()
+                }
+                s1 += sij0
+                s2 += s3 * sij0
+            }
+            s0[j - 1].low = y
+            s0[j - 1].high += y
+            if (s1 != 0f) y -= s2 / s1
+            j++
+        }
+        s0[m - 1].low = y
+        s0[m - 1].high += y
+        StackOffsetNone(series, order)
+    }
+}
+
+private fun Float.orZero(): Float = if (isNaN()) 0f else this

--- a/shape/src/commonMain/kotlin/StackOrder.kt
+++ b/shape/src/commonMain/kotlin/StackOrder.kt
@@ -1,0 +1,83 @@
+package com.juul.krayon.shape
+
+/** Determines the order in which series are stacked, returning the series indices in stacking order. */
+public fun interface StackOrder {
+    public operator fun invoke(series: List<Series<*, *>>): IntArray
+}
+
+/** Series are stacked in the given (input) order. */
+public object StackOrderNone : StackOrder {
+    override fun invoke(series: List<Series<*, *>>): IntArray = IntArray(series.size) { it }
+}
+
+/** Series are stacked in reverse of the given order. */
+public object StackOrderReverse : StackOrder {
+    override fun invoke(series: List<Series<*, *>>): IntArray = IntArray(series.size) { series.size - 1 - it }
+}
+
+/** Series are stacked by ascending total value (smallest at the bottom). */
+public object StackOrderAscending : StackOrder {
+    override fun invoke(series: List<Series<*, *>>): IntArray {
+        val sums = series.map(::seriesSum)
+        return series.indices.sortedBy { sums[it] }.toIntArray()
+    }
+}
+
+/** Series are stacked by descending total value (largest at the bottom). */
+public object StackOrderDescending : StackOrder {
+    override fun invoke(series: List<Series<*, *>>): IntArray = StackOrderAscending(series).reversedArray()
+}
+
+/** Series are stacked by the index of their maximum value (order of appearance). */
+public object StackOrderAppearance : StackOrder {
+    override fun invoke(series: List<Series<*, *>>): IntArray {
+        val peaks = series.map(::seriesPeak)
+        return series.indices.sortedBy { peaks[it] }.toIntArray()
+    }
+}
+
+/** Series are stacked inside-out by appearance, so that larger series are toward the center. */
+public object StackOrderInsideOut : StackOrder {
+    override fun invoke(series: List<Series<*, *>>): IntArray {
+        val n = series.size
+        val sums = series.map(::seriesSum)
+        val order = StackOrderAppearance(series)
+        var top = 0f
+        var bottom = 0f
+        val tops = mutableListOf<Int>()
+        val bottoms = mutableListOf<Int>()
+        for (i in 0 until n) {
+            val j = order[i]
+            if (top < bottom) {
+                top += sums[j]
+                tops += j
+            } else {
+                bottom += sums[j]
+                bottoms += j
+            }
+        }
+        return (bottoms.asReversed() + tops).toIntArray()
+    }
+}
+
+internal fun seriesSum(series: Series<*, *>): Float {
+    var sum = 0f
+    for (point in series) {
+        val value = point.high
+        if (!value.isNaN() && value != 0f) sum += value
+    }
+    return sum
+}
+
+internal fun seriesPeak(series: Series<*, *>): Int {
+    var peak = 0
+    var max = Float.NEGATIVE_INFINITY
+    for (i in series.indices) {
+        val value = series[i].high
+        if (value > max) {
+            max = value
+            peak = i
+        }
+    }
+    return peak
+}

--- a/shape/src/commonMain/kotlin/Symbol.kt
+++ b/shape/src/commonMain/kotlin/Symbol.kt
@@ -1,0 +1,28 @@
+package com.juul.krayon.shape
+
+import com.juul.krayon.kanvas.Path
+
+public fun <D : Any> symbol(): Symbol<D> = Symbol()
+
+/**
+ * Renders a [SymbolType] to a [Path], like [`d3.symbol`](https://github.com/d3/d3-shape/blob/main/src/symbol.js).
+ * Both the symbol [type] and its [size] (area in square pixels, default `64`) may be constants or accessor functions.
+ */
+public class Symbol<D : Any> internal constructor() {
+
+    private var type: (Arguments<D>) -> SymbolType = { Circle }
+    private var size: (Arguments<D>) -> Float = { 64f }
+
+    public fun type(type: SymbolType): Symbol<D> = apply { this.type = { type } }
+
+    public fun type(type: (Arguments<D>) -> SymbolType): Symbol<D> = apply { this.type = type }
+
+    public fun size(size: Float): Symbol<D> = apply { this.size = { size } }
+
+    public fun size(size: (Arguments<D>) -> Float): Symbol<D> = apply { this.size = size }
+
+    public fun render(datum: D, index: Int = 0, data: List<D?> = listOf(datum)): Path = Path {
+        val arguments = Arguments(datum, index, data)
+        type(arguments).draw(this, size(arguments))
+    }
+}

--- a/shape/src/commonMain/kotlin/SymbolTypes.kt
+++ b/shape/src/commonMain/kotlin/SymbolTypes.kt
@@ -1,0 +1,188 @@
+package com.juul.krayon.shape
+
+import com.juul.krayon.kanvas.Path
+import com.juul.krayon.kanvas.PathBuilder
+import kotlin.math.cos
+import kotlin.math.min
+import kotlin.math.sin
+import kotlin.math.sqrt
+
+private const val PI: Float = kotlin.math.PI.toFloat()
+private const val TAU: Float = 2f * PI
+
+/** A symbol shape that can draw itself into a [PathBuilder] scaled to a given area [size] (in square pixels). */
+public interface SymbolType {
+    public fun draw(context: PathBuilder<*>, size: Float)
+}
+
+/** Draws this symbol at the given [size] and returns the resulting [Path]. */
+public fun SymbolType.render(size: Float = 64f): Path = Path { draw(this, size) }
+
+/** A circle, sized so that its area matches [size]. */
+public object Circle : SymbolType {
+    override fun draw(context: PathBuilder<*>, size: Float) {
+        val r = sqrt(size / PI)
+        context.moveTo(r, 0f)
+        context.arcTo(-r, -r, r, r, 0f, 180f, false)
+        context.arcTo(-r, -r, r, r, 180f, 180f, false)
+    }
+}
+
+/** A Greek cross (plus sign) with arms of equal width. */
+public object Cross : SymbolType {
+    override fun draw(context: PathBuilder<*>, size: Float) {
+        val r = sqrt(size / 5f) / 2f
+        context.moveTo(-3 * r, -r)
+        context.lineTo(-r, -r)
+        context.lineTo(-r, -3 * r)
+        context.lineTo(r, -3 * r)
+        context.lineTo(r, -r)
+        context.lineTo(3 * r, -r)
+        context.lineTo(3 * r, r)
+        context.lineTo(r, r)
+        context.lineTo(r, 3 * r)
+        context.lineTo(-r, 3 * r)
+        context.lineTo(-r, r)
+        context.lineTo(-3 * r, r)
+        context.close()
+    }
+}
+
+/** A rhombus. */
+public object Diamond : SymbolType {
+    private val tan30: Float = sqrt(1f / 3f)
+    private val tan30x2: Float = tan30 * 2f
+
+    override fun draw(context: PathBuilder<*>, size: Float) {
+        val y = sqrt(size / tan30x2)
+        val x = y * tan30
+        context.moveTo(0f, -y)
+        context.lineTo(x, 0f)
+        context.lineTo(0f, y)
+        context.lineTo(-x, 0f)
+        context.close()
+    }
+}
+
+/** An axis-aligned square. */
+public object Square : SymbolType {
+    override fun draw(context: PathBuilder<*>, size: Float) {
+        val w = sqrt(size)
+        val x = -w / 2f
+        context.moveTo(x, x)
+        context.lineTo(x + w, x)
+        context.lineTo(x + w, x + w)
+        context.lineTo(x, x + w)
+        context.close()
+    }
+}
+
+/** A five-pointed star. */
+public object Star : SymbolType {
+    private const val KA: Float = 0.89081309152928522810f
+    private val kr: Float = sin(PI / 10f) / sin(7f * PI / 10f)
+    private val kx: Float = sin(TAU / 10f) * kr
+    private val ky: Float = -cos(TAU / 10f) * kr
+
+    override fun draw(context: PathBuilder<*>, size: Float) {
+        val r = sqrt(size * KA)
+        val x = kx * r
+        val y = ky * r
+        context.moveTo(0f, -r)
+        context.lineTo(x, y)
+        for (i in 1 until 5) {
+            val a = TAU * i / 5f
+            val c = cos(a)
+            val s = sin(a)
+            context.lineTo(s * r, -c * r)
+            context.lineTo(c * x - s * y, s * x + c * y)
+        }
+        context.close()
+    }
+}
+
+/** An upward-pointing equilateral triangle. */
+public object Triangle : SymbolType {
+    private val sqrt3: Float = sqrt(3f)
+
+    override fun draw(context: PathBuilder<*>, size: Float) {
+        val y = -sqrt(size / (sqrt3 * 3f))
+        context.moveTo(0f, y * 2f)
+        context.lineTo(-sqrt3 * y, -y)
+        context.lineTo(sqrt3 * y, -y)
+        context.close()
+    }
+}
+
+/** A "Y" shape. */
+public object Wye : SymbolType {
+    private const val C: Float = -0.5f
+    private val s: Float = sqrt(3f) / 2f
+    private val k: Float = 1f / sqrt(12f)
+    private val a: Float = (k / 2f + 1f) * 3f
+
+    override fun draw(context: PathBuilder<*>, size: Float) {
+        val r = sqrt(size / a)
+        val x0 = r / 2f
+        val y0 = r * k
+        val x1 = x0
+        val y1 = r * k + r
+        val x2 = -x1
+        val y2 = y1
+        context.moveTo(x0, y0)
+        context.lineTo(x1, y1)
+        context.lineTo(x2, y2)
+        context.lineTo(C * x0 - s * y0, s * x0 + C * y0)
+        context.lineTo(C * x1 - s * y1, s * x1 + C * y1)
+        context.lineTo(C * x2 - s * y2, s * x2 + C * y2)
+        context.lineTo(C * x0 + s * y0, C * y0 - s * x0)
+        context.lineTo(C * x1 + s * y1, C * y1 - s * x1)
+        context.lineTo(C * x2 + s * y2, C * y2 - s * x2)
+        context.close()
+    }
+}
+
+/** A plus sign drawn as two crossing strokes (intended to be stroked). */
+public object Plus : SymbolType {
+    override fun draw(context: PathBuilder<*>, size: Float) {
+        val r = sqrt(size - min(size / 7f, 2f)) * 0.87559f
+        context.moveTo(-r, 0f)
+        context.lineTo(r, 0f)
+        context.moveTo(0f, r)
+        context.lineTo(0f, -r)
+    }
+}
+
+/** An "X" drawn as two crossing strokes (intended to be stroked). */
+public object Times : SymbolType {
+    override fun draw(context: PathBuilder<*>, size: Float) {
+        val r = sqrt(size - min(size / 6f, 1.7f)) * 0.6189f
+        context.moveTo(-r, -r)
+        context.lineTo(r, r)
+        context.moveTo(-r, r)
+        context.lineTo(r, -r)
+    }
+}
+
+/** A six-armed asterisk drawn as three crossing strokes (intended to be stroked). */
+public object Asterisk : SymbolType {
+    private val sqrt3: Float = sqrt(3f)
+
+    override fun draw(context: PathBuilder<*>, size: Float) {
+        val r = sqrt(size + min(size / 28f, 0.75f)) * 0.59436f
+        val t = r / 2f
+        val u = t * sqrt3
+        context.moveTo(0f, r)
+        context.lineTo(0f, -r)
+        context.moveTo(-u, -t)
+        context.lineTo(u, t)
+        context.moveTo(-u, t)
+        context.lineTo(u, -t)
+    }
+}
+
+/** Symbol types designed to be filled, matching `d3.symbolsFill`. */
+public val symbolsFill: List<SymbolType> = listOf(Circle, Cross, Diamond, Square, Star, Triangle, Wye)
+
+/** Symbol types designed to be stroked, matching the in-scope subset of `d3.symbolsStroke`. */
+public val symbolsStroke: List<SymbolType> = listOf(Circle, Plus, Times, Asterisk)

--- a/shape/src/commonMain/kotlin/curve/Basis.kt
+++ b/shape/src/commonMain/kotlin/curve/Basis.kt
@@ -1,0 +1,62 @@
+package com.juul.krayon.shape.curve
+
+import com.juul.krayon.kanvas.PathBuilder
+import kotlin.Float.Companion.NaN
+
+/** B-spline curve. Ported from [d3-shape](https://github.com/d3/d3-shape/blob/main/src/curve/basis.js). */
+public object Basis : Curve {
+    private var x0: Float = NaN
+    private var y0: Float = NaN
+    private var x1: Float = NaN
+    private var y1: Float = NaN
+    private var line: Float = NaN
+    private var point: Int = 0
+
+    override fun startArea(context: PathBuilder<*>) {
+        line = 0f
+    }
+
+    override fun endArea(context: PathBuilder<*>) {
+        line = NaN
+    }
+
+    override fun startLine(context: PathBuilder<*>) {
+        x0 = NaN
+        y0 = NaN
+        x1 = NaN
+        y1 = NaN
+        point = 0
+    }
+
+    override fun endLine(context: PathBuilder<*>) {
+        when (point) {
+            3 -> {
+                basisPoint(context, x0, y0, x1, y1, x1, y1)
+                context.lineTo(x1, y1)
+            }
+            2 -> context.lineTo(x1, y1)
+        }
+        if (line.truthy() || (line != 0f && point == 1)) context.close()
+        line = 1f - line
+    }
+
+    override fun point(context: PathBuilder<*>, x: Float, y: Float) {
+        when (point) {
+            0 -> {
+                point = 1
+                if (line.truthy()) context.lineTo(x, y) else context.moveTo(x, y)
+            }
+            1 -> point = 2
+            2 -> {
+                point = 3
+                context.lineTo((5 * x0 + x1) / 6, (5 * y0 + y1) / 6)
+                basisPoint(context, x0, y0, x1, y1, x, y)
+            }
+            else -> basisPoint(context, x0, y0, x1, y1, x, y)
+        }
+        x0 = x1
+        x1 = x
+        y0 = y1
+        y1 = y
+    }
+}

--- a/shape/src/commonMain/kotlin/curve/BasisClosed.kt
+++ b/shape/src/commonMain/kotlin/curve/BasisClosed.kt
@@ -1,0 +1,82 @@
+package com.juul.krayon.shape.curve
+
+import com.juul.krayon.kanvas.PathBuilder
+import kotlin.Float.Companion.NaN
+
+/** Closed B-spline curve. Ported from [d3-shape](https://github.com/d3/d3-shape/blob/main/src/curve/basisClosed.js). */
+public object BasisClosed : Curve {
+    private var x0: Float = NaN
+    private var y0: Float = NaN
+    private var x1: Float = NaN
+    private var y1: Float = NaN
+    private var x2: Float = NaN
+    private var y2: Float = NaN
+    private var x3: Float = NaN
+    private var y3: Float = NaN
+    private var x4: Float = NaN
+    private var y4: Float = NaN
+    private var point: Int = 0
+
+    override fun startArea(context: PathBuilder<*>) {}
+
+    override fun endArea(context: PathBuilder<*>) {}
+
+    override fun startLine(context: PathBuilder<*>) {
+        x0 = NaN
+        y0 = NaN
+        x1 = NaN
+        y1 = NaN
+        x2 = NaN
+        y2 = NaN
+        x3 = NaN
+        y3 = NaN
+        x4 = NaN
+        y4 = NaN
+        point = 0
+    }
+
+    override fun endLine(context: PathBuilder<*>) {
+        when (point) {
+            1 -> {
+                context.moveTo(x2, y2)
+                context.close()
+            }
+            2 -> {
+                context.moveTo((x2 + 2 * x3) / 3, (y2 + 2 * y3) / 3)
+                context.lineTo((x3 + 2 * x2) / 3, (y3 + 2 * y2) / 3)
+                context.close()
+            }
+            3 -> {
+                point(context, x2, y2)
+                point(context, x3, y3)
+                point(context, x4, y4)
+            }
+        }
+    }
+
+    override fun point(context: PathBuilder<*>, x: Float, y: Float) {
+        when (point) {
+            0 -> {
+                point = 1
+                x2 = x
+                y2 = y
+            }
+            1 -> {
+                point = 2
+                x3 = x
+                y3 = y
+            }
+            2 -> {
+                point = 3
+                x4 = x
+                y4 = y
+                context.moveTo((x0 + 4 * x1 + x) / 6, (y0 + 4 * y1 + y) / 6)
+            }
+            else -> basisPoint(context, x0, y0, x1, y1, x, y)
+        }
+        x0 = x1
+        x1 = x
+        y0 = y1
+        y1 = y
+    }
+}

--- a/shape/src/commonMain/kotlin/curve/BasisOpen.kt
+++ b/shape/src/commonMain/kotlin/curve/BasisOpen.kt
@@ -1,0 +1,57 @@
+package com.juul.krayon.shape.curve
+
+import com.juul.krayon.kanvas.PathBuilder
+import kotlin.Float.Companion.NaN
+
+/** Open B-spline curve. Ported from [d3-shape](https://github.com/d3/d3-shape/blob/main/src/curve/basisOpen.js). */
+public object BasisOpen : Curve {
+    private var x0: Float = NaN
+    private var y0: Float = NaN
+    private var x1: Float = NaN
+    private var y1: Float = NaN
+    private var line: Float = NaN
+    private var point: Int = 0
+
+    override fun startArea(context: PathBuilder<*>) {
+        line = 0f
+    }
+
+    override fun endArea(context: PathBuilder<*>) {
+        line = NaN
+    }
+
+    override fun startLine(context: PathBuilder<*>) {
+        x0 = NaN
+        y0 = NaN
+        x1 = NaN
+        y1 = NaN
+        point = 0
+    }
+
+    override fun endLine(context: PathBuilder<*>) {
+        if (line.truthy() || (line != 0f && point == 3)) context.close()
+        line = 1f - line
+    }
+
+    override fun point(context: PathBuilder<*>, x: Float, y: Float) {
+        when (point) {
+            0 -> point = 1
+            1 -> point = 2
+            2 -> {
+                point = 3
+                val x0z = (x0 + 4 * x1 + x) / 6
+                val y0z = (y0 + 4 * y1 + y) / 6
+                if (line.truthy()) context.lineTo(x0z, y0z) else context.moveTo(x0z, y0z)
+            }
+            3 -> {
+                point = 4
+                basisPoint(context, x0, y0, x1, y1, x, y)
+            }
+            else -> basisPoint(context, x0, y0, x1, y1, x, y)
+        }
+        x0 = x1
+        x1 = x
+        y0 = y1
+        y1 = y
+    }
+}

--- a/shape/src/commonMain/kotlin/curve/Bump.kt
+++ b/shape/src/commonMain/kotlin/curve/Bump.kt
@@ -1,0 +1,56 @@
+package com.juul.krayon.shape.curve
+
+import com.juul.krayon.kanvas.PathBuilder
+import kotlin.Float.Companion.NaN
+
+/** Bump curve. Ported from [d3-shape](https://github.com/d3/d3-shape/blob/main/src/curve/bump.js). */
+internal class Bump(private val isX: Boolean) : Curve {
+    private var x0: Float = NaN
+    private var y0: Float = NaN
+    private var line: Float = NaN
+    private var point: Int = 0
+
+    override fun startArea(context: PathBuilder<*>) {
+        line = 0f
+    }
+
+    override fun endArea(context: PathBuilder<*>) {
+        line = NaN
+    }
+
+    override fun startLine(context: PathBuilder<*>) {
+        point = 0
+    }
+
+    override fun endLine(context: PathBuilder<*>) {
+        if (line.truthy() || (line != 0f && point == 1)) context.close()
+        line = 1f - line
+    }
+
+    override fun point(context: PathBuilder<*>, x: Float, y: Float) {
+        when (point) {
+            0 -> {
+                point = 1
+                if (line.truthy()) context.lineTo(x, y) else context.moveTo(x, y)
+            }
+            else -> {
+                if (point == 1) point = 2
+                if (isX) {
+                    x0 = (x0 + x) / 2
+                    context.cubicTo(x0, y0, x0, y, x, y)
+                } else {
+                    y0 = (y0 + y) / 2
+                    context.cubicTo(x0, y0, x, y0, x, y)
+                }
+            }
+        }
+        x0 = x
+        y0 = y
+    }
+}
+
+/** Bump curve with horizontal tangents at the endpoints. */
+public object BumpX : Curve by Bump(isX = true)
+
+/** Bump curve with vertical tangents at the endpoints. */
+public object BumpY : Curve by Bump(isX = false)

--- a/shape/src/commonMain/kotlin/curve/Cardinal.kt
+++ b/shape/src/commonMain/kotlin/curve/Cardinal.kt
@@ -1,0 +1,72 @@
+package com.juul.krayon.shape.curve
+
+import com.juul.krayon.kanvas.PathBuilder
+import kotlin.Float.Companion.NaN
+
+/**
+ * Cardinal spline curve. The [tension] (default `0`) determines the length of the tangents.
+ * Ported from [d3-shape](https://github.com/d3/d3-shape/blob/main/src/curve/cardinal.js).
+ */
+public class Cardinal(tension: Float = 0f) : Curve {
+    private val k: Float = (1f - tension) / 6f
+    private var x0: Float = NaN
+    private var y0: Float = NaN
+    private var x1: Float = NaN
+    private var y1: Float = NaN
+    private var x2: Float = NaN
+    private var y2: Float = NaN
+    private var line: Float = NaN
+    private var point: Int = 0
+
+    override fun startArea(context: PathBuilder<*>) {
+        line = 0f
+    }
+
+    override fun endArea(context: PathBuilder<*>) {
+        line = NaN
+    }
+
+    override fun startLine(context: PathBuilder<*>) {
+        x0 = NaN
+        y0 = NaN
+        x1 = NaN
+        y1 = NaN
+        x2 = NaN
+        y2 = NaN
+        point = 0
+    }
+
+    override fun endLine(context: PathBuilder<*>) {
+        when (point) {
+            2 -> context.lineTo(x2, y2)
+            3 -> cardinalPoint(context, k, x0, y0, x1, y1, x2, y2, x1, y1)
+        }
+        if (line.truthy() || (line != 0f && point == 1)) context.close()
+        line = 1f - line
+    }
+
+    override fun point(context: PathBuilder<*>, x: Float, y: Float) {
+        when (point) {
+            0 -> {
+                point = 1
+                if (line.truthy()) context.lineTo(x, y) else context.moveTo(x, y)
+            }
+            1 -> {
+                point = 2
+                x1 = x
+                y1 = y
+            }
+            2 -> {
+                point = 3
+                cardinalPoint(context, k, x0, y0, x1, y1, x2, y2, x, y)
+            }
+            else -> cardinalPoint(context, k, x0, y0, x1, y1, x2, y2, x, y)
+        }
+        x0 = x1
+        x1 = x2
+        x2 = x
+        y0 = y1
+        y1 = y2
+        y2 = y
+    }
+}

--- a/shape/src/commonMain/kotlin/curve/CardinalClosed.kt
+++ b/shape/src/commonMain/kotlin/curve/CardinalClosed.kt
@@ -1,0 +1,91 @@
+package com.juul.krayon.shape.curve
+
+import com.juul.krayon.kanvas.PathBuilder
+import kotlin.Float.Companion.NaN
+
+/**
+ * Closed cardinal spline curve. Ported from
+ * [d3-shape](https://github.com/d3/d3-shape/blob/main/src/curve/cardinalClosed.js).
+ */
+public class CardinalClosed(tension: Float = 0f) : Curve {
+    private val k: Float = (1f - tension) / 6f
+    private var x0: Float = NaN
+    private var y0: Float = NaN
+    private var x1: Float = NaN
+    private var y1: Float = NaN
+    private var x2: Float = NaN
+    private var y2: Float = NaN
+    private var x3: Float = NaN
+    private var y3: Float = NaN
+    private var x4: Float = NaN
+    private var y4: Float = NaN
+    private var x5: Float = NaN
+    private var y5: Float = NaN
+    private var point: Int = 0
+
+    override fun startArea(context: PathBuilder<*>) {}
+
+    override fun endArea(context: PathBuilder<*>) {}
+
+    override fun startLine(context: PathBuilder<*>) {
+        x0 = NaN
+        y0 = NaN
+        x1 = NaN
+        y1 = NaN
+        x2 = NaN
+        y2 = NaN
+        x3 = NaN
+        y3 = NaN
+        x4 = NaN
+        y4 = NaN
+        x5 = NaN
+        y5 = NaN
+        point = 0
+    }
+
+    override fun endLine(context: PathBuilder<*>) {
+        when (point) {
+            1 -> {
+                context.moveTo(x3, y3)
+                context.close()
+            }
+            2 -> {
+                context.lineTo(x3, y3)
+                context.close()
+            }
+            3 -> {
+                point(context, x3, y3)
+                point(context, x4, y4)
+                point(context, x5, y5)
+            }
+        }
+    }
+
+    override fun point(context: PathBuilder<*>, x: Float, y: Float) {
+        when (point) {
+            0 -> {
+                point = 1
+                x3 = x
+                y3 = y
+            }
+            1 -> {
+                point = 2
+                x4 = x
+                y4 = y
+                context.moveTo(x4, y4)
+            }
+            2 -> {
+                point = 3
+                x5 = x
+                y5 = y
+            }
+            else -> cardinalPoint(context, k, x0, y0, x1, y1, x2, y2, x, y)
+        }
+        x0 = x1
+        x1 = x2
+        x2 = x
+        y0 = y1
+        y1 = y2
+        y2 = y
+    }
+}

--- a/shape/src/commonMain/kotlin/curve/CardinalOpen.kt
+++ b/shape/src/commonMain/kotlin/curve/CardinalOpen.kt
@@ -1,0 +1,65 @@
+package com.juul.krayon.shape.curve
+
+import com.juul.krayon.kanvas.PathBuilder
+import kotlin.Float.Companion.NaN
+
+/**
+ * Open cardinal spline curve. Ported from
+ * [d3-shape](https://github.com/d3/d3-shape/blob/main/src/curve/cardinalOpen.js).
+ */
+public class CardinalOpen(tension: Float = 0f) : Curve {
+    private val k: Float = (1f - tension) / 6f
+    private var x0: Float = NaN
+    private var y0: Float = NaN
+    private var x1: Float = NaN
+    private var y1: Float = NaN
+    private var x2: Float = NaN
+    private var y2: Float = NaN
+    private var line: Float = NaN
+    private var point: Int = 0
+
+    override fun startArea(context: PathBuilder<*>) {
+        line = 0f
+    }
+
+    override fun endArea(context: PathBuilder<*>) {
+        line = NaN
+    }
+
+    override fun startLine(context: PathBuilder<*>) {
+        x0 = NaN
+        y0 = NaN
+        x1 = NaN
+        y1 = NaN
+        x2 = NaN
+        y2 = NaN
+        point = 0
+    }
+
+    override fun endLine(context: PathBuilder<*>) {
+        if (line.truthy() || (line != 0f && point == 3)) context.close()
+        line = 1f - line
+    }
+
+    override fun point(context: PathBuilder<*>, x: Float, y: Float) {
+        when (point) {
+            0 -> point = 1
+            1 -> point = 2
+            2 -> {
+                point = 3
+                if (line.truthy()) context.lineTo(x2, y2) else context.moveTo(x2, y2)
+            }
+            3 -> {
+                point = 4
+                cardinalPoint(context, k, x0, y0, x1, y1, x2, y2, x, y)
+            }
+            else -> cardinalPoint(context, k, x0, y0, x1, y1, x2, y2, x, y)
+        }
+        x0 = x1
+        x1 = x2
+        x2 = x
+        y0 = y1
+        y1 = y2
+        y2 = y
+    }
+}

--- a/shape/src/commonMain/kotlin/curve/CatmullRom.kt
+++ b/shape/src/commonMain/kotlin/curve/CatmullRom.kt
@@ -1,0 +1,135 @@
+package com.juul.krayon.shape.curve
+
+import com.juul.krayon.kanvas.PathBuilder
+import kotlin.Float.Companion.NaN
+import kotlin.math.pow
+import kotlin.math.sqrt
+
+internal fun catmullRomPoint(
+    context: PathBuilder<*>,
+    x0: Float,
+    y0: Float,
+    x1: Float,
+    y1: Float,
+    x2: Float,
+    y2: Float,
+    l01a: Float,
+    l012a: Float,
+    l12a: Float,
+    l122a: Float,
+    l23a: Float,
+    l232a: Float,
+    x: Float,
+    y: Float,
+) {
+    var cx1 = x1
+    var cy1 = y1
+    var cx2 = x2
+    var cy2 = y2
+
+    if (l01a > EPSILON) {
+        val a = 2 * l012a + 3 * l01a * l12a + l122a
+        val n = 3 * l01a * (l01a + l12a)
+        cx1 = (x1 * a - x0 * l122a + x2 * l012a) / n
+        cy1 = (y1 * a - y0 * l122a + y2 * l012a) / n
+    }
+
+    if (l23a > EPSILON) {
+        val b = 2 * l232a + 3 * l23a * l12a + l122a
+        val m = 3 * l23a * (l23a + l12a)
+        cx2 = (x2 * b + x1 * l232a - x * l122a) / m
+        cy2 = (y2 * b + y1 * l232a - y * l122a) / m
+    }
+
+    context.cubicTo(cx1, cy1, cx2, cy2, x2, y2)
+}
+
+/**
+ * Catmull–Rom spline curve. The [alpha] (default `0.5`, centripetal) controls the parameterization.
+ * An [alpha] of `0` degenerates to a uniform [Cardinal] spline, matching
+ * [d3-shape](https://github.com/d3/d3-shape/blob/main/src/curve/catmullRom.js).
+ */
+public class CatmullRom(alpha: Float = 0.5f) : Curve by (if (alpha != 0f) CatmullRomCurve(alpha) else Cardinal(0f))
+
+internal class CatmullRomCurve(private val alpha: Float) : Curve {
+    private var x0: Float = NaN
+    private var y0: Float = NaN
+    private var x1: Float = NaN
+    private var y1: Float = NaN
+    private var x2: Float = NaN
+    private var y2: Float = NaN
+    private var l01a: Float = 0f
+    private var l12a: Float = 0f
+    private var l23a: Float = 0f
+    private var l012a: Float = 0f
+    private var l122a: Float = 0f
+    private var l232a: Float = 0f
+    private var line: Float = NaN
+    private var point: Int = 0
+
+    override fun startArea(context: PathBuilder<*>) {
+        line = 0f
+    }
+
+    override fun endArea(context: PathBuilder<*>) {
+        line = NaN
+    }
+
+    override fun startLine(context: PathBuilder<*>) {
+        x0 = NaN
+        y0 = NaN
+        x1 = NaN
+        y1 = NaN
+        x2 = NaN
+        y2 = NaN
+        l01a = 0f
+        l12a = 0f
+        l23a = 0f
+        l012a = 0f
+        l122a = 0f
+        l232a = 0f
+        point = 0
+    }
+
+    override fun endLine(context: PathBuilder<*>) {
+        when (point) {
+            2 -> context.lineTo(x2, y2)
+            3 -> point(context, x2, y2)
+        }
+        if (line.truthy() || (line != 0f && point == 1)) context.close()
+        line = 1f - line
+    }
+
+    override fun point(context: PathBuilder<*>, x: Float, y: Float) {
+        if (point != 0) {
+            val x23 = x2 - x
+            val y23 = y2 - y
+            l232a = (x23 * x23 + y23 * y23).pow(alpha)
+            l23a = sqrt(l232a)
+        }
+
+        when (point) {
+            0 -> {
+                point = 1
+                if (line.truthy()) context.lineTo(x, y) else context.moveTo(x, y)
+            }
+            1 -> point = 2
+            2 -> {
+                point = 3
+                catmullRomPoint(context, x0, y0, x1, y1, x2, y2, l01a, l012a, l12a, l122a, l23a, l232a, x, y)
+            }
+            else -> catmullRomPoint(context, x0, y0, x1, y1, x2, y2, l01a, l012a, l12a, l122a, l23a, l232a, x, y)
+        }
+
+        l01a = l12a
+        l12a = l23a
+        l012a = l122a
+        l122a = l232a
+        x0 = x1
+        x1 = x2
+        x2 = x
+        y0 = y1
+        y1 = y2
+        y2 = y
+    }
+}

--- a/shape/src/commonMain/kotlin/curve/CatmullRomClosed.kt
+++ b/shape/src/commonMain/kotlin/curve/CatmullRomClosed.kt
@@ -1,0 +1,119 @@
+package com.juul.krayon.shape.curve
+
+import com.juul.krayon.kanvas.PathBuilder
+import kotlin.Float.Companion.NaN
+import kotlin.math.pow
+import kotlin.math.sqrt
+
+/**
+ * Closed Catmull–Rom spline curve. An [alpha] of `0` degenerates to a uniform [CardinalClosed]
+ * spline, matching [d3-shape](https://github.com/d3/d3-shape/blob/main/src/curve/catmullRomClosed.js).
+ */
+public class CatmullRomClosed(alpha: Float = 0.5f) :
+    Curve by (if (alpha != 0f) CatmullRomClosedCurve(alpha) else CardinalClosed(0f))
+
+internal class CatmullRomClosedCurve(private val alpha: Float) : Curve {
+    private var x0: Float = NaN
+    private var y0: Float = NaN
+    private var x1: Float = NaN
+    private var y1: Float = NaN
+    private var x2: Float = NaN
+    private var y2: Float = NaN
+    private var x3: Float = NaN
+    private var y3: Float = NaN
+    private var x4: Float = NaN
+    private var y4: Float = NaN
+    private var x5: Float = NaN
+    private var y5: Float = NaN
+    private var l01a: Float = 0f
+    private var l12a: Float = 0f
+    private var l23a: Float = 0f
+    private var l012a: Float = 0f
+    private var l122a: Float = 0f
+    private var l232a: Float = 0f
+    private var point: Int = 0
+
+    override fun startArea(context: PathBuilder<*>) {}
+
+    override fun endArea(context: PathBuilder<*>) {}
+
+    override fun startLine(context: PathBuilder<*>) {
+        x0 = NaN
+        y0 = NaN
+        x1 = NaN
+        y1 = NaN
+        x2 = NaN
+        y2 = NaN
+        x3 = NaN
+        y3 = NaN
+        x4 = NaN
+        y4 = NaN
+        x5 = NaN
+        y5 = NaN
+        l01a = 0f
+        l12a = 0f
+        l23a = 0f
+        l012a = 0f
+        l122a = 0f
+        l232a = 0f
+        point = 0
+    }
+
+    override fun endLine(context: PathBuilder<*>) {
+        when (point) {
+            1 -> {
+                context.moveTo(x3, y3)
+                context.close()
+            }
+            2 -> {
+                context.lineTo(x3, y3)
+                context.close()
+            }
+            3 -> {
+                point(context, x3, y3)
+                point(context, x4, y4)
+                point(context, x5, y5)
+            }
+        }
+    }
+
+    override fun point(context: PathBuilder<*>, x: Float, y: Float) {
+        if (point != 0) {
+            val x23 = x2 - x
+            val y23 = y2 - y
+            l232a = (x23 * x23 + y23 * y23).pow(alpha)
+            l23a = sqrt(l232a)
+        }
+
+        when (point) {
+            0 -> {
+                point = 1
+                x3 = x
+                y3 = y
+            }
+            1 -> {
+                point = 2
+                x4 = x
+                y4 = y
+                context.moveTo(x4, y4)
+            }
+            2 -> {
+                point = 3
+                x5 = x
+                y5 = y
+            }
+            else -> catmullRomPoint(context, x0, y0, x1, y1, x2, y2, l01a, l012a, l12a, l122a, l23a, l232a, x, y)
+        }
+
+        l01a = l12a
+        l12a = l23a
+        l012a = l122a
+        l122a = l232a
+        x0 = x1
+        x1 = x2
+        x2 = x
+        y0 = y1
+        y1 = y2
+        y2 = y
+    }
+}

--- a/shape/src/commonMain/kotlin/curve/CatmullRomOpen.kt
+++ b/shape/src/commonMain/kotlin/curve/CatmullRomOpen.kt
@@ -1,0 +1,93 @@
+package com.juul.krayon.shape.curve
+
+import com.juul.krayon.kanvas.PathBuilder
+import kotlin.Float.Companion.NaN
+import kotlin.math.pow
+import kotlin.math.sqrt
+
+/**
+ * Open Catmull–Rom spline curve. An [alpha] of `0` degenerates to a uniform [CardinalOpen] spline,
+ * matching [d3-shape](https://github.com/d3/d3-shape/blob/main/src/curve/catmullRomOpen.js).
+ */
+public class CatmullRomOpen(alpha: Float = 0.5f) :
+    Curve by (if (alpha != 0f) CatmullRomOpenCurve(alpha) else CardinalOpen(0f))
+
+internal class CatmullRomOpenCurve(private val alpha: Float) : Curve {
+    private var x0: Float = NaN
+    private var y0: Float = NaN
+    private var x1: Float = NaN
+    private var y1: Float = NaN
+    private var x2: Float = NaN
+    private var y2: Float = NaN
+    private var l01a: Float = 0f
+    private var l12a: Float = 0f
+    private var l23a: Float = 0f
+    private var l012a: Float = 0f
+    private var l122a: Float = 0f
+    private var l232a: Float = 0f
+    private var line: Float = NaN
+    private var point: Int = 0
+
+    override fun startArea(context: PathBuilder<*>) {
+        line = 0f
+    }
+
+    override fun endArea(context: PathBuilder<*>) {
+        line = NaN
+    }
+
+    override fun startLine(context: PathBuilder<*>) {
+        x0 = NaN
+        y0 = NaN
+        x1 = NaN
+        y1 = NaN
+        x2 = NaN
+        y2 = NaN
+        l01a = 0f
+        l12a = 0f
+        l23a = 0f
+        l012a = 0f
+        l122a = 0f
+        l232a = 0f
+        point = 0
+    }
+
+    override fun endLine(context: PathBuilder<*>) {
+        if (line.truthy() || (line != 0f && point == 3)) context.close()
+        line = 1f - line
+    }
+
+    override fun point(context: PathBuilder<*>, x: Float, y: Float) {
+        if (point != 0) {
+            val x23 = x2 - x
+            val y23 = y2 - y
+            l232a = (x23 * x23 + y23 * y23).pow(alpha)
+            l23a = sqrt(l232a)
+        }
+
+        when (point) {
+            0 -> point = 1
+            1 -> point = 2
+            2 -> {
+                point = 3
+                if (line.truthy()) context.lineTo(x2, y2) else context.moveTo(x2, y2)
+            }
+            3 -> {
+                point = 4
+                catmullRomPoint(context, x0, y0, x1, y1, x2, y2, l01a, l012a, l12a, l122a, l23a, l232a, x, y)
+            }
+            else -> catmullRomPoint(context, x0, y0, x1, y1, x2, y2, l01a, l012a, l12a, l122a, l23a, l232a, x, y)
+        }
+
+        l01a = l12a
+        l12a = l23a
+        l012a = l122a
+        l122a = l232a
+        x0 = x1
+        x1 = x2
+        x2 = x
+        y0 = y1
+        y1 = y2
+        y2 = y
+    }
+}

--- a/shape/src/commonMain/kotlin/curve/Internal.kt
+++ b/shape/src/commonMain/kotlin/curve/Internal.kt
@@ -1,0 +1,49 @@
+package com.juul.krayon.shape.curve
+
+import com.juul.krayon.kanvas.PathBuilder
+
+internal const val EPSILON: Float = 1e-12f
+
+/** Emulate JS truthiness for `NaN`/`0` sentinels used by the D3 curve algorithms. */
+internal fun Float.truthy(): Boolean = !isNaN() && this != 0f
+
+internal fun basisPoint(
+    context: PathBuilder<*>,
+    x0: Float,
+    y0: Float,
+    x1: Float,
+    y1: Float,
+    x: Float,
+    y: Float,
+) {
+    context.cubicTo(
+        (2 * x0 + x1) / 3,
+        (2 * y0 + y1) / 3,
+        (x0 + 2 * x1) / 3,
+        (y0 + 2 * y1) / 3,
+        (x0 + 4 * x1 + x) / 6,
+        (y0 + 4 * y1 + y) / 6,
+    )
+}
+
+internal fun cardinalPoint(
+    context: PathBuilder<*>,
+    k: Float,
+    x0: Float,
+    y0: Float,
+    x1: Float,
+    y1: Float,
+    x2: Float,
+    y2: Float,
+    x: Float,
+    y: Float,
+) {
+    context.cubicTo(
+        x1 + k * (x2 - x0),
+        y1 + k * (y2 - y0),
+        x2 + k * (x1 - x),
+        y2 + k * (y1 - y),
+        x2,
+        y2,
+    )
+}

--- a/shape/src/commonMain/kotlin/curve/Linear.kt
+++ b/shape/src/commonMain/kotlin/curve/Linear.kt
@@ -46,6 +46,3 @@ public object Linear : Curve {
         }
     }
 }
-
-/** Emulate JS truthiness. */
-private fun Float.truthy(): Boolean = (!this.isNaN() && this != 0f)

--- a/shape/src/commonMain/kotlin/curve/LinearClosed.kt
+++ b/shape/src/commonMain/kotlin/curve/LinearClosed.kt
@@ -1,0 +1,29 @@
+package com.juul.krayon.shape.curve
+
+import com.juul.krayon.kanvas.PathBuilder
+
+/** Closed polyline curve. Ported from [d3-shape](https://github.com/d3/d3-shape/blob/main/src/curve/linearClosed.js). */
+public object LinearClosed : Curve {
+    private var point: Int = 0
+
+    override fun startArea(context: PathBuilder<*>) {}
+
+    override fun endArea(context: PathBuilder<*>) {}
+
+    override fun startLine(context: PathBuilder<*>) {
+        point = 0
+    }
+
+    override fun endLine(context: PathBuilder<*>) {
+        if (point != 0) context.close()
+    }
+
+    override fun point(context: PathBuilder<*>, x: Float, y: Float) {
+        if (point != 0) {
+            context.lineTo(x, y)
+        } else {
+            point = 1
+            context.moveTo(x, y)
+        }
+    }
+}

--- a/shape/src/commonMain/kotlin/curve/Monotone.kt
+++ b/shape/src/commonMain/kotlin/curve/Monotone.kt
@@ -1,0 +1,179 @@
+package com.juul.krayon.shape.curve
+
+import com.juul.krayon.kanvas.PathBuilder
+import kotlin.Float.Companion.NaN
+import kotlin.math.abs
+
+/**
+ * Monotone cubic spline curve. Ported from
+ * [d3-shape](https://github.com/d3/d3-shape/blob/main/src/curve/monotone.js).
+ */
+internal class MonotoneCurve(private val reflect: Boolean) : Curve {
+    private var x0: Float = NaN
+    private var y0: Float = NaN
+    private var x1: Float = NaN
+    private var y1: Float = NaN
+    private var t0: Float = NaN
+    private var line: Float = NaN
+    private var point: Int = 0
+
+    override fun startArea(context: PathBuilder<*>) {
+        line = 0f
+    }
+
+    override fun endArea(context: PathBuilder<*>) {
+        line = NaN
+    }
+
+    override fun startLine(context: PathBuilder<*>) {
+        x0 = NaN
+        y0 = NaN
+        x1 = NaN
+        y1 = NaN
+        t0 = NaN
+        point = 0
+    }
+
+    override fun endLine(context: PathBuilder<*>) {
+        val ctx = if (reflect) ReflectPathBuilder(context) else context
+        when (point) {
+            2 -> ctx.lineTo(x1, y1)
+            3 -> monotonePoint(ctx, x0, y0, x1, y1, t0, slope2(x0, y0, x1, y1, t0))
+        }
+        if (line.truthy() || (line != 0f && point == 1)) ctx.close()
+        line = 1f - line
+    }
+
+    override fun point(context: PathBuilder<*>, x: Float, y: Float) {
+        val ctx = if (reflect) ReflectPathBuilder(context) else context
+        if (reflect) doPoint(ctx, y, x) else doPoint(ctx, x, y)
+    }
+
+    private fun doPoint(context: PathBuilder<*>, x: Float, y: Float) {
+        var t1 = NaN
+        if (x == x1 && y == y1) return
+
+        when (point) {
+            0 -> {
+                point = 1
+                if (line.truthy()) context.lineTo(x, y) else context.moveTo(x, y)
+            }
+            1 -> point = 2
+            2 -> {
+                point = 3
+                t1 = slope3(x0, y0, x1, y1, x, y)
+                monotonePoint(context, x0, y0, x1, y1, slope2(x0, y0, x1, y1, t1), t1)
+            }
+            else -> {
+                t1 = slope3(x0, y0, x1, y1, x, y)
+                monotonePoint(context, x0, y0, x1, y1, t0, t1)
+            }
+        }
+
+        x0 = x1
+        x1 = x
+        y0 = y1
+        y1 = y
+        t0 = t1
+    }
+}
+
+/** Monotone cubic spline where monotonicity is preserved along `x`. */
+public object MonotoneX : Curve by MonotoneCurve(reflect = false)
+
+/** Monotone cubic spline where monotonicity is preserved along `y`. */
+public object MonotoneY : Curve by MonotoneCurve(reflect = true)
+
+private fun sign(x: Float): Float = if (x < 0f) -1f else 1f
+
+private fun slope3(x0: Float, y0: Float, x1: Float, y1: Float, x2: Float, y2: Float): Float {
+    val h0 = x1 - x0
+    val h1 = x2 - x1
+    val d0 = if (h0 != 0f) {
+        h0
+    } else if (h1 < 0f) {
+        -0f
+    } else {
+        0f
+    }
+    val d1 = if (h1 != 0f) {
+        h1
+    } else if (h0 < 0f) {
+        -0f
+    } else {
+        0f
+    }
+    val s0 = (y1 - y0) / d0
+    val s1 = (y2 - y1) / d1
+    val p = (s0 * h1 + s1 * h0) / (h0 + h1)
+    val result = (sign(s0) + sign(s1)) * minOf(abs(s0), abs(s1), 0.5f * abs(p))
+    return if (result.isNaN() || result == 0f) 0f else result
+}
+
+private fun slope2(x0: Float, y0: Float, x1: Float, y1: Float, t: Float): Float {
+    val h = x1 - x0
+    return if (h != 0f) (3 * (y1 - y0) / h - t) / 2 else t
+}
+
+private fun monotonePoint(
+    context: PathBuilder<*>,
+    x0: Float,
+    y0: Float,
+    x1: Float,
+    y1: Float,
+    t0: Float,
+    t1: Float,
+) {
+    val dx = (x1 - x0) / 3
+    context.cubicTo(x0 + dx, y0 + dx * t0, x1 - dx, y1 - dx * t1, x1, y1)
+}
+
+private class ReflectPathBuilder(private val delegate: PathBuilder<*>) : PathBuilder<Unit> {
+    override fun moveTo(x: Float, y: Float): Unit = delegate.moveTo(y, x)
+
+    override fun lineTo(x: Float, y: Float): Unit = delegate.lineTo(y, x)
+
+    override fun cubicTo(
+        beginControlX: Float,
+        beginControlY: Float,
+        endControlX: Float,
+        endControlY: Float,
+        endX: Float,
+        endY: Float,
+    ): Unit = delegate.cubicTo(beginControlY, beginControlX, endControlY, endControlX, endY, endX)
+
+    override fun close(): Unit = delegate.close()
+
+    override fun relativeMoveTo(x: Float, y: Float): Unit = unsupported()
+
+    override fun relativeLineTo(x: Float, y: Float): Unit = unsupported()
+
+    override fun arcTo(
+        left: Float,
+        top: Float,
+        right: Float,
+        bottom: Float,
+        startAngle: Float,
+        sweepAngle: Float,
+        forceMoveTo: Boolean,
+    ): Unit = unsupported()
+
+    override fun quadraticTo(controlX: Float, controlY: Float, endX: Float, endY: Float): Unit = unsupported()
+
+    override fun relativeQuadraticTo(controlX: Float, controlY: Float, endX: Float, endY: Float): Unit = unsupported()
+
+    override fun relativeCubicTo(
+        beginControlX: Float,
+        beginControlY: Float,
+        endControlX: Float,
+        endControlY: Float,
+        endX: Float,
+        endY: Float,
+    ): Unit = unsupported()
+
+    override fun reset(): Unit = delegate.reset()
+
+    override fun build() {}
+
+    private fun unsupported(): Nothing = throw UnsupportedOperationException("Not used by monotone curves.")
+}

--- a/shape/src/commonMain/kotlin/curve/Natural.kt
+++ b/shape/src/commonMain/kotlin/curve/Natural.kt
@@ -1,0 +1,85 @@
+package com.juul.krayon.shape.curve
+
+import com.juul.krayon.kanvas.PathBuilder
+import kotlin.Float.Companion.NaN
+
+/** Natural cubic spline curve. Ported from [d3-shape](https://github.com/d3/d3-shape/blob/main/src/curve/natural.js). */
+public object Natural : Curve {
+    private val xs: MutableList<Float> = mutableListOf()
+    private val ys: MutableList<Float> = mutableListOf()
+    private var line: Float = NaN
+
+    override fun startArea(context: PathBuilder<*>) {
+        line = 0f
+    }
+
+    override fun endArea(context: PathBuilder<*>) {
+        line = NaN
+    }
+
+    override fun startLine(context: PathBuilder<*>) {
+        xs.clear()
+        ys.clear()
+    }
+
+    override fun endLine(context: PathBuilder<*>) {
+        val n = xs.size
+        if (n > 0) {
+            if (line.truthy()) context.lineTo(xs[0], ys[0]) else context.moveTo(xs[0], ys[0])
+            if (n == 2) {
+                context.lineTo(xs[1], ys[1])
+            } else if (n > 2) {
+                val px = controlPoints(xs)
+                val py = controlPoints(ys)
+                var i0 = 0
+                var i1 = 1
+                while (i1 < n) {
+                    context.cubicTo(px[0][i0], py[0][i0], px[1][i0], py[1][i0], xs[i1], ys[i1])
+                    i0++
+                    i1++
+                }
+            }
+        }
+        if (line.truthy() || (line != 0f && n == 1)) context.close()
+        line = 1f - line
+        xs.clear()
+        ys.clear()
+    }
+
+    override fun point(context: PathBuilder<*>, x: Float, y: Float) {
+        xs += x
+        ys += y
+    }
+}
+
+private fun controlPoints(x: List<Float>): Array<FloatArray> {
+    val n = x.size - 1
+    val a = FloatArray(n)
+    val b = FloatArray(n)
+    val r = FloatArray(n)
+    a[0] = 0f
+    b[0] = 2f
+    r[0] = x[0] + 2 * x[1]
+    for (i in 1 until n - 1) {
+        a[i] = 1f
+        b[i] = 4f
+        r[i] = 4 * x[i] + 2 * x[i + 1]
+    }
+    a[n - 1] = 2f
+    b[n - 1] = 7f
+    r[n - 1] = 8 * x[n - 1] + x[n]
+    for (i in 1 until n) {
+        val m = a[i] / b[i - 1]
+        b[i] -= m
+        r[i] -= m * r[i - 1]
+    }
+    a[n - 1] = r[n - 1] / b[n - 1]
+    for (i in n - 2 downTo 0) {
+        a[i] = (r[i] - a[i + 1]) / b[i]
+    }
+    b[n - 1] = (x[n] + a[n - 1]) / 2
+    for (i in 0 until n - 1) {
+        b[i] = 2 * x[i + 1] - a[i + 1]
+    }
+    return arrayOf(a, b)
+}

--- a/shape/src/commonMain/kotlin/curve/Step.kt
+++ b/shape/src/commonMain/kotlin/curve/Step.kt
@@ -1,0 +1,67 @@
+package com.juul.krayon.shape.curve
+
+import com.juul.krayon.kanvas.PathBuilder
+import kotlin.Float.Companion.NaN
+
+/** Piecewise constant curve. Ported from [d3-shape](https://github.com/d3/d3-shape/blob/main/src/curve/step.js). */
+internal class StepCurve(t: Float) : Curve {
+    private var t: Float = t
+    private var x: Float = NaN
+    private var y: Float = NaN
+    private var line: Float = NaN
+    private var point: Int = 0
+
+    override fun startArea(context: PathBuilder<*>) {
+        line = 0f
+    }
+
+    override fun endArea(context: PathBuilder<*>) {
+        line = NaN
+    }
+
+    override fun startLine(context: PathBuilder<*>) {
+        x = NaN
+        y = NaN
+        point = 0
+    }
+
+    override fun endLine(context: PathBuilder<*>) {
+        if (t > 0f && t < 1f && point == 2) context.lineTo(x, y)
+        if (line.truthy() || (line != 0f && point == 1)) context.close()
+        if (line >= 0f) {
+            t = 1f - t
+            line = 1f - line
+        }
+    }
+
+    override fun point(context: PathBuilder<*>, x: Float, y: Float) {
+        when (point) {
+            0 -> {
+                point = 1
+                if (line.truthy()) context.lineTo(x, y) else context.moveTo(x, y)
+            }
+            else -> {
+                if (point == 1) point = 2
+                if (t <= 0f) {
+                    context.lineTo(this.x, y)
+                    context.lineTo(x, y)
+                } else {
+                    val x1 = this.x * (1f - t) + x * t
+                    context.lineTo(x1, this.y)
+                    context.lineTo(x1, y)
+                }
+            }
+        }
+        this.x = x
+        this.y = y
+    }
+}
+
+/** Piecewise constant curve with the change occurring at the midpoint between adjacent points. */
+public object Step : Curve by StepCurve(0.5f)
+
+/** Piecewise constant curve with the change occurring before the current point (a vertical then horizontal step). */
+public object StepBefore : Curve by StepCurve(0f)
+
+/** Piecewise constant curve with the change occurring after the current point (a horizontal then vertical step). */
+public object StepAfter : Curve by StepCurve(1f)

--- a/shape/src/commonTest/kotlin/PathAssertions.kt
+++ b/shape/src/commonTest/kotlin/PathAssertions.kt
@@ -1,0 +1,103 @@
+package com.juul.krayon.shape
+
+import com.juul.krayon.kanvas.Path
+import com.juul.krayon.kanvas.PathBuilder
+import kotlin.test.assertEquals
+
+internal data class PathOp(val name: String, val args: List<Float>)
+
+internal class RecordingPathBuilder : PathBuilder<List<PathOp>> {
+    private val ops = mutableListOf<PathOp>()
+
+    override fun moveTo(x: Float, y: Float) {
+        ops += PathOp("M", listOf(x, y))
+    }
+
+    override fun relativeMoveTo(x: Float, y: Float) {
+        ops += PathOp("m", listOf(x, y))
+    }
+
+    override fun lineTo(x: Float, y: Float) {
+        ops += PathOp("L", listOf(x, y))
+    }
+
+    override fun relativeLineTo(x: Float, y: Float) {
+        ops += PathOp("l", listOf(x, y))
+    }
+
+    override fun arcTo(
+        left: Float,
+        top: Float,
+        right: Float,
+        bottom: Float,
+        startAngle: Float,
+        sweepAngle: Float,
+        forceMoveTo: Boolean,
+    ) {
+        ops += PathOp("A", listOf(left, top, right, bottom, startAngle, sweepAngle, if (forceMoveTo) 1f else 0f))
+    }
+
+    override fun quadraticTo(controlX: Float, controlY: Float, endX: Float, endY: Float) {
+        ops += PathOp("Q", listOf(controlX, controlY, endX, endY))
+    }
+
+    override fun relativeQuadraticTo(controlX: Float, controlY: Float, endX: Float, endY: Float) {
+        ops += PathOp("q", listOf(controlX, controlY, endX, endY))
+    }
+
+    override fun cubicTo(
+        beginControlX: Float,
+        beginControlY: Float,
+        endControlX: Float,
+        endControlY: Float,
+        endX: Float,
+        endY: Float,
+    ) {
+        ops += PathOp("C", listOf(beginControlX, beginControlY, endControlX, endControlY, endX, endY))
+    }
+
+    override fun relativeCubicTo(
+        beginControlX: Float,
+        beginControlY: Float,
+        endControlX: Float,
+        endControlY: Float,
+        endX: Float,
+        endY: Float,
+    ) {
+        ops += PathOp("c", listOf(beginControlX, beginControlY, endControlX, endControlY, endX, endY))
+    }
+
+    override fun close() {
+        ops += PathOp("Z", emptyList())
+    }
+
+    override fun reset() {
+        ops.clear()
+    }
+
+    override fun build(): List<PathOp> = ops.toList()
+}
+
+internal fun Path.ops(): List<PathOp> = buildWith(RecordingPathBuilder())
+
+/**
+ * Compares two paths command-by-command with floating-point tolerance. Unlike [Path.equals], this
+ * ignores tiny numeric differences (e.g. `Float` rounding versus the full-precision D3 fixtures).
+ */
+internal fun assertPathEquals(expected: Path, actual: Path, absoluteTolerance: Float = 1e-3f) {
+    val e = expected.ops()
+    val a = actual.ops()
+    assertEquals(e.size, a.size, "Different number of path commands.\nexpected: $e\nactual:   $a")
+    for (i in e.indices) {
+        assertEquals(e[i].name, a[i].name, "Different command at index $i.\nexpected: $e\nactual:   $a")
+        assertEquals(e[i].args.size, a[i].args.size, "Different argument count at index $i.\nexpected: $e\nactual:   $a")
+        for (j in e[i].args.indices) {
+            assertEquals(
+                expected = e[i].args[j],
+                actual = a[i].args[j],
+                absoluteTolerance = absoluteTolerance,
+                message = "Different argument $j of command $i.\nexpected: $e\nactual:   $a",
+            )
+        }
+    }
+}

--- a/shape/src/commonTest/kotlin/StackTest.kt
+++ b/shape/src/commonTest/kotlin/StackTest.kt
@@ -1,0 +1,133 @@
+package com.juul.krayon.shape
+
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+
+class StackTest {
+
+    private val data = listOf(
+        listOf(1f, 3f, 5f, 1f),
+        listOf(2f, 4f, 2f, 3f),
+        listOf(1f, 2f, 4f, 2f),
+    )
+
+    private fun assertSeries(
+        series: Series<*, *>,
+        vararg expected: Pair<Float, Float>,
+        tolerance: Float = 1e-4f,
+    ) {
+        assertEquals(expected.size, series.size, "point count for series ${series.key}")
+        for (i in expected.indices) {
+            assertEquals(expected[i].first, series[i].low, tolerance, "low[$i] of series ${series.key}")
+            assertEquals(expected[i].second, series[i].high, tolerance, "high[$i] of series ${series.key}")
+        }
+    }
+
+    @Test
+    fun stack_computesStackedSeriesForData() {
+        val result = stack<List<Float>, Int>().keys(listOf(0, 1, 2, 3)).invoke(data)
+        assertSeries(result[0], 0f to 1f, 0f to 2f, 0f to 1f)
+        assertSeries(result[1], 1f to 4f, 2f to 6f, 1f to 3f)
+        assertSeries(result[2], 4f to 9f, 6f to 8f, 3f to 7f)
+        assertSeries(result[3], 9f to 10f, 8f to 11f, 7f to 9f)
+        assertContentEquals(listOf(0, 1, 2, 3), result.map { it.index })
+    }
+
+    @Test
+    fun stack_withMapData_usesDefaultValueAccessor() {
+        val mapData = listOf(mapOf("a" to 1f, "b" to 3f), mapOf("a" to 2f, "b" to 4f))
+        val result = stack<Map<String, Float>, String>().keys(listOf("a", "b")).invoke(mapData)
+        assertSeries(result[0], 0f to 1f, 0f to 2f)
+        assertSeries(result[1], 1f to 4f, 2f to 6f)
+        assertEquals("a", result[0].key)
+        assertEquals("b", result[1].key)
+    }
+
+    @Test
+    fun stack_withCustomValueAccessor_passesDatumAndKey() {
+        val result = stack<List<Float>, Int>()
+            .keys(listOf(0, 1))
+            .value { datum, key -> datum[key] * 2 }
+            .invoke(listOf(listOf(1f, 3f)))
+        assertSeries(result[0], 0f to 2f)
+        assertSeries(result[1], 2f to 8f)
+    }
+
+    @Test
+    fun stack_orderReverse_reversesStackingOrder() {
+        val result = stack<List<Float>, Int>().keys(listOf(0, 1, 2, 3)).order(StackOrderReverse).invoke(data)
+        assertSeries(result[0], 9f to 10f, 9f to 11f, 8f to 9f)
+        assertSeries(result[1], 6f to 9f, 5f to 9f, 6f to 8f)
+        assertSeries(result[2], 1f to 6f, 3f to 5f, 2f to 6f)
+        assertSeries(result[3], 0f to 1f, 0f to 3f, 0f to 2f)
+        assertContentEquals(listOf(3, 2, 1, 0), result.map { it.index })
+    }
+
+    @Test
+    fun stack_offsetExpand_normalizesColumns() {
+        val result = stack<List<Float>, Int>().keys(listOf(0, 1, 2, 3)).offset(StackOffsetExpand).invoke(data)
+        assertSeries(result[0], 0f / 10 to 1f / 10, 0f / 11 to 2f / 11, 0f / 9 to 1f / 9)
+        assertSeries(result[3], 9f / 10 to 10f / 10, 8f / 11 to 11f / 11, 7f / 9 to 9f / 9)
+    }
+
+    @Test
+    fun stackOrderAscending_ordersBySum() {
+        assertContentEquals(intArrayOf(2, 0, 1).toList(), StackOrderAscending(orderFixture()).toList())
+    }
+
+    @Test
+    fun stackOrderDescending_ordersBySum() {
+        assertContentEquals(intArrayOf(1, 0, 2).toList(), StackOrderDescending(orderFixture()).toList())
+    }
+
+    @Test
+    fun stackOrderAppearance_ordersByPeak() {
+        val series = seriesOf(
+            listOf(0f, 0f, 1f),
+            listOf(3f, 2f, 0f),
+            listOf(0f, 4f, 0f),
+        )
+        assertContentEquals(intArrayOf(1, 2, 0).toList(), StackOrderAppearance(series).toList())
+    }
+
+    @Test
+    fun stackOrderInsideOut_ordersByAppearanceInsideOut() {
+        val series = seriesOf(
+            listOf(0f, 0f, 0f, 0f, 0f, 0f, 1f),
+            listOf(0f, 0f, 0f, 0f, 0f, 2f, 0f),
+            listOf(0f, 0f, 0f, 0f, 3f, 0f, 0f),
+            listOf(0f, 0f, 0f, 4f, 0f, 0f, 0f),
+            listOf(0f, 0f, 5f, 0f, 0f, 0f, 0f),
+            listOf(0f, 6f, 0f, 0f, 0f, 0f, 0f),
+            listOf(7f, 0f, 0f, 0f, 0f, 0f, 0f),
+        )
+        assertContentEquals(intArrayOf(2, 3, 6, 5, 4, 1, 0).toList(), StackOrderInsideOut(series).toList())
+    }
+
+    @Test
+    fun stackOffsetSilhouette_centersAroundZero() {
+        val result = stack<List<Float>, Int>().keys(listOf(0, 1, 2)).offset(StackOffsetSilhouette).invoke(data)
+        assertSeries(result[0], 0f - 9f / 2 to 1f - 9f / 2, 0f - 8f / 2 to 2f - 8f / 2, 0f - 7f / 2 to 1f - 7f / 2)
+        assertSeries(result[2], 4f - 9f / 2 to 9f - 9f / 2, 6f - 8f / 2 to 8f - 8f / 2, 3f - 7f / 2 to 7f - 7f / 2)
+    }
+
+    @Test
+    fun stackOffsetWiggle_minimizesWeightedWiggle() {
+        val result = stack<List<Float>, Int>().keys(listOf(0, 1, 2)).offset(StackOffsetWiggle).invoke(data)
+        assertSeries(result[0], 0f to 1f, -1f to 1f, 0.7857143f to 1.7857143f)
+        assertSeries(result[1], 1f to 4f, 1f to 5f, 1.7857143f to 3.7857143f)
+        assertSeries(result[2], 4f to 9f, 5f to 7f, 3.7857143f to 7.7857143f)
+    }
+
+    private fun orderFixture(): List<Series<Unit, Int>> = seriesOf(
+        listOf(1f, 2f, 3f),
+        listOf(2f, 3f, 4f),
+        listOf(0f, 1f, 2f),
+    )
+
+    private fun seriesOf(vararg rows: List<Float>): List<Series<Unit, Int>> =
+        rows.mapIndexed { index, row ->
+            Series(index, row.map { StackPoint(Unit, low = 0f, high = it) })
+        }
+}

--- a/shape/src/commonTest/kotlin/SymbolTest.kt
+++ b/shape/src/commonTest/kotlin/SymbolTest.kt
@@ -1,0 +1,101 @@
+package com.juul.krayon.shape
+
+import com.juul.krayon.kanvas.svg.toPath
+import kotlin.math.PI
+import kotlin.math.sqrt
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SymbolTest {
+
+    @Test
+    fun symbol_default_isCircleWithSize64() {
+        val r = sqrt(64f / PI.toFloat())
+        val ops = symbol<Unit>().render(Unit).ops()
+        assertEquals("M", ops[0].name)
+        assertEquals(r, ops[0].args[0], absoluteTolerance = 1e-4f)
+        assertEquals(0f, ops[0].args[1], absoluteTolerance = 1e-4f)
+        assertEquals(listOf("M", "A", "A"), ops.map { it.name })
+    }
+
+    @Test
+    fun symbol_typeAndSizeAccessors_produceExpectedPath() {
+        val fromGenerator = symbol<Float>().type(Cross).size { (datum) -> datum }.render(20f)
+        assertPathEquals(Cross.render(20f), fromGenerator)
+    }
+
+    @Test
+    fun circle_hasExpectedRadiusAndArcs() {
+        val ops = Circle.render(20f).ops()
+        val r = sqrt(20f / PI.toFloat())
+        assertEquals(r, ops[0].args[0], absoluteTolerance = 1e-4f)
+        assertEquals(2, ops.count { it.name == "A" })
+    }
+
+    @Test
+    fun cross_generatesExpectedPath() {
+        assertPathEquals("M-3,-1L-1,-1L-1,-3L1,-3L1,-1L3,-1L3,1L1,1L1,3L-1,3L-1,1L-3,1Z".toPath(), Cross.render(20f))
+    }
+
+    @Test
+    fun diamond_generatesExpectedPath() {
+        assertPathEquals("M0,-2.942831L1.699044,0L0,2.942831L-1.699044,0Z".toPath(), Diamond.render(10f))
+    }
+
+    @Test
+    fun square_generatesExpectedPath() {
+        assertPathEquals("M-1,-1L1,-1L1,1L-1,1Z".toPath(), Square.render(4f))
+        assertPathEquals("M-2,-2L2,-2L2,2L-2,2Z".toPath(), Square.render(16f))
+    }
+
+    @Test
+    fun star_generatesExpectedPath() {
+        assertPathEquals(
+            (
+                "M0,-2.984649L0.670095,-0.922307L2.838570,-0.922307L1.084237,0.352290L1.754333,2.414632" +
+                    "L0,1.140035L-1.754333,2.414632L-1.084237,0.352290L-2.838570,-0.922307L-0.670095,-0.922307Z"
+            ).toPath(),
+            Star.render(10f),
+        )
+    }
+
+    @Test
+    fun triangle_generatesExpectedPath() {
+        assertPathEquals("M0,-2.774528L2.402811,1.387264L-2.402811,1.387264Z".toPath(), Triangle.render(10f))
+    }
+
+    @Test
+    fun wye_generatesExpectedPath() {
+        assertPathEquals(
+            (
+                "M0.853360,0.492688L0.853360,2.199408L-0.853360,2.199408L-0.853360,0.492688L-2.331423,-0.360672" +
+                    "L-1.478063,-1.838735L0,-0.985375L1.478063,-1.838735L2.331423,-0.360672Z"
+            ).toPath(),
+            Wye.render(10f),
+        )
+    }
+
+    @Test
+    fun plus_generatesExpectedPath() {
+        assertPathEquals("M-3.714814,0L3.714814,0M0,3.714814L0,-3.714814".toPath(), Plus.render(20f))
+    }
+
+    @Test
+    fun times_generatesExpectedPath() {
+        assertPathEquals("M-2.647561,-2.647561L2.647561,2.647561M-2.647561,2.647561L2.647561,-2.647561".toPath(), Times.render(20f))
+    }
+
+    @Test
+    fun asterisk_generatesExpectedPath() {
+        assertPathEquals(
+            "M0,2.705108L0,-2.705108M-2.342692,-1.352554L2.342692,1.352554M-2.342692,1.352554L2.342692,-1.352554".toPath(),
+            Asterisk.render(20f),
+        )
+    }
+
+    @Test
+    fun registries_containExpectedSymbols() {
+        assertEquals(listOf(Circle, Cross, Diamond, Square, Star, Triangle, Wye), symbolsFill)
+        assertEquals(listOf(Circle, Plus, Times, Asterisk), symbolsStroke)
+    }
+}

--- a/shape/src/commonTest/kotlin/curve/BasisTests.kt
+++ b/shape/src/commonTest/kotlin/curve/BasisTests.kt
@@ -1,0 +1,82 @@
+package com.juul.krayon.shape.curve
+
+import com.juul.krayon.kanvas.svg.toPath
+import com.juul.krayon.shape.Point
+import com.juul.krayon.shape.area
+import com.juul.krayon.shape.assertPathEquals
+import com.juul.krayon.shape.line
+import kotlin.test.Test
+
+class BasisTests {
+
+    @Test
+    fun line_curveBasis_generatesExpectedPath() {
+        val l = line<Point>().curve(Basis)
+        assertPathEquals("M0,1Z".toPath(), l.render(listOf(Point(0f, 1f))))
+        assertPathEquals("M0,1L1,3".toPath(), l.render(listOf(Point(0f, 1f), Point(1f, 3f))))
+        assertPathEquals(
+            (
+                "M0,1L0.166667,1.333333C0.333333,1.666667,0.666667,2.333333,1,2.333333" +
+                    "C1.333333,2.333333,1.666667,1.666667,1.833333,1.333333L2,1"
+            ).toPath(),
+            l.render(listOf(Point(0f, 1f), Point(1f, 3f), Point(2f, 1f))),
+        )
+    }
+
+    @Test
+    fun area_curveBasis_generatesExpectedPath() {
+        val a = area<Point>().curve(Basis)
+        assertPathEquals("M0,1L0,0Z".toPath(), a.render(listOf(Point(0f, 1f))))
+        assertPathEquals("M0,1L1,3L1,0L0,0Z".toPath(), a.render(listOf(Point(0f, 1f), Point(1f, 3f))))
+        assertPathEquals(
+            (
+                "M0,1L0.166667,1.333333C0.333333,1.666667,0.666667,2.333333,1,2.333333" +
+                    "C1.333333,2.333333,1.666667,1.666667,1.833333,1.333333L2,1L2,0L1.833333,0" +
+                    "C1.666667,0,1.333333,0,1,0C0.666667,0,0.333333,0,0.166667,0L0,0Z"
+            ).toPath(),
+            a.render(listOf(Point(0f, 1f), Point(1f, 3f), Point(2f, 1f))),
+        )
+    }
+
+    @Test
+    fun line_curveBasisClosed_generatesExpectedPath() {
+        val l = line<Point>().curve(BasisClosed)
+        assertPathEquals("M0,0Z".toPath(), l.render(listOf(Point(0f, 0f))))
+        assertPathEquals("M0,6.666667L0,3.333333Z".toPath(), l.render(listOf(Point(0f, 0f), Point(0f, 10f))))
+        assertPathEquals(
+            (
+                "M1.666667,8.333333C3.333333,10,6.666667,10,6.666667,8.333333" +
+                    "C6.666667,6.666667,3.333333,3.333333,1.666667,3.333333C0,3.333333,0,6.666667,1.666667,8.333333"
+            ).toPath(),
+            l.render(listOf(Point(0f, 0f), Point(0f, 10f), Point(10f, 10f))),
+        )
+        assertPathEquals(
+            (
+                "M1.666667,8.333333C3.333333,10,6.666667,10,8.333333,8.333333" +
+                    "C10,6.666667,10,3.333333,8.333333,1.666667C6.666667,0,3.333333,0,1.666667,1.666667" +
+                    "C0,3.333333,0,6.666667,1.666667,8.333333"
+            ).toPath(),
+            l.render(listOf(Point(0f, 0f), Point(0f, 10f), Point(10f, 10f), Point(10f, 0f))),
+        )
+    }
+
+    @Test
+    fun line_curveBasisOpen_generatesExpectedPath() {
+        val l = line<Point>().curve(BasisOpen)
+        assertPathEquals("M1.666667,8.333333Z".toPath(), l.render(listOf(Point(0f, 0f), Point(0f, 10f), Point(10f, 10f))))
+        assertPathEquals(
+            "M1.666667,8.333333C3.333333,10,6.666667,10,8.333333,8.333333".toPath(),
+            l.render(listOf(Point(0f, 0f), Point(0f, 10f), Point(10f, 10f), Point(10f, 0f))),
+        )
+    }
+
+    @Test
+    fun area_curveBasisOpen_generatesExpectedPath() {
+        val a = area<Point>().curve(BasisOpen)
+        assertPathEquals("M1.666667,8.333333L1.666667,0Z".toPath(), a.render(listOf(Point(0f, 0f), Point(0f, 10f), Point(10f, 10f))))
+        assertPathEquals(
+            "M1.666667,8.333333C3.333333,10,6.666667,10,8.333333,8.333333L8.333333,0C6.666667,0,3.333333,0,1.666667,0Z".toPath(),
+            a.render(listOf(Point(0f, 0f), Point(0f, 10f), Point(10f, 10f), Point(10f, 0f))),
+        )
+    }
+}

--- a/shape/src/commonTest/kotlin/curve/BumpTests.kt
+++ b/shape/src/commonTest/kotlin/curve/BumpTests.kt
@@ -1,0 +1,43 @@
+package com.juul.krayon.shape.curve
+
+import com.juul.krayon.kanvas.svg.toPath
+import com.juul.krayon.shape.Point
+import com.juul.krayon.shape.area
+import com.juul.krayon.shape.assertPathEquals
+import com.juul.krayon.shape.line
+import kotlin.test.Test
+
+class BumpTests {
+
+    @Test
+    fun line_curveBumpX_generatesExpectedPath() {
+        val l = line<Point>().curve(BumpX)
+        assertPathEquals("M0,1Z".toPath(), l.render(listOf(Point(0f, 1f))))
+        assertPathEquals("M0,1C0.5,1,0.5,3,1,3".toPath(), l.render(listOf(Point(0f, 1f), Point(1f, 3f))))
+        assertPathEquals(
+            "M0,1C0.5,1,0.5,3,1,3C1.5,3,1.5,1,2,1".toPath(),
+            l.render(listOf(Point(0f, 1f), Point(1f, 3f), Point(2f, 1f))),
+        )
+    }
+
+    @Test
+    fun area_curveBumpX_generatesExpectedPath() {
+        val a = area<Point>().curve(BumpX)
+        assertPathEquals("M0,1L0,0Z".toPath(), a.render(listOf(Point(0f, 1f))))
+        assertPathEquals(
+            "M0,1C0.5,1,0.5,3,1,3L1,0C0.5,0,0.5,0,0,0Z".toPath(),
+            a.render(listOf(Point(0f, 1f), Point(1f, 3f))),
+        )
+    }
+
+    @Test
+    fun line_curveBumpY_generatesExpectedPath() {
+        val l = line<Point>().curve(BumpY)
+        assertPathEquals("M0,1Z".toPath(), l.render(listOf(Point(0f, 1f))))
+        assertPathEquals("M0,1C0,2,1,2,1,3".toPath(), l.render(listOf(Point(0f, 1f), Point(1f, 3f))))
+        assertPathEquals(
+            "M0,1C0,2,1,2,1,3C1,2,2,2,2,1".toPath(),
+            l.render(listOf(Point(0f, 1f), Point(1f, 3f), Point(2f, 1f))),
+        )
+    }
+}

--- a/shape/src/commonTest/kotlin/curve/CardinalTests.kt
+++ b/shape/src/commonTest/kotlin/curve/CardinalTests.kt
@@ -1,0 +1,67 @@
+package com.juul.krayon.shape.curve
+
+import com.juul.krayon.kanvas.svg.toPath
+import com.juul.krayon.shape.Point
+import com.juul.krayon.shape.area
+import com.juul.krayon.shape.assertPathEquals
+import com.juul.krayon.shape.line
+import kotlin.test.Test
+
+class CardinalTests {
+
+    private val four = listOf(Point(0f, 1f), Point(1f, 3f), Point(2f, 1f), Point(3f, 3f))
+
+    @Test
+    fun line_curveCardinal_generatesExpectedPath() {
+        val l = line<Point>().curve(Cardinal())
+        assertPathEquals("M0,1Z".toPath(), l.render(listOf(Point(0f, 1f))))
+        assertPathEquals("M0,1L1,3".toPath(), l.render(listOf(Point(0f, 1f), Point(1f, 3f))))
+        assertPathEquals(
+            "M0,1C0,1,0.666667,3,1,3C1.333333,3,2,1,2,1".toPath(),
+            l.render(listOf(Point(0f, 1f), Point(1f, 3f), Point(2f, 1f))),
+        )
+        assertPathEquals(
+            "M0,1C0,1,0.666667,3,1,3C1.333333,3,1.666667,1,2,1C2.333333,1,3,3,3,3".toPath(),
+            l.render(four),
+        )
+    }
+
+    @Test
+    fun line_curveCardinal_withTension_usesSpecifiedTension() {
+        val l = line<Point>().curve(Cardinal(0.5f))
+        assertPathEquals(
+            "M0,1C0,1,0.833333,3,1,3C1.166667,3,1.833333,1,2,1C2.166667,1,3,3,3,3".toPath(),
+            l.render(four),
+        )
+    }
+
+    @Test
+    fun area_curveCardinal_generatesExpectedPath() {
+        val a = area<Point>().curve(Cardinal())
+        assertPathEquals("M0,1L0,0Z".toPath(), a.render(listOf(Point(0f, 1f))))
+        assertPathEquals(
+            "M0,1C0,1,0.666667,3,1,3C1.333333,3,2,1,2,1L2,0C2,0,1.333333,0,1,0C0.666667,0,0,0,0,0Z".toPath(),
+            a.render(listOf(Point(0f, 1f), Point(1f, 3f), Point(2f, 1f))),
+        )
+    }
+
+    @Test
+    fun line_curveCardinalClosed_generatesExpectedPath() {
+        val l = line<Point>().curve(CardinalClosed())
+        assertPathEquals("M1,3L0,1Z".toPath(), l.render(listOf(Point(0f, 1f), Point(1f, 3f))))
+        assertPathEquals(
+            "M1,3C1.333333,3,1.666667,1,2,1C2.333333,1,3.333333,3,3,3C2.666667,3,0.333333,1,0,1C-0.333333,1,0.666667,3,1,3".toPath(),
+            l.render(four),
+        )
+    }
+
+    @Test
+    fun line_curveCardinalOpen_generatesExpectedPath() {
+        val l = line<Point>().curve(CardinalOpen())
+        assertPathEquals("M1,3Z".toPath(), l.render(listOf(Point(0f, 1f), Point(1f, 3f), Point(2f, 1f))))
+        assertPathEquals(
+            "M1,3C1.333333,3,1.666667,1,2,1".toPath(),
+            l.render(four),
+        )
+    }
+}

--- a/shape/src/commonTest/kotlin/curve/CatmullRomTests.kt
+++ b/shape/src/commonTest/kotlin/curve/CatmullRomTests.kt
@@ -1,0 +1,64 @@
+package com.juul.krayon.shape.curve
+
+import com.juul.krayon.kanvas.svg.toPath
+import com.juul.krayon.shape.Point
+import com.juul.krayon.shape.area
+import com.juul.krayon.shape.assertPathEquals
+import com.juul.krayon.shape.line
+import kotlin.test.Test
+
+class CatmullRomTests {
+
+    private val four = listOf(Point(0f, 1f), Point(1f, 3f), Point(2f, 1f), Point(3f, 3f))
+
+    @Test
+    fun line_curveCatmullRom_generatesExpectedPath() {
+        val l = line<Point>().curve(CatmullRom())
+        assertPathEquals("M0,1Z".toPath(), l.render(listOf(Point(0f, 1f))))
+        assertPathEquals("M0,1L1,3".toPath(), l.render(listOf(Point(0f, 1f), Point(1f, 3f))))
+        assertPathEquals(
+            "M0,1C0,1,0.666667,3,1,3C1.333333,3,2,1,2,1".toPath(),
+            l.render(listOf(Point(0f, 1f), Point(1f, 3f), Point(2f, 1f))),
+        )
+        assertPathEquals(
+            "M0,1C0,1,0.666667,3,1,3C1.333333,3,1.666667,1,2,1C2.333333,1,3,3,3,3".toPath(),
+            l.render(four),
+        )
+    }
+
+    @Test
+    fun area_curveCatmullRom_alpha0_generatesExpectedPath() {
+        val a = area<Point>().curve(CatmullRom(0f))
+        assertPathEquals(
+            "M0,1C0,1,0.666667,3,1,3C1.333333,3,2,1,2,1L2,0C2,0,1.333333,0,1,0C0.666667,0,0,0,0,0Z".toPath(),
+            a.render(listOf(Point(0f, 1f), Point(1f, 3f), Point(2f, 1f))),
+        )
+    }
+
+    @Test
+    fun line_curveCatmullRomClosed_generatesExpectedPath() {
+        val l = line<Point>().curve(CatmullRomClosed())
+        assertPathEquals("M1,3L0,1Z".toPath(), l.render(listOf(Point(0f, 1f), Point(1f, 3f))))
+        assertPathEquals(
+            "M1,3C1.333333,3,2.200267,1.324038,2,1C1.810600,0.693544,0.189400,0.693544,0,1C-0.200267,1.324038,0.666667,3,1,3".toPath(),
+            l.render(listOf(Point(0f, 1f), Point(1f, 3f), Point(2f, 1f))),
+        )
+        assertPathEquals(
+            (
+                "M1,3C1.333333,3,1.666667,1,2,1C2.333333,1,3.160469,2.858341,3,3" +
+                    "C2.796233,3.179882,0.203767,0.820118,0,1C-0.160469,1.141659,0.666667,3,1,3"
+            ).toPath(),
+            l.render(four),
+        )
+    }
+
+    @Test
+    fun line_curveCatmullRomOpen_generatesExpectedPath() {
+        val l = line<Point>().curve(CatmullRomOpen())
+        assertPathEquals("M1,3Z".toPath(), l.render(listOf(Point(0f, 1f), Point(1f, 3f), Point(2f, 1f))))
+        assertPathEquals(
+            "M1,3C1.333333,3,1.666667,1,2,1".toPath(),
+            l.render(four),
+        )
+    }
+}

--- a/shape/src/commonTest/kotlin/curve/LinearClosedTests.kt
+++ b/shape/src/commonTest/kotlin/curve/LinearClosedTests.kt
@@ -1,0 +1,18 @@
+package com.juul.krayon.shape.curve
+
+import com.juul.krayon.kanvas.svg.toPath
+import com.juul.krayon.shape.Point
+import com.juul.krayon.shape.assertPathEquals
+import com.juul.krayon.shape.line
+import kotlin.test.Test
+
+class LinearClosedTests {
+
+    @Test
+    fun line_curveLinearClosed_generatesExpectedPath() {
+        val l = line<Point>().curve(LinearClosed)
+        assertPathEquals("M0,1Z".toPath(), l.render(listOf(Point(0f, 1f))))
+        assertPathEquals("M0,1L2,3Z".toPath(), l.render(listOf(Point(0f, 1f), Point(2f, 3f))))
+        assertPathEquals("M0,1L2,3L4,5Z".toPath(), l.render(listOf(Point(0f, 1f), Point(2f, 3f), Point(4f, 5f))))
+    }
+}

--- a/shape/src/commonTest/kotlin/curve/MonotoneTests.kt
+++ b/shape/src/commonTest/kotlin/curve/MonotoneTests.kt
@@ -1,0 +1,62 @@
+package com.juul.krayon.shape.curve
+
+import com.juul.krayon.kanvas.svg.toPath
+import com.juul.krayon.shape.Point
+import com.juul.krayon.shape.area
+import com.juul.krayon.shape.assertPathEquals
+import com.juul.krayon.shape.line
+import kotlin.test.Test
+
+class MonotoneTests {
+
+    @Test
+    fun line_curveMonotoneX_generatesExpectedPath() {
+        val l = line<Point>().curve(MonotoneX)
+        assertPathEquals("M0,1Z".toPath(), l.render(listOf(Point(0f, 1f))))
+        assertPathEquals("M0,1L1,3".toPath(), l.render(listOf(Point(0f, 1f), Point(1f, 3f))))
+        assertPathEquals(
+            "M0,1C0.333333,2,0.666667,3,1,3C1.333333,3,1.666667,2,2,1".toPath(),
+            l.render(listOf(Point(0f, 1f), Point(1f, 3f), Point(2f, 1f))),
+        )
+        assertPathEquals(
+            "M0,1C0.333333,2,0.666667,3,1,3C1.333333,3,1.666667,1,2,1C2.333333,1,2.666667,2,3,3".toPath(),
+            l.render(listOf(Point(0f, 1f), Point(1f, 3f), Point(2f, 1f), Point(3f, 3f))),
+        )
+    }
+
+    @Test
+    fun line_curveMonotoneX_preservesMonotonicity() {
+        val l = line<Point>().curve(MonotoneX)
+        assertPathEquals(
+            (
+                "M0,200C33.333333,150,66.666667,100,100,100C133.333333,100,166.666667,100,200,100" +
+                    "C233.333333,100,266.666667,300,300,300C333.333333,300,366.666667,300,400,300"
+            ).toPath(),
+            l.render(listOf(Point(0f, 200f), Point(100f, 100f), Point(200f, 100f), Point(300f, 300f), Point(400f, 300f))),
+        )
+    }
+
+    @Test
+    fun area_curveMonotoneX_generatesExpectedPath() {
+        val a = area<Point>().curve(MonotoneX)
+        assertPathEquals(
+            "M0,1C0.333333,2,0.666667,3,1,3C1.333333,3,1.666667,2,2,1L2,0C1.666667,0,1.333333,0,1,0C0.666667,0,0.333333,0,0,0Z".toPath(),
+            a.render(listOf(Point(0f, 1f), Point(1f, 3f), Point(2f, 1f))),
+        )
+    }
+
+    @Test
+    fun line_curveMonotoneY_generatesExpectedPath() {
+        val l = line<Point>().curve(MonotoneY)
+        assertPathEquals("M1,0Z".toPath(), l.render(listOf(Point(1f, 0f))))
+        assertPathEquals("M1,0L3,1".toPath(), l.render(listOf(Point(1f, 0f), Point(3f, 1f))))
+        assertPathEquals(
+            "M1,0C2,0.333333,3,0.666667,3,1C3,1.333333,2,1.666667,1,2".toPath(),
+            l.render(listOf(Point(1f, 0f), Point(3f, 1f), Point(1f, 2f))),
+        )
+        assertPathEquals(
+            "M1,0C2,0.333333,3,0.666667,3,1C3,1.333333,1,1.666667,1,2C1,2.333333,2,2.666667,3,3".toPath(),
+            l.render(listOf(Point(1f, 0f), Point(3f, 1f), Point(1f, 2f), Point(3f, 3f))),
+        )
+    }
+}

--- a/shape/src/commonTest/kotlin/curve/NaturalTests.kt
+++ b/shape/src/commonTest/kotlin/curve/NaturalTests.kt
@@ -1,0 +1,39 @@
+package com.juul.krayon.shape.curve
+
+import com.juul.krayon.kanvas.svg.toPath
+import com.juul.krayon.shape.Point
+import com.juul.krayon.shape.area
+import com.juul.krayon.shape.assertPathEquals
+import com.juul.krayon.shape.line
+import kotlin.test.Test
+
+class NaturalTests {
+
+    @Test
+    fun line_curveNatural_generatesExpectedPath() {
+        val l = line<Point>().curve(Natural)
+        assertPathEquals("M0,1Z".toPath(), l.render(listOf(Point(0f, 1f))))
+        assertPathEquals("M0,1L1,3".toPath(), l.render(listOf(Point(0f, 1f), Point(1f, 3f))))
+        assertPathEquals(
+            "M0,1C0.333333,2,0.666667,3,1,3C1.333333,3,1.666667,2,2,1".toPath(),
+            l.render(listOf(Point(0f, 1f), Point(1f, 3f), Point(2f, 1f))),
+        )
+        assertPathEquals(
+            (
+                "M0,1C0.333333,2.111111,0.666667,3.222222,1,3C1.333333,2.777778,1.666667,1.222222,2,1" +
+                    "C2.333333,0.777778,2.666667,1.888889,3,3"
+            ).toPath(),
+            l.render(listOf(Point(0f, 1f), Point(1f, 3f), Point(2f, 1f), Point(3f, 3f))),
+        )
+    }
+
+    @Test
+    fun area_curveNatural_generatesExpectedPath() {
+        val a = area<Point>().curve(Natural)
+        assertPathEquals("M0,1L0,0Z".toPath(), a.render(listOf(Point(0f, 1f))))
+        assertPathEquals(
+            "M0,1C0.333333,2,0.666667,3,1,3C1.333333,3,1.666667,2,2,1L2,0C1.666667,0,1.333333,0,1,0C0.666667,0,0.333333,0,0,0Z".toPath(),
+            a.render(listOf(Point(0f, 1f), Point(1f, 3f), Point(2f, 1f))),
+        )
+    }
+}

--- a/shape/src/commonTest/kotlin/curve/StepTests.kt
+++ b/shape/src/commonTest/kotlin/curve/StepTests.kt
@@ -1,0 +1,42 @@
+package com.juul.krayon.shape.curve
+
+import com.juul.krayon.kanvas.svg.toPath
+import com.juul.krayon.shape.Point
+import com.juul.krayon.shape.area
+import com.juul.krayon.shape.assertPathEquals
+import com.juul.krayon.shape.line
+import kotlin.test.Test
+
+class StepTests {
+
+    @Test
+    fun line_curveStep_generatesExpectedPath() {
+        val l = line<Point>().curve(Step)
+        assertPathEquals("M0,1Z".toPath(), l.render(listOf(Point(0f, 1f))))
+        assertPathEquals("M0,1L1,1L1,3L2,3".toPath(), l.render(listOf(Point(0f, 1f), Point(2f, 3f))))
+        assertPathEquals("M0,1L1,1L1,3L3,3L3,5L4,5".toPath(), l.render(listOf(Point(0f, 1f), Point(2f, 3f), Point(4f, 5f))))
+    }
+
+    @Test
+    fun area_curveStep_generatesExpectedPath() {
+        val a = area<Point>().curve(Step)
+        assertPathEquals("M0,1L0,0Z".toPath(), a.render(listOf(Point(0f, 1f))))
+        assertPathEquals("M0,1L1,1L1,3L2,3L2,0L1,0L1,0L0,0Z".toPath(), a.render(listOf(Point(0f, 1f), Point(2f, 3f))))
+    }
+
+    @Test
+    fun line_curveStepBefore_generatesExpectedPath() {
+        val l = line<Point>().curve(StepBefore)
+        assertPathEquals("M0,1Z".toPath(), l.render(listOf(Point(0f, 1f))))
+        assertPathEquals("M0,1L0,3L2,3".toPath(), l.render(listOf(Point(0f, 1f), Point(2f, 3f))))
+        assertPathEquals("M0,1L0,3L2,3L2,5L4,5".toPath(), l.render(listOf(Point(0f, 1f), Point(2f, 3f), Point(4f, 5f))))
+    }
+
+    @Test
+    fun line_curveStepAfter_generatesExpectedPath() {
+        val l = line<Point>().curve(StepAfter)
+        assertPathEquals("M0,1Z".toPath(), l.render(listOf(Point(0f, 1f))))
+        assertPathEquals("M0,1L2,1L2,3".toPath(), l.render(listOf(Point(0f, 1f), Point(2f, 3f))))
+        assertPathEquals("M0,1L2,1L2,3L4,3L4,5".toPath(), l.render(listOf(Point(0f, 1f), Point(2f, 3f), Point(4f, 5f))))
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Substantially expands the `shape` module to more faithfully mirror [d3-shape](https://github.com/d3/d3-shape), plugging into the existing `Curve`/`PathBuilder` protocol and the immutable-fluent generator style used by `line()`/`area()`/`arc()`/`pie()`. Landed in three logical commits.

### 1. Curves (`shape/src/commonMain/kotlin/curve/`)
Ports the remaining d3-shape curve interpolators, each in its own file, with correct area (start/end) handling:
- `Basis`, `BasisClosed`, `BasisOpen`
- `Cardinal`, `CardinalClosed`, `CardinalOpen` (with `tension`)
- `CatmullRom`, `CatmullRomClosed`, `CatmullRomOpen` (with `alpha`; `alpha == 0` degenerates to the cardinal variant, matching d3)
- `MonotoneX`, `MonotoneY`
- `Natural`
- `Step`, `StepBefore`, `StepAfter`
- `BumpX`, `BumpY`
- `LinearClosed`

`Linear` is unchanged (its private `truthy` helper was hoisted into a shared internal helper reused by the new curves).

### 2. Stack generator
`stack()` → `Stack<D, K>`: `keys`, `value` accessor, `order`, `offset`, producing `List<Series<D, K>>` of `StackPoint(low, high)` — directly feedable to `area()`/`line()`. Includes:
- Orders: `StackOrderNone`, `StackOrderReverse`, `StackOrderAscending`, `StackOrderDescending`, `StackOrderAppearance`, `StackOrderInsideOut`
- Offsets: `StackOffsetNone`, `StackOffsetExpand`, `StackOffsetDiverging`, `StackOffsetSilhouette`, `StackOffsetWiggle`

### 3. Symbol generator
`symbol()` → `Symbol<D>` with `type`/`size` accessors rendering to a `Path`, plus a `SymbolType` interface and types: `Circle`, `Cross`, `Diamond`, `Square`, `Star`, `Triangle`, `Wye`, `Plus`, `Times`, `Asterisk`. Registry lists `symbolsFill` / `symbolsStroke` are provided.

## Testing
- Common tests (`kotlin.test`) verify curve line/area output, stack orders/offsets, and symbol paths against exact **d3-shape fixtures**, using a tolerant, recording-`PathBuilder`-based comparison for `Float` rounding.
- `./gradlew :shape:build` passes across all targets (JVM, Android, JS, WasmJs, native), including `apiCheck` and `lintKotlin`. `api/jvm/shape.api` and `api/shape.klib.api` regenerated via `apiDump`.

## Scope
- Only the `shape` module is modified.
- Radial line/area and link generators are intentionally out of scope.
- `NOTICE` already credits D3 (ISC), so no change was needed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a7b8496-4fbc-43f6-a4d3-35b3b4aa577f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a7b8496-4fbc-43f6-a4d3-35b3b4aa577f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

