### PR TITLE
Port d3-format into a new `format` module

### DIFF
--- a/format/api/android/format.api
+++ b/format/api/android/format.api
@@ -1,0 +1,82 @@
+public final class com/juul/krayon/format/FormatKt {
+	public static final fun format (Lcom/juul/krayon/format/FormatSpecifier;)Lcom/juul/krayon/format/NumberFormat;
+	public static final fun format (Ljava/lang/String;)Lcom/juul/krayon/format/NumberFormat;
+	public static final fun formatPrefix (Ljava/lang/String;D)Lcom/juul/krayon/format/NumberFormat;
+	public static final fun getEnUS ()Lcom/juul/krayon/format/FormatLocaleDefinition;
+	public static final fun precisionFixed (D)I
+	public static final fun precisionPrefix (DD)I
+	public static final fun precisionRound (DD)I
+}
+
+public final class com/juul/krayon/format/FormatLocale {
+	public fun <init> (Lcom/juul/krayon/format/FormatLocaleDefinition;)V
+	public final fun format (Lcom/juul/krayon/format/FormatSpecifier;)Lcom/juul/krayon/format/NumberFormat;
+	public final fun format (Ljava/lang/String;)Lcom/juul/krayon/format/NumberFormat;
+	public final fun formatPrefix (Ljava/lang/String;D)Lcom/juul/krayon/format/NumberFormat;
+}
+
+public final class com/juul/krayon/format/FormatLocaleDefinition {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/util/List;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/juul/krayon/format/FormatLocaleDefinition;
+	public static synthetic fun copy$default (Lcom/juul/krayon/format/FormatLocaleDefinition;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/juul/krayon/format/FormatLocaleDefinition;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCurrencyPrefix ()Ljava/lang/String;
+	public final fun getCurrencySuffix ()Ljava/lang/String;
+	public final fun getDecimal ()Ljava/lang/String;
+	public final fun getGrouping ()Ljava/util/List;
+	public final fun getMinus ()Ljava/lang/String;
+	public final fun getNan ()Ljava/lang/String;
+	public final fun getNumerals ()Ljava/util/List;
+	public final fun getPercent ()Ljava/lang/String;
+	public final fun getThousands ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/juul/krayon/format/FormatSpecifier {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/Integer;ZLjava/lang/Integer;ZLjava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/Integer;ZLjava/lang/Integer;ZLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getAlign ()Ljava/lang/String;
+	public final fun getComma ()Z
+	public final fun getFill ()Ljava/lang/String;
+	public final fun getPrecision ()Ljava/lang/Integer;
+	public final fun getSign ()Ljava/lang/String;
+	public final fun getSymbol ()Ljava/lang/String;
+	public final fun getTrim ()Z
+	public final fun getType ()Ljava/lang/String;
+	public final fun getWidth ()Ljava/lang/Integer;
+	public final fun getZero ()Z
+	public final fun setAlign (Ljava/lang/String;)V
+	public final fun setComma (Z)V
+	public final fun setFill (Ljava/lang/String;)V
+	public final fun setPrecision (Ljava/lang/Integer;)V
+	public final fun setSign (Ljava/lang/String;)V
+	public final fun setSymbol (Ljava/lang/String;)V
+	public final fun setTrim (Z)V
+	public final fun setType (Ljava/lang/String;)V
+	public final fun setWidth (Ljava/lang/Integer;)V
+	public final fun setZero (Z)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/juul/krayon/format/FormatSpecifierKt {
+	public static final fun formatSpecifier (Ljava/lang/String;)Lcom/juul/krayon/format/FormatSpecifier;
+}
+
+public final class com/juul/krayon/format/NumberFormat {
+	public final fun invoke (D)Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+

--- a/format/api/format.api
+++ b/format/api/format.api
@@ -1,0 +1,82 @@
+public final class com/juul/krayon/format/FormatKt {
+	public static final fun format (Lcom/juul/krayon/format/FormatSpecifier;)Lcom/juul/krayon/format/NumberFormat;
+	public static final fun format (Ljava/lang/String;)Lcom/juul/krayon/format/NumberFormat;
+	public static final fun formatPrefix (Ljava/lang/String;D)Lcom/juul/krayon/format/NumberFormat;
+	public static final fun getEnUS ()Lcom/juul/krayon/format/FormatLocaleDefinition;
+	public static final fun precisionFixed (D)I
+	public static final fun precisionPrefix (DD)I
+	public static final fun precisionRound (DD)I
+}
+
+public final class com/juul/krayon/format/FormatLocale {
+	public fun <init> (Lcom/juul/krayon/format/FormatLocaleDefinition;)V
+	public final fun format (Lcom/juul/krayon/format/FormatSpecifier;)Lcom/juul/krayon/format/NumberFormat;
+	public final fun format (Ljava/lang/String;)Lcom/juul/krayon/format/NumberFormat;
+	public final fun formatPrefix (Ljava/lang/String;D)Lcom/juul/krayon/format/NumberFormat;
+}
+
+public final class com/juul/krayon/format/FormatLocaleDefinition {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/util/List;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/juul/krayon/format/FormatLocaleDefinition;
+	public static synthetic fun copy$default (Lcom/juul/krayon/format/FormatLocaleDefinition;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/juul/krayon/format/FormatLocaleDefinition;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCurrencyPrefix ()Ljava/lang/String;
+	public final fun getCurrencySuffix ()Ljava/lang/String;
+	public final fun getDecimal ()Ljava/lang/String;
+	public final fun getGrouping ()Ljava/util/List;
+	public final fun getMinus ()Ljava/lang/String;
+	public final fun getNan ()Ljava/lang/String;
+	public final fun getNumerals ()Ljava/util/List;
+	public final fun getPercent ()Ljava/lang/String;
+	public final fun getThousands ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/juul/krayon/format/FormatSpecifier {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/Integer;ZLjava/lang/Integer;ZLjava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/Integer;ZLjava/lang/Integer;ZLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getAlign ()Ljava/lang/String;
+	public final fun getComma ()Z
+	public final fun getFill ()Ljava/lang/String;
+	public final fun getPrecision ()Ljava/lang/Integer;
+	public final fun getSign ()Ljava/lang/String;
+	public final fun getSymbol ()Ljava/lang/String;
+	public final fun getTrim ()Z
+	public final fun getType ()Ljava/lang/String;
+	public final fun getWidth ()Ljava/lang/Integer;
+	public final fun getZero ()Z
+	public final fun setAlign (Ljava/lang/String;)V
+	public final fun setComma (Z)V
+	public final fun setFill (Ljava/lang/String;)V
+	public final fun setPrecision (Ljava/lang/Integer;)V
+	public final fun setSign (Ljava/lang/String;)V
+	public final fun setSymbol (Ljava/lang/String;)V
+	public final fun setTrim (Z)V
+	public final fun setType (Ljava/lang/String;)V
+	public final fun setWidth (Ljava/lang/Integer;)V
+	public final fun setZero (Z)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/juul/krayon/format/FormatSpecifierKt {
+	public static final fun formatSpecifier (Ljava/lang/String;)Lcom/juul/krayon/format/FormatSpecifier;
+}
+
+public final class com/juul/krayon/format/NumberFormat {
+	public final fun invoke (D)Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+

--- a/format/api/format.klib.api
+++ b/format/api/format.klib.api
@@ -1,0 +1,105 @@
+// Klib ABI Dump
+// Targets: [iosArm64, iosSimulatorArm64, js, macosArm64, wasmJs]
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: true
+// - Show declarations: true
+
+// Library unique name: <com.juul.krayon:format>
+final class com.juul.krayon.format/FormatLocale { // com.juul.krayon.format/FormatLocale|null[0]
+    constructor <init>(com.juul.krayon.format/FormatLocaleDefinition) // com.juul.krayon.format/FormatLocale.<init>|<init>(com.juul.krayon.format.FormatLocaleDefinition){}[0]
+
+    final fun format(com.juul.krayon.format/FormatSpecifier): com.juul.krayon.format/NumberFormat // com.juul.krayon.format/FormatLocale.format|format(com.juul.krayon.format.FormatSpecifier){}[0]
+    final fun format(kotlin/String): com.juul.krayon.format/NumberFormat // com.juul.krayon.format/FormatLocale.format|format(kotlin.String){}[0]
+    final fun formatPrefix(kotlin/String, kotlin/Double): com.juul.krayon.format/NumberFormat // com.juul.krayon.format/FormatLocale.formatPrefix|formatPrefix(kotlin.String;kotlin.Double){}[0]
+}
+
+final class com.juul.krayon.format/FormatLocaleDefinition { // com.juul.krayon.format/FormatLocaleDefinition|null[0]
+    constructor <init>(kotlin/String = ..., kotlin/String? = ..., kotlin.collections/List<kotlin/Int>? = ..., kotlin/String = ..., kotlin/String = ..., kotlin.collections/List<kotlin/String>? = ..., kotlin/String = ..., kotlin/String = ..., kotlin/String = ...) // com.juul.krayon.format/FormatLocaleDefinition.<init>|<init>(kotlin.String;kotlin.String?;kotlin.collections.List<kotlin.Int>?;kotlin.String;kotlin.String;kotlin.collections.List<kotlin.String>?;kotlin.String;kotlin.String;kotlin.String){}[0]
+
+    final val currencyPrefix // com.juul.krayon.format/FormatLocaleDefinition.currencyPrefix|{}currencyPrefix[0]
+        final fun <get-currencyPrefix>(): kotlin/String // com.juul.krayon.format/FormatLocaleDefinition.currencyPrefix.<get-currencyPrefix>|<get-currencyPrefix>(){}[0]
+    final val currencySuffix // com.juul.krayon.format/FormatLocaleDefinition.currencySuffix|{}currencySuffix[0]
+        final fun <get-currencySuffix>(): kotlin/String // com.juul.krayon.format/FormatLocaleDefinition.currencySuffix.<get-currencySuffix>|<get-currencySuffix>(){}[0]
+    final val decimal // com.juul.krayon.format/FormatLocaleDefinition.decimal|{}decimal[0]
+        final fun <get-decimal>(): kotlin/String // com.juul.krayon.format/FormatLocaleDefinition.decimal.<get-decimal>|<get-decimal>(){}[0]
+    final val grouping // com.juul.krayon.format/FormatLocaleDefinition.grouping|{}grouping[0]
+        final fun <get-grouping>(): kotlin.collections/List<kotlin/Int>? // com.juul.krayon.format/FormatLocaleDefinition.grouping.<get-grouping>|<get-grouping>(){}[0]
+    final val minus // com.juul.krayon.format/FormatLocaleDefinition.minus|{}minus[0]
+        final fun <get-minus>(): kotlin/String // com.juul.krayon.format/FormatLocaleDefinition.minus.<get-minus>|<get-minus>(){}[0]
+    final val nan // com.juul.krayon.format/FormatLocaleDefinition.nan|{}nan[0]
+        final fun <get-nan>(): kotlin/String // com.juul.krayon.format/FormatLocaleDefinition.nan.<get-nan>|<get-nan>(){}[0]
+    final val numerals // com.juul.krayon.format/FormatLocaleDefinition.numerals|{}numerals[0]
+        final fun <get-numerals>(): kotlin.collections/List<kotlin/String>? // com.juul.krayon.format/FormatLocaleDefinition.numerals.<get-numerals>|<get-numerals>(){}[0]
+    final val percent // com.juul.krayon.format/FormatLocaleDefinition.percent|{}percent[0]
+        final fun <get-percent>(): kotlin/String // com.juul.krayon.format/FormatLocaleDefinition.percent.<get-percent>|<get-percent>(){}[0]
+    final val thousands // com.juul.krayon.format/FormatLocaleDefinition.thousands|{}thousands[0]
+        final fun <get-thousands>(): kotlin/String? // com.juul.krayon.format/FormatLocaleDefinition.thousands.<get-thousands>|<get-thousands>(){}[0]
+
+    final fun component1(): kotlin/String // com.juul.krayon.format/FormatLocaleDefinition.component1|component1(){}[0]
+    final fun component2(): kotlin/String? // com.juul.krayon.format/FormatLocaleDefinition.component2|component2(){}[0]
+    final fun component3(): kotlin.collections/List<kotlin/Int>? // com.juul.krayon.format/FormatLocaleDefinition.component3|component3(){}[0]
+    final fun component4(): kotlin/String // com.juul.krayon.format/FormatLocaleDefinition.component4|component4(){}[0]
+    final fun component5(): kotlin/String // com.juul.krayon.format/FormatLocaleDefinition.component5|component5(){}[0]
+    final fun component6(): kotlin.collections/List<kotlin/String>? // com.juul.krayon.format/FormatLocaleDefinition.component6|component6(){}[0]
+    final fun component7(): kotlin/String // com.juul.krayon.format/FormatLocaleDefinition.component7|component7(){}[0]
+    final fun component8(): kotlin/String // com.juul.krayon.format/FormatLocaleDefinition.component8|component8(){}[0]
+    final fun component9(): kotlin/String // com.juul.krayon.format/FormatLocaleDefinition.component9|component9(){}[0]
+    final fun copy(kotlin/String = ..., kotlin/String? = ..., kotlin.collections/List<kotlin/Int>? = ..., kotlin/String = ..., kotlin/String = ..., kotlin.collections/List<kotlin/String>? = ..., kotlin/String = ..., kotlin/String = ..., kotlin/String = ...): com.juul.krayon.format/FormatLocaleDefinition // com.juul.krayon.format/FormatLocaleDefinition.copy|copy(kotlin.String;kotlin.String?;kotlin.collections.List<kotlin.Int>?;kotlin.String;kotlin.String;kotlin.collections.List<kotlin.String>?;kotlin.String;kotlin.String;kotlin.String){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.juul.krayon.format/FormatLocaleDefinition.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.juul.krayon.format/FormatLocaleDefinition.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.juul.krayon.format/FormatLocaleDefinition.toString|toString(){}[0]
+}
+
+final class com.juul.krayon.format/FormatSpecifier { // com.juul.krayon.format/FormatSpecifier|null[0]
+    constructor <init>(kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin/Boolean = ..., kotlin/Int? = ..., kotlin/Boolean = ..., kotlin/Int? = ..., kotlin/Boolean = ..., kotlin/String? = ...) // com.juul.krayon.format/FormatSpecifier.<init>|<init>(kotlin.String?;kotlin.String?;kotlin.String?;kotlin.String?;kotlin.Boolean;kotlin.Int?;kotlin.Boolean;kotlin.Int?;kotlin.Boolean;kotlin.String?){}[0]
+
+    final var align // com.juul.krayon.format/FormatSpecifier.align|{}align[0]
+        final fun <get-align>(): kotlin/String // com.juul.krayon.format/FormatSpecifier.align.<get-align>|<get-align>(){}[0]
+        final fun <set-align>(kotlin/String) // com.juul.krayon.format/FormatSpecifier.align.<set-align>|<set-align>(kotlin.String){}[0]
+    final var comma // com.juul.krayon.format/FormatSpecifier.comma|{}comma[0]
+        final fun <get-comma>(): kotlin/Boolean // com.juul.krayon.format/FormatSpecifier.comma.<get-comma>|<get-comma>(){}[0]
+        final fun <set-comma>(kotlin/Boolean) // com.juul.krayon.format/FormatSpecifier.comma.<set-comma>|<set-comma>(kotlin.Boolean){}[0]
+    final var fill // com.juul.krayon.format/FormatSpecifier.fill|{}fill[0]
+        final fun <get-fill>(): kotlin/String // com.juul.krayon.format/FormatSpecifier.fill.<get-fill>|<get-fill>(){}[0]
+        final fun <set-fill>(kotlin/String) // com.juul.krayon.format/FormatSpecifier.fill.<set-fill>|<set-fill>(kotlin.String){}[0]
+    final var precision // com.juul.krayon.format/FormatSpecifier.precision|{}precision[0]
+        final fun <get-precision>(): kotlin/Int? // com.juul.krayon.format/FormatSpecifier.precision.<get-precision>|<get-precision>(){}[0]
+        final fun <set-precision>(kotlin/Int?) // com.juul.krayon.format/FormatSpecifier.precision.<set-precision>|<set-precision>(kotlin.Int?){}[0]
+    final var sign // com.juul.krayon.format/FormatSpecifier.sign|{}sign[0]
+        final fun <get-sign>(): kotlin/String // com.juul.krayon.format/FormatSpecifier.sign.<get-sign>|<get-sign>(){}[0]
+        final fun <set-sign>(kotlin/String) // com.juul.krayon.format/FormatSpecifier.sign.<set-sign>|<set-sign>(kotlin.String){}[0]
+    final var symbol // com.juul.krayon.format/FormatSpecifier.symbol|{}symbol[0]
+        final fun <get-symbol>(): kotlin/String // com.juul.krayon.format/FormatSpecifier.symbol.<get-symbol>|<get-symbol>(){}[0]
+        final fun <set-symbol>(kotlin/String) // com.juul.krayon.format/FormatSpecifier.symbol.<set-symbol>|<set-symbol>(kotlin.String){}[0]
+    final var trim // com.juul.krayon.format/FormatSpecifier.trim|{}trim[0]
+        final fun <get-trim>(): kotlin/Boolean // com.juul.krayon.format/FormatSpecifier.trim.<get-trim>|<get-trim>(){}[0]
+        final fun <set-trim>(kotlin/Boolean) // com.juul.krayon.format/FormatSpecifier.trim.<set-trim>|<set-trim>(kotlin.Boolean){}[0]
+    final var type // com.juul.krayon.format/FormatSpecifier.type|{}type[0]
+        final fun <get-type>(): kotlin/String // com.juul.krayon.format/FormatSpecifier.type.<get-type>|<get-type>(){}[0]
+        final fun <set-type>(kotlin/String) // com.juul.krayon.format/FormatSpecifier.type.<set-type>|<set-type>(kotlin.String){}[0]
+    final var width // com.juul.krayon.format/FormatSpecifier.width|{}width[0]
+        final fun <get-width>(): kotlin/Int? // com.juul.krayon.format/FormatSpecifier.width.<get-width>|<get-width>(){}[0]
+        final fun <set-width>(kotlin/Int?) // com.juul.krayon.format/FormatSpecifier.width.<set-width>|<set-width>(kotlin.Int?){}[0]
+    final var zero // com.juul.krayon.format/FormatSpecifier.zero|{}zero[0]
+        final fun <get-zero>(): kotlin/Boolean // com.juul.krayon.format/FormatSpecifier.zero.<get-zero>|<get-zero>(){}[0]
+        final fun <set-zero>(kotlin/Boolean) // com.juul.krayon.format/FormatSpecifier.zero.<set-zero>|<set-zero>(kotlin.Boolean){}[0]
+
+    final fun toString(): kotlin/String // com.juul.krayon.format/FormatSpecifier.toString|toString(){}[0]
+}
+
+final class com.juul.krayon.format/NumberFormat { // com.juul.krayon.format/NumberFormat|null[0]
+    final fun invoke(kotlin/Double): kotlin/String // com.juul.krayon.format/NumberFormat.invoke|invoke(kotlin.Double){}[0]
+    final fun toString(): kotlin/String // com.juul.krayon.format/NumberFormat.toString|toString(){}[0]
+}
+
+final val com.juul.krayon.format/enUS // com.juul.krayon.format/enUS|{}enUS[0]
+    final fun <get-enUS>(): com.juul.krayon.format/FormatLocaleDefinition // com.juul.krayon.format/enUS.<get-enUS>|<get-enUS>(){}[0]
+
+final fun com.juul.krayon.format/format(com.juul.krayon.format/FormatSpecifier): com.juul.krayon.format/NumberFormat // com.juul.krayon.format/format|format(com.juul.krayon.format.FormatSpecifier){}[0]
+final fun com.juul.krayon.format/format(kotlin/String): com.juul.krayon.format/NumberFormat // com.juul.krayon.format/format|format(kotlin.String){}[0]
+final fun com.juul.krayon.format/formatPrefix(kotlin/String, kotlin/Double): com.juul.krayon.format/NumberFormat // com.juul.krayon.format/formatPrefix|formatPrefix(kotlin.String;kotlin.Double){}[0]
+final fun com.juul.krayon.format/formatSpecifier(kotlin/String): com.juul.krayon.format/FormatSpecifier // com.juul.krayon.format/formatSpecifier|formatSpecifier(kotlin.String){}[0]
+final fun com.juul.krayon.format/precisionFixed(kotlin/Double): kotlin/Int // com.juul.krayon.format/precisionFixed|precisionFixed(kotlin.Double){}[0]
+final fun com.juul.krayon.format/precisionPrefix(kotlin/Double, kotlin/Double): kotlin/Int // com.juul.krayon.format/precisionPrefix|precisionPrefix(kotlin.Double;kotlin.Double){}[0]
+final fun com.juul.krayon.format/precisionRound(kotlin/Double, kotlin/Double): kotlin/Int // com.juul.krayon.format/precisionRound|precisionRound(kotlin.Double;kotlin.Double){}[0]

--- a/format/api/jvm/format.api
+++ b/format/api/jvm/format.api
@@ -1,0 +1,82 @@
+public final class com/juul/krayon/format/FormatKt {
+	public static final fun format (Lcom/juul/krayon/format/FormatSpecifier;)Lcom/juul/krayon/format/NumberFormat;
+	public static final fun format (Ljava/lang/String;)Lcom/juul/krayon/format/NumberFormat;
+	public static final fun formatPrefix (Ljava/lang/String;D)Lcom/juul/krayon/format/NumberFormat;
+	public static final fun getEnUS ()Lcom/juul/krayon/format/FormatLocaleDefinition;
+	public static final fun precisionFixed (D)I
+	public static final fun precisionPrefix (DD)I
+	public static final fun precisionRound (DD)I
+}
+
+public final class com/juul/krayon/format/FormatLocale {
+	public fun <init> (Lcom/juul/krayon/format/FormatLocaleDefinition;)V
+	public final fun format (Lcom/juul/krayon/format/FormatSpecifier;)Lcom/juul/krayon/format/NumberFormat;
+	public final fun format (Ljava/lang/String;)Lcom/juul/krayon/format/NumberFormat;
+	public final fun formatPrefix (Ljava/lang/String;D)Lcom/juul/krayon/format/NumberFormat;
+}
+
+public final class com/juul/krayon/format/FormatLocaleDefinition {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/util/List;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/juul/krayon/format/FormatLocaleDefinition;
+	public static synthetic fun copy$default (Lcom/juul/krayon/format/FormatLocaleDefinition;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/juul/krayon/format/FormatLocaleDefinition;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCurrencyPrefix ()Ljava/lang/String;
+	public final fun getCurrencySuffix ()Ljava/lang/String;
+	public final fun getDecimal ()Ljava/lang/String;
+	public final fun getGrouping ()Ljava/util/List;
+	public final fun getMinus ()Ljava/lang/String;
+	public final fun getNan ()Ljava/lang/String;
+	public final fun getNumerals ()Ljava/util/List;
+	public final fun getPercent ()Ljava/lang/String;
+	public final fun getThousands ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/juul/krayon/format/FormatSpecifier {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/Integer;ZLjava/lang/Integer;ZLjava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/Integer;ZLjava/lang/Integer;ZLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getAlign ()Ljava/lang/String;
+	public final fun getComma ()Z
+	public final fun getFill ()Ljava/lang/String;
+	public final fun getPrecision ()Ljava/lang/Integer;
+	public final fun getSign ()Ljava/lang/String;
+	public final fun getSymbol ()Ljava/lang/String;
+	public final fun getTrim ()Z
+	public final fun getType ()Ljava/lang/String;
+	public final fun getWidth ()Ljava/lang/Integer;
+	public final fun getZero ()Z
+	public final fun setAlign (Ljava/lang/String;)V
+	public final fun setComma (Z)V
+	public final fun setFill (Ljava/lang/String;)V
+	public final fun setPrecision (Ljava/lang/Integer;)V
+	public final fun setSign (Ljava/lang/String;)V
+	public final fun setSymbol (Ljava/lang/String;)V
+	public final fun setTrim (Z)V
+	public final fun setType (Ljava/lang/String;)V
+	public final fun setWidth (Ljava/lang/Integer;)V
+	public final fun setZero (Z)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/juul/krayon/format/FormatSpecifierKt {
+	public static final fun formatSpecifier (Ljava/lang/String;)Lcom/juul/krayon/format/FormatSpecifier;
+}
+
+public final class com/juul/krayon/format/NumberFormat {
+	public final fun invoke (D)Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+

--- a/format/build.gradle.kts
+++ b/format/build.gradle.kts
@@ -1,0 +1,3 @@
+plugins {
+    id("library-conventions")
+}

--- a/format/src/commonMain/kotlin/Bignum.kt
+++ b/format/src/commonMain/kotlin/Bignum.kt
@@ -1,0 +1,146 @@
+package com.juul.krayon.format
+
+internal class Bignum private constructor(private val words: IntArray) {
+
+    fun isZero(): Boolean = words.isEmpty()
+
+    fun compareTo(other: Bignum): Int {
+        if (words.size != other.words.size) return words.size.compareTo(other.words.size)
+        for (i in words.indices.reversed()) {
+            if (words[i] != other.words[i]) return words[i].compareTo(other.words[i])
+        }
+        return 0
+    }
+
+    fun timesSmall(multiplier: Int): Bignum {
+        if (multiplier == 0 || isZero()) return ZERO
+        if (multiplier == 1) return this
+        val result = IntArray(words.size + 1)
+        var carry = 0L
+        for (i in words.indices) {
+            val current = words[i].toLong() * multiplier + carry
+            result[i] = (current % BASE).toInt()
+            carry = current / BASE
+        }
+        result[words.size] = carry.toInt()
+        return of(result)
+    }
+
+    fun timesPow(base: Int, exponent: Int): Bignum {
+        if (exponent <= 0) return this
+        val (chunk, chunkExponent) = when (base) {
+            2 -> CHUNK_TWO
+            5 -> CHUNK_FIVE
+            10 -> CHUNK_TEN
+            else -> error("Unsupported base $base")
+        }
+        var result = this
+        var remaining = exponent
+        while (remaining >= chunkExponent) {
+            result = result.timesSmall(chunk)
+            remaining -= chunkExponent
+        }
+        var tail = 1
+        repeat(remaining) { tail *= base }
+        if (tail != 1) result = result.timesSmall(tail)
+        return result
+    }
+
+    fun plus(other: Bignum): Bignum {
+        if (isZero()) return other
+        if (other.isZero()) return this
+        val size = maxOf(words.size, other.words.size) + 1
+        val result = IntArray(size)
+        var carry = 0L
+        for (i in 0 until size) {
+            val a = if (i < words.size) words[i].toLong() else 0L
+            val b = if (i < other.words.size) other.words[i].toLong() else 0L
+            val sum = a + b + carry
+            result[i] = (sum % BASE).toInt()
+            carry = sum / BASE
+        }
+        return of(result)
+    }
+
+    /** Returns `floor(this / 10^exponent)`. */
+    fun divPow10(exponent: Int): Bignum {
+        if (exponent <= 0 || isZero()) return this
+        val wholeWords = exponent / DIGITS_PER_WORD
+        val remainderDigits = exponent % DIGITS_PER_WORD
+        if (wholeWords >= words.size) return ZERO
+        var shifted = of(words.copyOfRange(wholeWords, words.size))
+        if (remainderDigits > 0) {
+            var divisor = 1
+            repeat(remainderDigits) { divisor *= 10 }
+            shifted = shifted.divModSmall(divisor).first
+        }
+        return shifted
+    }
+
+    fun divModSmall(divisor: Int): Pair<Bignum, Int> {
+        val result = IntArray(words.size)
+        var remainder = 0L
+        for (i in words.indices.reversed()) {
+            val current = remainder * BASE + words[i]
+            result[i] = (current / divisor).toInt()
+            remainder = current % divisor
+        }
+        return of(result) to remainder.toInt()
+    }
+
+    fun toDecimalString(): String {
+        if (isZero()) return "0"
+        return buildString {
+            append(words.last())
+            for (i in words.size - 2 downTo 0) {
+                val chunk = words[i].toString()
+                repeat(DIGITS_PER_WORD - chunk.length) { append('0') }
+                append(chunk)
+            }
+        }
+    }
+
+    fun toStringRadix(radix: Int): String {
+        if (isZero()) return "0"
+        val digits = StringBuilder()
+        var current = this
+        while (!current.isZero()) {
+            val (quotient, remainder) = current.divModSmall(radix)
+            digits.append(RADIX_DIGITS[remainder])
+            current = quotient
+        }
+        return digits.reverse().toString()
+    }
+
+    companion object {
+        private const val DIGITS_PER_WORD = 9
+        private const val BASE = 1_000_000_000L
+        private const val RADIX_DIGITS = "0123456789abcdef"
+        private val CHUNK_TWO = 536_870_912 to 29 // 2^29 < 10^9
+        private val CHUNK_FIVE = 244_140_625 to 12 // 5^12 < 10^9
+        private val CHUNK_TEN = 100_000_000 to 8 // 10^8 < 10^9
+
+        val ZERO: Bignum = Bignum(IntArray(0))
+
+        private fun of(rawWords: IntArray): Bignum {
+            var size = rawWords.size
+            while (size > 0 && rawWords[size - 1] == 0) size--
+            if (size == 0) return ZERO
+            return Bignum(if (size == rawWords.size) rawWords else rawWords.copyOf(size))
+        }
+
+        fun of(value: Long): Bignum {
+            require(value >= 0) { "Bignum only represents non-negative values." }
+            if (value == 0L) return ZERO
+            var remaining = value
+            val words = ArrayList<Int>(3)
+            while (remaining > 0) {
+                words.add((remaining % BASE).toInt())
+                remaining /= BASE
+            }
+            return of(words.toIntArray())
+        }
+
+        fun tenPow(exponent: Int): Bignum = of(1L).timesPow(10, exponent)
+    }
+}

--- a/format/src/commonMain/kotlin/Format.kt
+++ b/format/src/commonMain/kotlin/Format.kt
@@ -1,0 +1,61 @@
+package com.juul.krayon.format
+
+import kotlin.math.abs
+
+/** The default `en-US` locale definition. See [d3](https://github.com/d3/d3-format/blob/main/locale/en-US.json). */
+public val enUS: FormatLocaleDefinition = FormatLocaleDefinition(
+    decimal = ".",
+    thousands = ",",
+    grouping = listOf(3),
+    currencyPrefix = "$",
+    currencySuffix = "",
+)
+
+private val defaultLocale = FormatLocale(enUS)
+
+/** Builds a formatter from a [specifier] string using the default [enUS] locale. */
+public fun format(specifier: String): NumberFormat = defaultLocale.format(specifier)
+
+/** Builds a formatter from a parsed [specifier] using the default [enUS] locale. */
+public fun format(specifier: FormatSpecifier): NumberFormat = defaultLocale.format(specifier)
+
+/** Builds an SI-prefix formatter for [value] using the default [enUS] locale. */
+public fun formatPrefix(specifier: String, value: Double): NumberFormat = defaultLocale.formatPrefix(specifier, value)
+
+/**
+ * Returns the suggested decimal precision for fixed-point notation given a [step].
+ *
+ * See the equivalent [d3 function](https://github.com/d3/d3-format#precisionFixed).
+ */
+public fun precisionFixed(step: Double): Int {
+    val exponent = exponent10(step) ?: throw IllegalArgumentException("step must be finite and non-zero, but was $step")
+    return maxOf(0, -exponent)
+}
+
+/**
+ * Returns the suggested decimal precision for rounding to significant digits over a [step] and [max] range.
+ *
+ * See the equivalent [d3 function](https://github.com/d3/d3-format#precisionRound).
+ */
+public fun precisionRound(step: Double, max: Double): Int {
+    val absStep = abs(step)
+    val stepExponent = exponent10(absStep)
+        ?: throw IllegalArgumentException("step must be finite and non-zero, but was $step")
+    val difference = abs(max) - absStep
+    val differenceExponent = exponent10(difference)
+        ?: throw IllegalArgumentException("abs(max) - abs(step) must be finite and non-zero, but was $difference")
+    return maxOf(0, differenceExponent - stepExponent) + 1
+}
+
+/**
+ * Returns the suggested decimal precision for SI-prefix notation given a [step] and reference [value].
+ *
+ * See the equivalent [d3 function](https://github.com/d3/d3-format#precisionPrefix).
+ */
+public fun precisionPrefix(step: Double, value: Double): Int {
+    val valueExponent = exponent10(value)
+        ?: throw IllegalArgumentException("value must be finite and non-zero, but was $value")
+    val stepExponent = exponent10(step)
+        ?: throw IllegalArgumentException("step must be finite and non-zero, but was $step")
+    return maxOf(0, maxOf(-8, minOf(8, valueExponent.floorDiv(3))) * 3 - stepExponent)
+}

--- a/format/src/commonMain/kotlin/FormatLocale.kt
+++ b/format/src/commonMain/kotlin/FormatLocale.kt
@@ -1,0 +1,271 @@
+package com.juul.krayon.format
+
+import kotlin.math.pow
+
+private val siPrefixes =
+    listOf("y", "z", "a", "f", "p", "n", "\u00b5", "m", "", "k", "M", "G", "T", "P", "E", "Z", "Y")
+
+private val knownTypes = setOf("e", "f", "g", "r", "s", "%", "p", "b", "o", "d", "x", "X", "c")
+private val radixTypes = setOf("b", "o", "x", "X")
+
+/**
+ * The locale-specific definitions used to build a [FormatLocale].
+ *
+ * See the equivalent [d3 definition](https://github.com/d3/d3-format#locale_format).
+ */
+public data class FormatLocaleDefinition(
+    val decimal: String = ".",
+    val thousands: String? = null,
+    val grouping: List<Int>? = null,
+    val currencyPrefix: String = "",
+    val currencySuffix: String = "",
+    val numerals: List<String>? = null,
+    val percent: String = "%",
+    val minus: String = "\u2212",
+    val nan: String = "NaN",
+)
+
+/** A number formatter bound to a [FormatSpecifier] and its [FormatLocale]. Invoke it with a value to format. */
+public class NumberFormat internal constructor(
+    private val specifier: FormatSpecifier,
+    private val delegate: (Double) -> String,
+) {
+    public operator fun invoke(value: Double): String = delegate(value)
+
+    override fun toString(): String = specifier.toString()
+}
+
+/**
+ * A locale-aware factory for number formatters.
+ *
+ * See the equivalent [d3 factory](https://github.com/d3/d3-format#formatLocale).
+ */
+public class FormatLocale(definition: FormatLocaleDefinition) {
+
+    private val decimal = definition.decimal
+    private val thousands = definition.thousands
+    private val grouping = definition.grouping
+    private val currencyPrefix = definition.currencyPrefix
+    private val currencySuffix = definition.currencySuffix
+    private val numerals = definition.numerals
+    private val percent = definition.percent
+    private val minus = definition.minus
+    private val nan = definition.nan
+
+    /** Builds a formatter from a [specifier] string. See [d3](https://github.com/d3/d3-format#locale_format). */
+    public fun format(specifier: String): NumberFormat = format(formatSpecifier(specifier))
+
+    /** Builds a formatter from a parsed [specifier]. */
+    public fun format(specifier: FormatSpecifier): NumberFormat = build(specifier, "", "")
+
+    /**
+     * Builds a formatter that always uses the SI prefix appropriate for [value].
+     *
+     * See the equivalent [d3 function](https://github.com/d3/d3-format#locale_formatPrefix).
+     */
+    public fun formatPrefix(specifier: String, value: Double): NumberFormat {
+        val parsed = formatSpecifier(specifier)
+        parsed.type = "f"
+        val exponent = maxOf(-8, minOf(8, (exponent10(value) ?: 0).floorDiv(3))) * 3
+        val factor = 10.0.pow(-exponent)
+        val prefixSuffix = siPrefixes[8 + exponent / 3]
+        val inner = build(parsed, "", prefixSuffix)
+        return NumberFormat(parsed) { inner(factor * it) }
+    }
+
+    private fun build(specifier: FormatSpecifier, optionPrefix: String, optionSuffix: String): NumberFormat {
+        val fillInput = specifier.fill
+        val alignInput = specifier.align
+        val sign = specifier.sign
+        val symbol = specifier.symbol
+        val width = specifier.width
+        var comma = specifier.comma
+        var precisionInput = specifier.precision
+        var trim = specifier.trim
+        var type = specifier.type
+
+        if (type == "n") {
+            comma = true
+            type = "g"
+        } else if (type !in knownTypes) {
+            if (precisionInput == null) precisionInput = 12
+            trim = true
+            type = "g"
+        }
+
+        var zero = specifier.zero
+        var fill = fillInput
+        var align = alignInput
+        if (zero || (fill == "0" && align == "=")) {
+            zero = true
+            fill = "0"
+            align = "="
+        }
+
+        val symbolPrefix = when {
+            symbol == "$" -> currencyPrefix
+            symbol == "#" && type in radixTypes -> "0" + type.lowercase()
+            else -> ""
+        }
+        val symbolSuffix = when {
+            symbol == "$" -> currencySuffix
+            type == "%" || type == "p" -> percent
+            else -> ""
+        }
+        val basePrefix = optionPrefix + symbolPrefix
+        val baseSuffix = symbolSuffix + optionSuffix
+
+        val maybeSuffix = type in setOf("d", "e", "f", "g", "p", "r", "s", "%")
+
+        val precision = when {
+            precisionInput == null -> 6
+            type == "g" || type == "p" || type == "r" || type == "s" -> maxOf(1, minOf(21, precisionInput))
+            else -> maxOf(0, minOf(20, precisionInput))
+        }
+
+        val delegate: (Double) -> String = format@{ value ->
+            var valuePrefix = basePrefix
+            var valueSuffix = baseSuffix
+            var body: String
+
+            if (type == "c") {
+                valueSuffix = jsNumberToString(value) + valueSuffix
+                body = ""
+            } else {
+                var negative = value < 0.0 || (value == 0.0 && 1.0 / value < 0.0)
+                var prefixExponent: Int? = null
+                if (value.isNaN()) {
+                    body = nan
+                } else {
+                    val result = applyType(type, kotlin.math.abs(value), precision)
+                    body = result.first
+                    prefixExponent = result.second
+                }
+                if (trim) body = formatTrim(body)
+                if (negative && (body.toDoubleOrNull() == 0.0) && sign != "+") negative = false
+
+                valuePrefix = (
+                    if (negative) {
+                        if (sign == "(") "(" else minus
+                    } else {
+                        if (sign == "-" || sign == "(") "" else sign
+                    }
+                ) + valuePrefix
+
+                val siSuffix = if (type == "s" && prefixExponent != null) siPrefixes[8 + prefixExponent / 3] else ""
+                valueSuffix = siSuffix + valueSuffix + (if (negative && sign == "(") ")" else "")
+
+                if (maybeSuffix) {
+                    var i = 0
+                    while (i < body.length) {
+                        val code = body[i].code
+                        if (code < 48 || code > 57) {
+                            valueSuffix = (if (code == 46) decimal + body.substring(i + 1) else body.substring(i)) + valueSuffix
+                            body = body.substring(0, i)
+                            break
+                        }
+                        i++
+                    }
+                }
+            }
+
+            if (comma && !zero) body = group(body, Int.MAX_VALUE)
+
+            val length = valuePrefix.length + body.length + valueSuffix.length
+            var padding = if (width != null && length < width) fill.repeat(width - length) else ""
+
+            if (comma && zero) {
+                body = group(
+                    padding + body,
+                    if (padding.isNotEmpty() && width != null) width - valueSuffix.length else Int.MAX_VALUE,
+                )
+                padding = ""
+            }
+
+            val assembled = when (align) {
+                "<" -> valuePrefix + body + valueSuffix + padding
+                "=" -> valuePrefix + padding + body + valueSuffix
+                "^" -> {
+                    val half = padding.length shr 1
+                    padding.substring(0, half) + valuePrefix + body + valueSuffix + padding.substring(half)
+                }
+                else -> padding + valuePrefix + body + valueSuffix
+            }
+
+            applyNumerals(assembled)
+        }
+
+        return NumberFormat(specifier, delegate)
+    }
+
+    private fun applyType(type: String, absValue: Double, precision: Int): Pair<String, Int?> = when (type) {
+        "e" -> formatExponential(absValue, precision) to null
+        "f" -> formatFixed(absValue, precision) to null
+        "g" -> formatPrecision(absValue, precision) to null
+        "r" -> formatRounded(absValue, precision) to null
+        "s" -> formatPrefixAuto(absValue, precision)
+        "%" -> formatFixed(absValue * 100.0, precision) to null
+        "p" -> formatRounded(absValue * 100.0, precision) to null
+        "b" -> formatRadix(absValue, 2) to null
+        "o" -> formatRadix(absValue, 8) to null
+        "d" -> formatDecimalInteger(absValue) to null
+        "x" -> formatRadix(absValue, 16) to null
+        "X" -> formatRadix(absValue, 16).uppercase() to null
+        else -> jsNumberToString(absValue) to null
+    }
+
+    private fun group(value: String, width: Int): String {
+        val grouping = grouping
+        val thousands = thousands
+        if (grouping.isNullOrEmpty() || thousands == null) return value
+        val chunks = ArrayList<String>()
+        var index = value.length
+        var groupIndex = 0
+        var groupSize = grouping[0]
+        var consumed = 0
+        while (index > 0 && groupSize > 0) {
+            if (consumed + groupSize + 1 > width) groupSize = maxOf(1, width - consumed)
+            val end = index
+            index -= groupSize
+            val start = if (index < 0) 0 else index
+            chunks.add(value.substring(start, end))
+            consumed += groupSize + 1
+            if (consumed > width) break
+            groupIndex = (groupIndex + 1) % grouping.size
+            groupSize = grouping[groupIndex]
+        }
+        chunks.reverse()
+        return chunks.joinToString(separator = thousands)
+    }
+
+    private fun applyNumerals(value: String): String {
+        val numerals = numerals ?: return value
+        return buildString {
+            for (character in value) {
+                append(if (character in '0'..'9') numerals[character - '0'] else character.toString())
+            }
+        }
+    }
+}
+
+internal fun formatTrim(text: String): String {
+    var trimStart = -1
+    var trimEnd = 0
+    var i = 1
+    while (i < text.length) {
+        when (text[i]) {
+            '.' -> {
+                trimStart = i
+                trimEnd = i
+            }
+            '0' -> {
+                if (trimStart == 0) trimStart = i
+                trimEnd = i
+            }
+            in '1'..'9' -> if (trimStart > 0) trimStart = 0
+            else -> break
+        }
+        i++
+    }
+    return if (trimStart > 0) text.substring(0, trimStart) + text.substring(trimEnd + 1) else text
+}

--- a/format/src/commonMain/kotlin/FormatSpecifier.kt
+++ b/format/src/commonMain/kotlin/FormatSpecifier.kt
@@ -1,0 +1,130 @@
+package com.juul.krayon.format
+
+private const val ALIGN_CHARS = "<>=^"
+private const val SIGN_CHARS = "+-( "
+
+/**
+ * A parsed format specifier following the mini-language
+ * `[[fill]align][sign][symbol][0][width][,][.precision][~][type]`.
+ *
+ * See the equivalent [d3 type](https://github.com/d3/d3-format#formatSpecifier).
+ */
+public class FormatSpecifier(
+    fill: String? = null,
+    align: String? = null,
+    sign: String? = null,
+    symbol: String? = null,
+    zero: Boolean = false,
+    width: Int? = null,
+    comma: Boolean = false,
+    precision: Int? = null,
+    trim: Boolean = false,
+    type: String? = null,
+) {
+    public var fill: String = fill ?: " "
+    public var align: String = align ?: ">"
+    public var sign: String = sign ?: "-"
+    public var symbol: String = symbol ?: ""
+    public var zero: Boolean = zero
+    public var width: Int? = width
+    public var comma: Boolean = comma
+    public var precision: Int? = precision
+    public var trim: Boolean = trim
+    public var type: String = type ?: ""
+
+    override fun toString(): String = buildString {
+        append(fill)
+        append(align)
+        append(sign)
+        append(symbol)
+        append(if (zero) "0" else "")
+        append(width?.let { maxOf(1, it).toString() } ?: "")
+        append(if (comma) "," else "")
+        append(precision?.let { "." + maxOf(0, it) } ?: "")
+        append(if (trim) "~" else "")
+        append(type)
+    }
+}
+
+/**
+ * Parses a format [specifier] string following the grammar
+ * `[[fill]align][sign][symbol][0][width][,][.precision][~][type]`.
+ *
+ * See the equivalent [d3 function](https://github.com/d3/d3-format#formatSpecifier).
+ */
+public fun formatSpecifier(specifier: String): FormatSpecifier {
+    val length = specifier.length
+    var index = 0
+
+    var fill: String? = null
+    var align: String? = null
+    when {
+        index + 1 < length && specifier[index + 1] in ALIGN_CHARS -> {
+            fill = specifier[index].toString()
+            align = specifier[index + 1].toString()
+            index += 2
+        }
+        index < length && specifier[index] in ALIGN_CHARS -> {
+            align = specifier[index].toString()
+            index += 1
+        }
+    }
+
+    var sign: String? = null
+    if (index < length && specifier[index] in SIGN_CHARS) {
+        sign = specifier[index].toString()
+        index++
+    }
+
+    var symbol: String? = null
+    if (index < length && (specifier[index] == '$' || specifier[index] == '#')) {
+        symbol = specifier[index].toString()
+        index++
+    }
+
+    var zero = false
+    if (index < length && specifier[index] == '0') {
+        zero = true
+        index++
+    }
+
+    var width: Int? = null
+    val widthStart = index
+    while (index < length && specifier[index] in '0'..'9') index++
+    if (index > widthStart) width = specifier.substring(widthStart, index).toInt()
+
+    var comma = false
+    if (index < length && specifier[index] == ',') {
+        comma = true
+        index++
+    }
+
+    var precision: Int? = null
+    if (index < length && specifier[index] == '.') {
+        val precisionStart = index + 1
+        var precisionEnd = precisionStart
+        while (precisionEnd < length && specifier[precisionEnd] in '0'..'9') precisionEnd++
+        if (precisionEnd == precisionStart) throw IllegalArgumentException("invalid format: $specifier")
+        precision = specifier.substring(precisionStart, precisionEnd).toInt()
+        index = precisionEnd
+    }
+
+    var trim = false
+    if (index < length && specifier[index] == '~') {
+        trim = true
+        index++
+    }
+
+    var type: String? = null
+    if (index < length && isTypeCharacter(specifier[index])) {
+        type = specifier[index].toString()
+        index++
+    }
+
+    if (index != length) throw IllegalArgumentException("invalid format: $specifier")
+
+    return FormatSpecifier(fill, align, sign, symbol, zero, width, comma, precision, trim, type)
+}
+
+private fun isTypeCharacter(character: Char): Boolean =
+    character == '%' || character in 'a'..'z' || character in 'A'..'Z'

--- a/format/src/commonMain/kotlin/NumberStrings.kt
+++ b/format/src/commonMain/kotlin/NumberStrings.kt
@@ -1,0 +1,219 @@
+package com.juul.krayon.format
+
+import kotlin.math.abs
+import kotlin.math.floor
+import kotlin.math.log10
+
+private class DoubleParts(val significand: Long, val binaryExponent: Int)
+
+private fun decompose(absValue: Double): DoubleParts {
+    val bits = absValue.toRawBits()
+    val rawExponent = ((bits ushr 52) and 0x7FF).toInt()
+    val mantissa = bits and 0x000FFFFFFFFFFFFFL
+    return if (rawExponent == 0) {
+        DoubleParts(mantissa, -1074)
+    } else {
+        DoubleParts(mantissa or 0x0010000000000000L, rawExponent - 1075)
+    }
+}
+
+/** Returns `round(|value| * 10^scale)` as a non-negative integer, rounding halves away from zero. */
+private fun roundToScaleBignum(value: Double, scale: Int): Bignum {
+    val absValue = abs(value)
+    if (absValue == 0.0) return Bignum.ZERO
+    val parts = decompose(absValue)
+    val powerOfTwo = parts.binaryExponent + scale
+    val powerOfFive = scale
+    val denominatorTwo = if (powerOfTwo < 0) -powerOfTwo else 0
+    val denominatorFive = if (powerOfFive < 0) -powerOfFive else 0
+    val commonDenominator = maxOf(denominatorTwo, denominatorFive)
+    val exponentTwo = powerOfTwo + commonDenominator
+    val exponentFive = powerOfFive + commonDenominator
+    var numerator = Bignum.of(parts.significand).timesPow(2, exponentTwo).timesPow(5, exponentFive)
+    if (commonDenominator == 0) return numerator
+    val half = Bignum.of(5L).timesPow(10, commonDenominator - 1)
+    numerator = numerator.plus(half)
+    return numerator.divPow10(commonDenominator)
+}
+
+private fun compareToPowerOfTen(absValue: Double, exponent: Int): Int {
+    val parts = decompose(absValue)
+    val binaryExponent = parts.binaryExponent
+    var lhs = Bignum.of(parts.significand)
+    if (binaryExponent > 0) lhs = lhs.timesPow(2, binaryExponent)
+    if (exponent < 0) lhs = lhs.timesPow(10, -exponent)
+    var rhs = Bignum.of(1L)
+    if (binaryExponent < 0) rhs = rhs.timesPow(2, -binaryExponent)
+    if (exponent > 0) rhs = rhs.timesPow(10, exponent)
+    return lhs.compareTo(rhs)
+}
+
+/** Exact `floor(log10(|value|))` for finite, non-zero input. */
+private fun exactFloorLog10(absValue: Double): Int {
+    var estimate = floor(log10(absValue)).toInt()
+    while (compareToPowerOfTen(absValue, estimate) < 0) estimate--
+    while (compareToPowerOfTen(absValue, estimate + 1) >= 0) estimate++
+    return estimate
+}
+
+/** Correctly-rounded [precision] significant digits and the base-10 exponent of the first digit. */
+private fun exactSignificantDigits(absValue: Double, precision: Int): Pair<String, Int> {
+    val exponent = exactFloorLog10(absValue)
+    val scale = precision - 1 - exponent
+    val rounded = roundToScaleBignum(absValue, scale).toDecimalString()
+    return if (rounded.length > precision) {
+        rounded.substring(0, precision) to (exponent + 1)
+    } else {
+        rounded to exponent
+    }
+}
+
+private fun trimTrailingZeros(digits: String): String {
+    var end = digits.length
+    while (end > 1 && digits[end - 1] == '0') end--
+    return digits.substring(0, end)
+}
+
+/** Shortest round-tripping significant digits and base-10 exponent, mirroring `Number.prototype.toString`. */
+private fun shortestDigits(absValue: Double): Pair<String, Int> {
+    for (precision in 1..17) {
+        val (digits, exponent) = exactSignificantDigits(absValue, precision)
+        val rebuilt = buildString {
+            append(digits[0])
+            if (digits.length > 1) {
+                append('.')
+                append(digits.substring(1))
+            }
+            append('e')
+            append(exponent)
+        }
+        if (rebuilt.toDouble() == absValue) {
+            return trimTrailingZeros(digits) to exponent
+        }
+    }
+    val (digits, exponent) = exactSignificantDigits(absValue, 17)
+    return trimTrailingZeros(digits) to exponent
+}
+
+private fun significandDigits(absValue: Double, precision: Int): Pair<String, Int> {
+    if (absValue == 0.0) return "0".repeat(precision) to 0
+    return exactSignificantDigits(absValue, precision)
+}
+
+/** Mirror of d3's `formatDecimalParts`; `precision <= 0` uses the shortest representation. */
+internal fun formatDecimalParts(value: Double, precision: Int): Pair<String, Int>? {
+    val absValue = abs(value)
+    if (!absValue.isFinite() || absValue == 0.0) return null
+    return if (precision <= 0) shortestDigits(absValue) else exactSignificantDigits(absValue, precision)
+}
+
+/** Shortest-representation base-10 exponent, or `null` for zero and non-finite values. */
+internal fun exponent10(value: Double): Int? {
+    val absValue = abs(value)
+    if (!absValue.isFinite() || absValue == 0.0) return null
+    return shortestDigits(absValue).second
+}
+
+private fun exponentialForm(mantissaDigits: String, exponent: Int): String {
+    val mantissa = if (mantissaDigits.length == 1) {
+        mantissaDigits
+    } else {
+        mantissaDigits[0] + "." + mantissaDigits.substring(1)
+    }
+    return mantissa + "e" + (if (exponent < 0) "-" else "+") + abs(exponent)
+}
+
+internal fun formatFixed(absValue: Double, precision: Int): String {
+    if (!absValue.isFinite()) return "Infinity"
+    val digits = roundToScaleBignum(absValue, precision).toDecimalString()
+    if (precision == 0) return digits
+    val padded = digits.padStart(precision + 1, '0')
+    val cut = padded.length - precision
+    return padded.substring(0, cut) + "." + padded.substring(cut)
+}
+
+internal fun formatExponential(absValue: Double, precision: Int): String {
+    if (!absValue.isFinite()) return "Infinity"
+    val (digits, exponent) = significandDigits(absValue, precision + 1)
+    val mantissa = if (precision == 0) digits else digits[0] + "." + digits.substring(1)
+    return mantissa + "e" + (if (exponent < 0) "-" else "+") + abs(exponent)
+}
+
+internal fun formatPrecision(absValue: Double, precision: Int): String {
+    if (!absValue.isFinite()) return "Infinity"
+    val (digits, exponent) = significandDigits(absValue, precision)
+    return when {
+        exponent < -6 || exponent >= precision -> exponentialForm(digits, exponent)
+        exponent >= 0 -> {
+            val integerLength = exponent + 1
+            if (integerLength >= precision) {
+                digits
+            } else {
+                digits.substring(0, integerLength) + "." + digits.substring(integerLength)
+            }
+        }
+        else -> "0." + "0".repeat(-exponent - 1) + digits
+    }
+}
+
+internal fun formatDecimalInteger(absValue: Double): String {
+    if (!absValue.isFinite()) return "Infinity"
+    val rounded = floor(absValue + 0.5)
+    if (rounded == 0.0) return "0"
+    val (digits, exponent) = shortestDigits(rounded)
+    return digits + "0".repeat(exponent - digits.length + 1)
+}
+
+internal fun formatRounded(absValue: Double, precision: Int): String {
+    if (!absValue.isFinite()) return "Infinity"
+    val (coefficient, exponent) = formatDecimalParts(absValue, precision) ?: return "0"
+    return when {
+        exponent < 0 -> "0." + "0".repeat(-exponent - 1) + coefficient
+        coefficient.length > exponent + 1 ->
+            coefficient.substring(0, exponent + 1) + "." + coefficient.substring(exponent + 1)
+        else -> coefficient + "0".repeat(exponent - coefficient.length + 1)
+    }
+}
+
+internal fun formatPrefixAuto(absValue: Double, precision: Int): Pair<String, Int?> {
+    if (!absValue.isFinite()) return "Infinity" to null
+    val (coefficient, exponent) = formatDecimalParts(absValue, precision)
+        ?: return formatPrecision(absValue, precision) to null
+    val prefixExponent = maxOf(-8, minOf(8, exponent.floorDiv(3))) * 3
+    val shift = exponent - prefixExponent + 1
+    val length = coefficient.length
+    val text = when {
+        shift == length -> coefficient
+        shift > length -> coefficient + "0".repeat(shift - length)
+        shift > 0 -> coefficient.substring(0, shift) + "." + coefficient.substring(shift)
+        else -> {
+            val inner = formatDecimalParts(absValue, maxOf(0, precision + shift - 1))?.first ?: "0"
+            "0." + "0".repeat(-shift) + inner
+        }
+    }
+    return text to prefixExponent
+}
+
+internal fun formatRadix(absValue: Double, radix: Int): String {
+    if (!absValue.isFinite()) return "Infinity"
+    return roundToScaleBignum(absValue, 0).toStringRadix(radix)
+}
+
+internal fun jsNumberToString(value: Double): String {
+    if (value.isNaN()) return "NaN"
+    if (value == 0.0) return "0"
+    if (value.isInfinite()) return if (value > 0) "Infinity" else "-Infinity"
+    val (digits, exponent) = shortestDigits(abs(value))
+    val length = digits.length
+    val body = when {
+        exponent >= 21 || exponent <= -7 -> exponentialForm(digits, exponent)
+        exponent >= 0 ->
+            if (length <= exponent + 1) {
+                digits + "0".repeat(exponent + 1 - length)
+            } else {
+                digits.substring(0, exponent + 1) + "." + digits.substring(exponent + 1)
+            }
+        else -> "0." + "0".repeat(-exponent - 1) + digits
+    }
+    return if (value < 0) "-$body" else body
+}

--- a/format/src/commonTest/kotlin/FormatPrefixTests.kt
+++ b/format/src/commonTest/kotlin/FormatPrefixTests.kt
@@ -1,0 +1,36 @@
+package com.juul.krayon.format
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+private const val MINUS = "\u2212"
+private const val MICRO = "\u00b5"
+
+class FormatPrefixTests {
+
+    @Test
+    fun formatPrefix_usesPrefixAppropriateToValue() {
+        assertEquals("420$MICRO", formatPrefix(",.0s", 1e-6)(0.00042))
+        assertEquals("4,200$MICRO", formatPrefix(",.0s", 1e-6)(0.0042))
+        assertEquals("0.420m", formatPrefix(",.3s", 1e-3)(0.00042))
+    }
+
+    @Test
+    fun formatPrefix_extremeReferenceValues() {
+        assertEquals("1y", formatPrefix(",.0s", 1e-27)(1e-24))
+        assertEquals("1Y", formatPrefix(",.0s", 1e27)(1e24))
+    }
+
+    @Test
+    fun formatPrefix_currencyAndWidth() {
+        val f = formatPrefix(" $12,.1s", 1e6)
+        assertEquals(" ".repeat(5) + "$MINUS$42.0M", f(-42e6))
+        assertEquals(" ".repeat(7) + "$4.2M", f(4.2e6))
+    }
+
+    @Test
+    fun formatPrefix_parentheses() {
+        assertEquals("$1k", formatPrefix("($~s", 1e3)(1e3))
+        assertEquals("($1k)", formatPrefix("($~s", 1e3)(-1e3))
+    }
+}

--- a/format/src/commonTest/kotlin/FormatSpecifierTests.kt
+++ b/format/src/commonTest/kotlin/FormatSpecifierTests.kt
@@ -1,0 +1,72 @@
+package com.juul.krayon.format
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+
+class FormatSpecifierTests {
+
+    @Test
+    fun formatSpecifier_empty_hasExpectedDefaults() {
+        val specifier = formatSpecifier("")
+        assertEquals(" ", specifier.fill)
+        assertEquals(">", specifier.align)
+        assertEquals("-", specifier.sign)
+        assertEquals("", specifier.symbol)
+        assertFalse(specifier.zero)
+        assertNull(specifier.width)
+        assertFalse(specifier.comma)
+        assertNull(specifier.precision)
+        assertFalse(specifier.trim)
+        assertEquals("", specifier.type)
+    }
+
+    @Test
+    fun formatSpecifier_default_toStringNormalizes() {
+        assertEquals(" >-d", format("d").toString())
+        assertEquals(" >-", formatSpecifier("").toString())
+    }
+
+    @Test
+    fun formatSpecifier_preservesUnknownType() {
+        val specifier = formatSpecifier("q")
+        assertFalse(specifier.trim)
+        assertEquals("q", specifier.type)
+    }
+
+    @Test
+    fun formatSpecifier_toStringReflectsMutations() {
+        val specifier = formatSpecifier("")
+        specifier.fill = "_"
+        specifier.align = "^"
+        specifier.sign = "+"
+        specifier.symbol = "$"
+        specifier.zero = true
+        specifier.width = 12
+        specifier.comma = true
+        specifier.precision = 2
+        specifier.type = "f"
+        specifier.trim = true
+        assertEquals("_^+$012,.2~f", specifier.toString())
+        assertEquals("+$0,000,000,042", format(specifier)(42.0))
+    }
+
+    @Test
+    fun formatSpecifier_clampsWidthAndPrecision() {
+        val precision = formatSpecifier("")
+        precision.precision = -1
+        assertEquals(" >-.0", precision.toString())
+        val width = formatSpecifier("")
+        width.width = -1
+        assertEquals(" >-1", width.toString())
+    }
+
+    @Test
+    fun formatSpecifier_invalidThrows() {
+        assertFailsWith<IllegalArgumentException> { formatSpecifier("foo") }
+        assertFailsWith<IllegalArgumentException> { formatSpecifier(".-2s") }
+        assertFailsWith<IllegalArgumentException> { formatSpecifier(".f") }
+    }
+}

--- a/format/src/commonTest/kotlin/FormatTrimTests.kt
+++ b/format/src/commonTest/kotlin/FormatTrimTests.kt
@@ -1,0 +1,84 @@
+package com.juul.krayon.format
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+private const val MINUS = "\u2212"
+
+class FormatTrimTests {
+
+    @Test
+    fun trim_rounded() {
+        val f = format("~r")
+        assertEquals("1", f(1.0))
+        assertEquals("0.1", f(0.1))
+        assertEquals("0.01", f(0.01))
+        assertEquals("10.0001", f(10.0001))
+        assertEquals("123.45", f(123.45))
+        assertEquals("123.457", f(123.4567))
+        assertEquals("0.000009", f(0.000009))
+        assertEquals("0.111119", f(0.111119))
+        assertEquals("0.111112", f(0.1111119))
+        assertEquals("0.111111", f(0.11111119))
+    }
+
+    @Test
+    fun trim_exponential() {
+        val f = format("~e")
+        assertEquals("0e+0", f(0.0))
+        assertEquals("4.2e+1", f(42.0))
+        assertEquals("4.2e+7", f(42000000.0))
+        assertEquals("4.2e-2", f(0.042))
+        assertEquals("${MINUS}4e+0", f(-4.0))
+        assertEquals("4.2e+10", f(42000000000.0))
+        assertEquals("4.2e-10", f(0.00000000042))
+    }
+
+    @Test
+    fun trim_exponentialWithPrecision() {
+        val f = format(".4~e")
+        assertEquals("1.2345e-10", f(0.00000000012345))
+        assertEquals("1.234e-10", f(0.00000000012340))
+        assertEquals("1.23e-10", f(0.00000000012300))
+        assertEquals("1.2345e+10", f(12345000000.0))
+        assertEquals("1.23e+10", f(12300000000.0))
+    }
+
+    @Test
+    fun trim_siPrefix() {
+        val f = format("~s")
+        assertEquals("0", f(0.0))
+        assertEquals("100", f(100.0))
+        assertEquals("999.5", f(999.5))
+        assertEquals("999.5k", f(999500.0))
+        assertEquals("1k", f(1000.0))
+        assertEquals("1.5k", f(1500.0))
+        assertEquals("1.5005k", f(1500.5))
+        assertEquals("1M", f(1e6))
+        assertEquals("1G", f(1e9))
+        assertEquals("1P", f(1e15))
+    }
+
+    @Test
+    fun trim_percent() {
+        val f = format("~%")
+        assertEquals("0%", f(0.0))
+        assertEquals("10%", f(0.1))
+        assertEquals("1%", f(0.01))
+        assertEquals("0.1%", f(0.001))
+        assertEquals("0.01%", f(0.0001))
+    }
+
+    @Test
+    fun trim_respectsCommas() {
+        val f = format(",~g")
+        assertEquals("10,000", f(10000.0))
+        assertEquals("10,000.1", f(10000.1))
+    }
+
+    @Test
+    fun trim_clampedPrecision() {
+        assertEquals("0.00000000000000000000", format(".30f")(0.0))
+        assertEquals("1", format(".0g")(1.0))
+    }
+}

--- a/format/src/commonTest/kotlin/FormatTypeTests.kt
+++ b/format/src/commonTest/kotlin/FormatTypeTests.kt
@@ -1,0 +1,351 @@
+package com.juul.krayon.format
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+private const val MINUS = "\u2212"
+private const val MICRO = "\u00b5"
+
+class FormatTypeTests {
+
+    @Test
+    fun fixed_outputsFixedPointNotation() {
+        assertEquals("0.5", format(".1f")(0.49))
+        assertEquals("0.45", format(".2f")(0.449))
+        assertEquals("0.445", format(".3f")(0.4449))
+        assertEquals("0.44445", format(".5f")(0.444449))
+        assertEquals("100.0", format(".1f")(100.0))
+        assertEquals("100.00", format(".2f")(100.0))
+        assertEquals("100.00000", format(".5f")(100.0))
+        assertEquals("42.000000", format("f")(42.0))
+    }
+
+    @Test
+    fun fixed_currencyWithCommaAndSign() {
+        val f = format("+$,.2f")
+        assertEquals("+$0.00", f(0.0))
+        assertEquals("+$0.43", f(0.429))
+        assertEquals("$MINUS$0.43", f(-0.429))
+        assertEquals("$MINUS$1.00", f(-1.0))
+        assertEquals("+$10,000.00", f(1e4))
+    }
+
+    @Test
+    fun fixed_groupsThousands() {
+        assertEquals("1,234,567.45", format("10,.2f")(1234567.449))
+        assertEquals("12,345,678.445", format("10,.3f")(12345678.4449))
+        assertEquals("123,456,789.44445", format("10,.5f")(123456789.444449))
+        assertEquals("1,234,567.00", format("10,.2f")(1234567.0))
+    }
+
+    @Test
+    fun fixed_negativeZeroFormatsAsZero() {
+        assertEquals("0.000000", format("f")(-0.0))
+        assertEquals("0.000000", format("f")(-1e-12))
+        assertEquals("${MINUS}0.000000", format("+f")(-0.0))
+        assertEquals("+0.000000", format("+f")(0.0))
+        assertEquals("${MINUS}0.000000", format("+f")(-1e-12))
+        assertEquals("+0.000000", format("+f")(1e-12))
+    }
+
+    @Test
+    fun fixed_infinity() {
+        assertEquals("${MINUS}Infinity", format("f")(Double.NEGATIVE_INFINITY))
+        assertEquals("Infinity", format(",f")(Double.POSITIVE_INFINITY))
+    }
+
+    @Test
+    fun exponential_outputsExponentNotation() {
+        val f = format("e")
+        assertEquals("0.000000e+0", f(0.0))
+        assertEquals("4.200000e+1", f(42.0))
+        assertEquals("4.200000e+7", f(42000000.0))
+        assertEquals("${MINUS}4.000000e+0", f(-4.0))
+        assertEquals("${MINUS}4.200000e+6", f(-4200000.0))
+        assertEquals("4e+1", format(".0e")(42.0))
+        assertEquals("4.200e+1", format(".3e")(42.0))
+        assertEquals("${MINUS}1.000000e-12", format("1e")(-1e-12))
+    }
+
+    @Test
+    fun general_outputsGeneralNotation() {
+        assertEquals("0.05", format(".1g")(0.049))
+        assertEquals("0.5", format(".1g")(0.49))
+        assertEquals("0.45", format(".2g")(0.449))
+        assertEquals("0.44445", format(".5g")(0.444449))
+        assertEquals("1e+2", format(".1g")(100.0))
+        assertEquals("1.0e+2", format(".2g")(100.0))
+        assertEquals("100", format(".3g")(100.0))
+        assertEquals("100.00", format(".5g")(100.0))
+        assertEquals("100.20", format(".5g")(100.2))
+        assertEquals("0.0020", format(".2g")(0.002))
+    }
+
+    @Test
+    fun general_groupsThousands() {
+        val f = format(",.12g")
+        assertEquals("0.00000000000", f(0.0))
+        assertEquals("42.0000000000", f(42.0))
+        assertEquals("42,000,000.0000", f(42000000.0))
+        assertEquals("420,000,000.000", f(420000000.0))
+        assertEquals("${MINUS}4,200,000.00000", f(-4200000.0))
+    }
+
+    @Test
+    fun rounded_roundsToSignificantDigits() {
+        assertEquals("0.05", format(".1r")(0.049))
+        assertEquals("${MINUS}0.05", format(".1r")(-0.049))
+        assertEquals("0.5", format(".1r")(0.49))
+        assertEquals("0.45", format(".2r")(0.449))
+        assertEquals("1.00", format(".3r")(1.00))
+        assertEquals("1.00", format(".3r")(0.9995))
+        assertEquals("123.450", format("r")(123.45))
+        assertEquals("100", format(".1r")(123.45))
+        assertEquals("120", format(".2r")(123.45))
+        assertEquals("123", format(".3r")(123.45))
+        assertEquals("123.5", format(".4r")(123.45))
+        assertEquals("123.45", format(".5r")(123.45))
+        assertEquals("0.09", format(".1r")(0.09))
+        assertEquals("0.00000001", format(".1r")(0.0000000129))
+        assertEquals("0.000000013", format(".2r")(0.0000000129))
+        assertEquals("0.9999999999", format(".10r")(0.9999999999))
+    }
+
+    @Test
+    fun rounded_roundsZeroAndVerySmall() {
+        assertEquals("0", format(".2r")(0.0))
+        assertEquals("0", format("r")(0.0))
+        assertEquals("0.00000000000000000000010", format(".2r")(1e-22))
+    }
+
+    @Test
+    fun default_usesSignificantPrecisionAndTrims() {
+        assertEquals("5", format(".1")(4.9))
+        assertEquals("0.5", format(".1")(0.49))
+        assertEquals("4.9", format(".2")(4.9))
+        assertEquals("0.449", format(".3")(0.449))
+        assertEquals("0.445", format(".3")(0.4449))
+        assertEquals("10", format(".5")(10.0))
+        assertEquals("21010", format(".5")(21010.0))
+        assertEquals("1.1", format(".5")(1.10001))
+        assertEquals("1.1e+6", format(".5")(1.10001e6))
+        assertEquals("1.10001", format(".6")(1.10001))
+        assertEquals("1", format(".5")(1.00001))
+        assertEquals("1e+6", format(".5")(1.00001e6))
+    }
+
+    @Test
+    fun currency_default() {
+        val f = format("$")
+        assertEquals("$0", f(0.0))
+        assertEquals("$0.042", f(0.042))
+        assertEquals("$4.2", f(4.2))
+        assertEquals("$MINUS$4.2", f(-4.2))
+    }
+
+    @Test
+    fun currency_parenthesesForNegatives() {
+        val f = format("($")
+        assertEquals("$0", f(0.0))
+        assertEquals("$4.2", f(4.2))
+        assertEquals("($0.042)", f(-0.042))
+        assertEquals("($4.2)", f(-4.2))
+    }
+
+    @Test
+    fun decimal_zeroFillAndSpaceFill() {
+        assertEquals("00000042", format("08d")(42.0))
+        assertEquals("42000000", format("08d")(42000000.0))
+        assertEquals("${MINUS}0000004", format("08d")(-4.0))
+        assertEquals("${MINUS}4200000", format("08d")(-4200000.0))
+        assertEquals(" ".repeat(6) + "42", format("8d")(42.0))
+        assertEquals(" ".repeat(6) + "${MINUS}4", format("8d")(-4.0))
+    }
+
+    @Test
+    fun decimal_underscoreFill() {
+        assertEquals("_______0", format("_>8d")(0.0))
+        assertEquals("______42", format("_>8d")(42.0))
+        assertEquals("______${MINUS}4", format("_>8d")(-4.0))
+        assertEquals("_____${MINUS}42", format("_>8d")(-42.0))
+    }
+
+    @Test
+    fun decimal_zeroFillWithSignAndGroup() {
+        val f = format("+08,d")
+        assertEquals("+0,000,000", f(0.0))
+        assertEquals("+0,000,042", f(42.0))
+        assertEquals("+42,000,000", f(42000000.0))
+        assertEquals("${MINUS}0,000,004", f(-4.0))
+        assertEquals("${MINUS}4,200,000", f(-4200000.0))
+    }
+
+    @Test
+    fun decimal_roundsAndUsesZeroPrecision() {
+        assertEquals("4", format("d")(4.2))
+        assertEquals("42", format(".2d")(42.0))
+        assertEquals("${MINUS}4", format(".2d")(-4.2))
+        assertEquals("0", format("1d")(-0.0))
+        assertEquals("0", format("1d")(-1e-12))
+    }
+
+    @Test
+    fun decimal_groupsVeryLargeNumbers() {
+        val f = format(",d")
+        assertEquals("1,000,000,000,000,000,000,000", f(1e21))
+        assertEquals("1,300,000,000,000,000,000,000,000,000", f(1.3e27))
+    }
+
+    @Test
+    fun decimal_alignment() {
+        assertEquals("0 ", format("<2,d")(0.0))
+        assertEquals(" 0", format(">2,d")(0.0))
+        assertEquals(" 0 ", format("^3,d")(0.0))
+        assertEquals(" ".repeat(8) + "1,000" + " ".repeat(8), format("^21,d")(1000.0))
+    }
+
+    @Test
+    fun decimal_padAfterSign() {
+        assertEquals("+0", format("=+1,d")(0.0))
+        assertEquals("+ 0", format("=+3,d")(0.0))
+        assertEquals("+$" + " ".repeat(2) + "0", format("=+$5,d")(0.0))
+    }
+
+    @Test
+    fun hexadecimal() {
+        assertEquals("deadbeef", format("x")(0xdeadbeef.toDouble()))
+        assertEquals("0xdeadbeef", format("#x")(0xdeadbeef.toDouble()))
+        assertEquals("de,adb,eef", format(",x")(0xdeadbeef.toDouble()))
+        assertEquals("0xade,adb,eef", format("#,x")(0xadeadbeef.toDouble()))
+        assertEquals("+0xdeadbeef", format("+#x")(0xdeadbeef.toDouble()))
+        assertEquals("${MINUS}0xdeadbeef", format("+#x")(-(0xdeadbeef.toDouble())))
+        assertEquals("$" + "de,adb,eef", format("$,x")(0xdeadbeef.toDouble()))
+        assertEquals("deadbeef", format(".2x")(0xdeadbeef.toDouble()))
+        assertEquals("2", format("x")(2.4))
+        assertEquals("0", format("x")(-0.0))
+        assertEquals("${MINUS}eee", format("x")(-0xeee.toDouble()))
+        assertEquals("DEADBEEF", format("X")(0xdeadbeef.toDouble()))
+        assertEquals("0xDEADBEEF", format("#X")(0xdeadbeef.toDouble()))
+        assertEquals("${MINUS}EEE", format("X")(-0xeee.toDouble()))
+    }
+
+    @Test
+    fun hexadecimal_widthConsidersPrefix() {
+        assertEquals("000000000000deadbeef", format("020x")(0xdeadbeef.toDouble()))
+        assertEquals("0x0000000000deadbeef", format("#020x")(0xdeadbeef.toDouble()))
+    }
+
+    @Test
+    fun binaryAndOctal() {
+        assertEquals("1010", format("b")(10.0))
+        assertEquals("0b1010", format("#b")(10.0))
+        assertEquals("12", format("o")(10.0))
+        assertEquals("0o12", format("#o")(10.0))
+    }
+
+    @Test
+    fun percent() {
+        val f = format("p")
+        assertEquals("0.123000%", f(0.00123))
+        assertEquals("12.3000%", f(0.123))
+        assertEquals("123.000%", f(1.23))
+        assertEquals("${MINUS}12.3000%", f(-0.123))
+        val g = format("+.2p")
+        assertEquals("+0.12%", g(0.00123))
+        assertEquals("+12%", g(0.123))
+        assertEquals("${MINUS}120%", g(-1.23))
+    }
+
+    @Test
+    fun n_isAliasForCommaG() {
+        assertEquals("123,457", format("n")(123456.78))
+        assertEquals("123,457", format(",g")(123456.78))
+        val f = format(".12n")
+        assertEquals("42,000,000.0000", f(42000000.0))
+        assertEquals("1.00000000000e+21", f(1e21))
+    }
+
+    @Test
+    fun character() {
+        assertEquals("42", format("c")(42.0))
+        assertEquals("3.14", format("c")(3.14))
+    }
+
+    @Test
+    fun siPrefix_defaultPrecision() {
+        val f = format("s")
+        assertEquals("0.00000", f(0.0))
+        assertEquals("1.00000", f(1.0))
+        assertEquals("100.000", f(100.0))
+        assertEquals("999.500", f(999.5))
+        assertEquals("999.500k", f(999500.0))
+        assertEquals("1.00000k", f(1000.0))
+        assertEquals("1.50050k", f(1500.5))
+        assertEquals("10.0000$MICRO", f(0.00001))
+        assertEquals("1.00000$MICRO", f(0.000001))
+        assertEquals("Infinity", f(Double.POSITIVE_INFINITY))
+        assertEquals("NaN", f(Double.NaN))
+    }
+
+    @Test
+    fun siPrefix_withPrecision() {
+        val f1 = format(".3s")
+        assertEquals("0.00", f1(0.0))
+        assertEquals("100", f1(100.0))
+        assertEquals("1.00k", f1(999.5))
+        assertEquals("1.00M", f1(999500.0))
+        assertEquals("1.50k", f1(1500.5))
+        assertEquals("146M", f1(145500000.0))
+        assertEquals("146M", f1(145999999.99999347))
+        assertEquals("100Y", f1(1e26))
+        assertEquals("1.00$MICRO", f1(0.000001))
+        assertEquals("10.0m", f1(0.009995))
+        val f2 = format(".4s")
+        assertEquals("999.5", f2(999.5))
+        assertEquals("999.5k", f2(999500.0))
+        assertEquals("9.995m", f2(0.009995))
+    }
+
+    @Test
+    fun siPrefix_yoctoAndYotta() {
+        val f = format(".8s")
+        assertEquals("0.0000013y", f(1.29e-30))
+        assertEquals("1.2900000y", f(1.29e-24))
+        assertEquals("129.00000y", f(1.29e-22))
+        assertEquals("1.2900000z", f(1.29e-21))
+        assertEquals("1.2300000Z", f(1.23e21))
+        assertEquals("123.00000Z", f(1.23e23))
+        assertEquals("1.2300000Y", f(1.23e24))
+        assertEquals("1230000.0Y", f(1.23e30))
+        assertEquals("${MINUS}1.2900000y", f(-1.29e-24))
+        assertEquals("${MINUS}1230000.0Y", f(-1.23e30))
+    }
+
+    @Test
+    fun siPrefix_currency() {
+        val f2 = format("$.3s")
+        assertEquals("$0.00", f2(0.0))
+        assertEquals("$10.0", f2(10.0))
+        assertEquals("$1.00k", f2(999.5))
+        assertEquals("$146M", f2(145500000.0))
+        assertEquals("$1.00$MICRO", f2(0.000001))
+    }
+
+    @Test
+    fun siPrefix_consistentPrecision() {
+        val f = format(".0s")
+        assertEquals("10$MICRO", f(1e-5))
+        assertEquals("1m", f(1e-3))
+        assertEquals("100m", f(1e-1))
+        assertEquals("1", f(1e0))
+        assertEquals("1k", f(1e3))
+        assertEquals("100k", f(1e5))
+    }
+
+    @Test
+    fun siPrefix_zeroFillGroupsThousands() {
+        assertEquals("000,000,000,042.0000", format("020,s")(42.0))
+        assertEquals("00,000,000,042.0000T", format("020,s")(42e12))
+        assertEquals("42,000,000Y", format(",s")(42e30))
+    }
+}

--- a/format/src/commonTest/kotlin/LocaleTests.kt
+++ b/format/src/commonTest/kotlin/LocaleTests.kt
@@ -1,0 +1,129 @@
+package com.juul.krayon.format
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+private const val MINUS = "\u2212"
+
+class LocaleTests {
+
+    @Test
+    fun locale_observesDecimalPoint() {
+        assertEquals("002|00", FormatLocale(FormatLocaleDefinition(decimal = "|")).format("06.2f")(2.0))
+        assertEquals("002/00", FormatLocale(FormatLocaleDefinition(decimal = "/")).format("06.2f")(2.0))
+    }
+
+    @Test
+    fun locale_observesCurrencyPrefixAndSuffix() {
+        assertEquals(
+            "\u0e3f02.00",
+            FormatLocale(FormatLocaleDefinition(decimal = ".", currencyPrefix = "\u0e3f")).format("$06.2f")(2.0),
+        )
+        assertEquals(
+            "02.00\u0e3f",
+            FormatLocale(FormatLocaleDefinition(decimal = ".", currencySuffix = "\u0e3f")).format("$06.2f")(2.0),
+        )
+    }
+
+    @Test
+    fun locale_currencySuffixAfterSiSuffix() {
+        assertEquals(
+            "1,20G \u20ac",
+            FormatLocale(FormatLocaleDefinition(decimal = ",", currencySuffix = " \u20ac")).format("$.3s")(1.2e9),
+        )
+    }
+
+    @Test
+    fun locale_noGroupingWithoutDefinition() {
+        assertEquals("000000002.00", FormatLocale(FormatLocaleDefinition(decimal = ".")).format("012,.2f")(2.0))
+    }
+
+    @Test
+    fun locale_observesGroupSizes() {
+        assertEquals(
+            "0,000,002.00",
+            FormatLocale(FormatLocaleDefinition(decimal = ".", grouping = listOf(3), thousands = ",")).format("012,.2f")(2.0),
+        )
+        assertEquals(
+            "0,00,00,02.00",
+            FormatLocale(FormatLocaleDefinition(decimal = ".", grouping = listOf(2), thousands = ",")).format("012,.2f")(2.0),
+        )
+        assertEquals(
+            "00,000,02.00",
+            FormatLocale(FormatLocaleDefinition(decimal = ".", grouping = listOf(2, 3), thousands = ",")).format("012,.2f")(2.0),
+        )
+        assertEquals(
+            "10,00,00,00,00,000",
+            FormatLocale(
+                FormatLocaleDefinition(decimal = ".", grouping = listOf(3, 2, 2, 2, 2, 2, 2), thousands = ","),
+            ).format(",d")(1e12),
+        )
+    }
+
+    @Test
+    fun locale_indianNumberingSystem() {
+        val indian = FormatLocale(
+            FormatLocaleDefinition(decimal = ".", grouping = listOf(3, 2, 2, 2, 2, 2, 2), thousands = ","),
+        ).format(",")
+        assertEquals("1,000", indian(1000.0))
+        assertEquals("1,00,000", indian(100000.0))
+        assertEquals("10,00,000", indian(1000000.0))
+        assertEquals("1,00,00,000", indian(10000000.0))
+        assertEquals("1,00,00,000.4543", indian(10000000.4543))
+        assertEquals("${MINUS}1,00,00,000", indian(-10000000.0))
+    }
+
+    @Test
+    fun locale_observesThousandsSeparator() {
+        assertEquals(
+            "0 000 002.00",
+            FormatLocale(FormatLocaleDefinition(decimal = ".", grouping = listOf(3), thousands = " ")).format("012,.2f")(2.0),
+        )
+    }
+
+    @Test
+    fun locale_observesPercentSign() {
+        assertEquals(
+            "200.00!",
+            FormatLocale(FormatLocaleDefinition(decimal = ".", percent = "!")).format("06.2%")(2.0),
+        )
+    }
+
+    @Test
+    fun locale_observesMinusSign() {
+        assertEquals("-02.00", FormatLocale(FormatLocaleDefinition(decimal = ".", minus = "-")).format("06.2f")(-2.0))
+        assertEquals("${MINUS}02.00", FormatLocale(FormatLocaleDefinition(decimal = ".", minus = "\u2212")).format("06.2f")(-2.0))
+        assertEquals("\u2796" + "02.00", FormatLocale(FormatLocaleDefinition(decimal = ".", minus = "\u2796")).format("06.2f")(-2.0))
+        assertEquals("${MINUS}02.00", FormatLocale(FormatLocaleDefinition(decimal = ".")).format("06.2f")(-2.0))
+    }
+
+    @Test
+    fun locale_observesNan() {
+        assertEquals("   N/A", FormatLocale(FormatLocaleDefinition(nan = "N/A")).format("6.2f")(Double.NaN))
+    }
+
+    @Test
+    fun locale_frenchDefault() {
+        val french = FormatLocale(
+            FormatLocaleDefinition(
+                decimal = ",",
+                thousands = ".",
+                grouping = listOf(3),
+                currencySuffix = "\u00a0\u20ac",
+                percent = "\u202f%",
+            ),
+        )
+        assertEquals("12.345.678,90\u00a0\u20ac", french.format("$,.2f")(12345678.90))
+        assertEquals("1.234.567.890\u202f%", french.format(",.0%")(12345678.90))
+    }
+
+    @Test
+    fun locale_numerals() {
+        val arabic = FormatLocale(
+            FormatLocaleDefinition(
+                numerals = listOf("\u0660", "\u0661", "\u0662", "\u0663", "\u0664", "\u0665", "\u0666", "\u0667", "\u0668", "\u0669"),
+            ),
+        )
+        assertEquals("\u0661\u0662\u0663", arabic.format("d")(123.0))
+    }
+}

--- a/format/src/commonTest/kotlin/PrecisionTests.kt
+++ b/format/src/commonTest/kotlin/PrecisionTests.kt
@@ -1,0 +1,89 @@
+package com.juul.krayon.format
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class PrecisionTests {
+
+    @Test
+    fun precisionFixed_returnsExpectedValue() {
+        assertEquals(0, precisionFixed(8.9))
+        assertEquals(0, precisionFixed(1.1))
+        assertEquals(1, precisionFixed(0.89))
+        assertEquals(1, precisionFixed(0.11))
+        assertEquals(2, precisionFixed(0.089))
+        assertEquals(2, precisionFixed(0.011))
+    }
+
+    @Test
+    fun precisionFixed_invalidThrows() {
+        assertFailsWith<IllegalArgumentException> { precisionFixed(0.0) }
+        assertFailsWith<IllegalArgumentException> { precisionFixed(Double.NaN) }
+        assertFailsWith<IllegalArgumentException> { precisionFixed(Double.POSITIVE_INFINITY) }
+    }
+
+    @Test
+    fun precisionRound_returnsExpectedValue() {
+        assertEquals(2, precisionRound(0.1, 1.1))
+        assertEquals(2, precisionRound(0.01, 0.99))
+        assertEquals(2, precisionRound(0.01, 1.00))
+        assertEquals(3, precisionRound(0.01, 1.01))
+    }
+
+    @Test
+    fun precisionRound_invalidThrows() {
+        assertFailsWith<IllegalArgumentException> { precisionRound(0.0, 1.0) }
+        assertFailsWith<IllegalArgumentException> { precisionRound(Double.NaN, 1.0) }
+        assertFailsWith<IllegalArgumentException> { precisionRound(Double.POSITIVE_INFINITY, 1.0) }
+    }
+
+    @Test
+    fun precisionPrefix_sameUnitsReturnsZero() {
+        var i = -24
+        while (i <= 24) {
+            var j = i
+            while (j < i + 3) {
+                assertEquals(0, precisionPrefix(pow10(i), pow10(j)))
+                j++
+            }
+            i += 3
+        }
+    }
+
+    @Test
+    fun precisionPrefix_fractionalDigitsNeeded() {
+        var i = -24
+        while (i <= 24) {
+            var j = i - 4
+            while (j < i) {
+                assertEquals(i - j, precisionPrefix(pow10(j), pow10(i)))
+                j++
+            }
+            i += 3
+        }
+    }
+
+    @Test
+    fun precisionPrefix_belowYocto() {
+        assertEquals(0, precisionPrefix(1e-24, 1e-24))
+        assertEquals(1, precisionPrefix(1e-25, 1e-25))
+        assertEquals(2, precisionPrefix(1e-26, 1e-26))
+        assertEquals(4, precisionPrefix(1e-28, 1e-28))
+    }
+
+    @Test
+    fun precisionPrefix_aboveYotta() {
+        assertEquals(0, precisionPrefix(1e24, 1e24))
+        assertEquals(0, precisionPrefix(1e24, 1e27))
+        assertEquals(1, precisionPrefix(1e23, 1e27))
+    }
+
+    @Test
+    fun precisionPrefix_invalidThrows() {
+        assertFailsWith<IllegalArgumentException> { precisionPrefix(0.0, 1.0) }
+        assertFailsWith<IllegalArgumentException> { precisionPrefix(Double.NaN, 1.0) }
+    }
+
+    private fun pow10(exponent: Int): Double = "1e$exponent".toDouble()
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -26,6 +26,7 @@ include(
     "core",
     "element",
     "element-view",
+    "format",
     "hierarchy",
     "interpolate",
     "kanvas",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Ports [d3-format](https://github.com/d3/d3-format) into a new, self-contained Kotlin Multiplatform module `format` (package `com.juul.krayon.format`), published under `com.juul.krayon`.

The module has no internal dependencies and implements number formatting entirely with deterministic arithmetic (no platform `String.format`), so output is identical across JVM/JS/Native/Wasm.

## What's included

- **Format specifier mini-language** `[[fill]align][sign][symbol][0][width][,][.precision][~][type]`, parsed by a hand-written parser (`formatSpecifier`) that avoids cross-platform `Regex` group-indexing differences.
- **All d3 types**: `e f g r s % p b o d x X c` and the default (`.12~g`), plus `n` (alias for `,g`).
- **`format(specifier)`** returning a callable `NumberFormat`, and **`formatPrefix(specifier, value)`** for fixed SI-prefix formatting.
- **Precision helpers**: `precisionFixed`, `precisionRound`, `precisionPrefix`.
- **Locale abstraction** (`FormatLocaleDefinition` / `FormatLocale`) covering grouping, decimal, currency, percent, minus, NaN, and numerals, with a sensible `enUS` default. Full locale packs are intentionally out of scope, but custom locales are fully supported.

## Deterministic numerics

To match d3's JS-backed output exactly and identically on every target, the numeric core is implemented from scratch:

- An internal base-`10^9` big-integer (`Bignum`) supports exact scaling and half-up rounding without division.
- `toFixed` / `toExponential` / `toPrecision` / SI-prefix rounding are derived from the exact IEEE-754 value of the input `Double`.
- Shortest round-trip representation (for `exponent`, the `c` type, and large-integer `d`) is found by searching increasing precision and verifying via `toDouble()` round-trip.

## Tests

Extensive `commonTest` coverage ported from d3's test fixtures: every type, precision, grouping (including Indian and French locales), SI prefixes (yocto…yotta), trimming, `formatPrefix`, the precision helpers, and edge cases (negatives, negative zero, zero, rounding, infinity, NaN). Passing on JVM, JS, and Wasm.

## Notes

- Only shared file touched outside the module is `settings.gradle.kts` (added `"format"`).
- `NumberFormat` exposes `operator fun invoke(Double): String` rather than implementing the `(Double) -> String` function type, which Kotlin/JS prohibits.
- Committed API dumps (`apiDump`). The `android/` and root `.api` dumps were replicated from the JVM dump because this environment lacks the Android SDK; for a pure-common module these are byte-identical to the JVM dump (verified against `color`/`time`).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-22237ff0-9097-47e0-89e2-1aaab470316c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-22237ff0-9097-47e0-89e2-1aaab470316c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

