### PR TITLE
hierarchy: port d3-hierarchy layouts (tree, cluster, pack, partition, stratify)

### DIFF
--- a/hierarchy/api/android/hierarchy.api
+++ b/hierarchy/api/android/hierarchy.api
@@ -3,6 +3,11 @@ public final class com/juul/krayon/hierarchy/HierarchyKt {
 	public static final fun hierarchy (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lcom/juul/krayon/hierarchy/Node;
 }
 
+public final class com/juul/krayon/hierarchy/Link {
+	public final fun getSource ()Lcom/juul/krayon/hierarchy/Node;
+	public final fun getTarget ()Lcom/juul/krayon/hierarchy/Node;
+}
+
 public final class com/juul/krayon/hierarchy/Node {
 	public final fun getChildren ()Ljava/util/List;
 	public final fun getData ()Ljava/lang/Object;
@@ -14,7 +19,9 @@ public final class com/juul/krayon/hierarchy/Node {
 
 public final class com/juul/krayon/hierarchy/NodeKt {
 	public static final fun ancestors (Lcom/juul/krayon/hierarchy/Node;)Lkotlin/sequences/Sequence;
+	public static final fun copy (Lcom/juul/krayon/hierarchy/Node;)Lcom/juul/krayon/hierarchy/Node;
 	public static final fun count (Lcom/juul/krayon/hierarchy/Node;)Lcom/juul/krayon/hierarchy/Node;
+	public static final fun descendants (Lcom/juul/krayon/hierarchy/Node;)Ljava/util/List;
 	public static final fun each (Lcom/juul/krayon/hierarchy/Node;Lkotlin/jvm/functions/Function1;)Lcom/juul/krayon/hierarchy/Node;
 	public static final fun eachAfter (Lcom/juul/krayon/hierarchy/Node;Lkotlin/jvm/functions/Function1;)Lcom/juul/krayon/hierarchy/Node;
 	public static final fun eachAfterIndexed (Lcom/juul/krayon/hierarchy/Node;Lkotlin/jvm/functions/Function2;)Lcom/juul/krayon/hierarchy/Node;
@@ -24,6 +31,9 @@ public final class com/juul/krayon/hierarchy/NodeKt {
 	public static final fun getDepth (Lcom/juul/krayon/hierarchy/Node;)I
 	public static final fun getHeight (Lcom/juul/krayon/hierarchy/Node;)I
 	public static final fun isLeaf (Lcom/juul/krayon/hierarchy/Node;)Z
+	public static final fun leaves (Lcom/juul/krayon/hierarchy/Node;)Ljava/util/List;
+	public static final fun links (Lcom/juul/krayon/hierarchy/Node;)Ljava/util/List;
+	public static final fun path (Lcom/juul/krayon/hierarchy/Node;Lcom/juul/krayon/hierarchy/Node;)Ljava/util/List;
 	public static final fun removeHierarchy (Lcom/juul/krayon/hierarchy/Node;)Lkotlin/sequences/Sequence;
 	public static final fun sort (Lcom/juul/krayon/hierarchy/Node;Ljava/util/Comparator;)Lcom/juul/krayon/hierarchy/Node;
 	public static final fun sum (Lcom/juul/krayon/hierarchy/Node;Lkotlin/jvm/functions/Function1;)Lcom/juul/krayon/hierarchy/Node;
@@ -32,8 +42,113 @@ public final class com/juul/krayon/hierarchy/NodeKt {
 	public static final fun traversePreOrder (Lcom/juul/krayon/hierarchy/Node;)Lkotlin/sequences/Sequence;
 }
 
+public final class com/juul/krayon/hierarchy/Point {
+	public final fun getX ()F
+	public final fun getY ()F
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/juul/krayon/hierarchy/StratifyKt {
+	public static final fun stratify (Ljava/lang/Iterable;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lcom/juul/krayon/hierarchy/Node;
+}
+
 public final class com/juul/krayon/hierarchy/SumOfKt {
 	public static final fun sumOf (Ljava/lang/Iterable;Lkotlin/jvm/functions/Function1;)F
+}
+
+public final class com/juul/krayon/hierarchy/cluster/Cluster {
+	public fun <init> ()V
+	public fun <init> (FFZLkotlin/jvm/functions/Function2;)V
+	public synthetic fun <init> (FFZLkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getHeight ()F
+	public final fun getNodeSize ()Z
+	public final fun getSeparation ()Lkotlin/jvm/functions/Function2;
+	public final fun getWidth ()F
+	public final fun layout (Lcom/juul/krayon/hierarchy/Node;)Lcom/juul/krayon/hierarchy/Node;
+	public final fun setHeight (F)V
+	public final fun setNodeSize (Z)V
+	public final fun setSeparation (Lkotlin/jvm/functions/Function2;)V
+	public final fun setWidth (F)V
+}
+
+public final class com/juul/krayon/hierarchy/cluster/ClusterKt {
+	public static final fun defaultSeparation ()Lkotlin/jvm/functions/Function2;
+	public static final fun layoutWith (Lcom/juul/krayon/hierarchy/Node;Lcom/juul/krayon/hierarchy/cluster/Cluster;)Lcom/juul/krayon/hierarchy/Node;
+}
+
+public final class com/juul/krayon/hierarchy/pack/Circle {
+	public final fun getRadius ()F
+	public final fun getX ()F
+	public final fun getY ()F
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/juul/krayon/hierarchy/pack/Pack {
+	public fun <init> ()V
+	public fun <init> (FFLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (FFLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getHeight ()F
+	public final fun getPadding ()Lkotlin/jvm/functions/Function1;
+	public final fun getRadius ()Lkotlin/jvm/functions/Function1;
+	public final fun getWidth ()F
+	public final fun layout (Lcom/juul/krayon/hierarchy/Node;)Lcom/juul/krayon/hierarchy/Node;
+	public final fun setHeight (F)V
+	public final fun setPadding (Lkotlin/jvm/functions/Function1;)V
+	public final fun setRadius (Lkotlin/jvm/functions/Function1;)V
+	public final fun setWidth (F)V
+}
+
+public final class com/juul/krayon/hierarchy/pack/PackKt {
+	public static final fun layoutWith (Lcom/juul/krayon/hierarchy/Node;Lcom/juul/krayon/hierarchy/pack/Pack;)Lcom/juul/krayon/hierarchy/Node;
+}
+
+public final class com/juul/krayon/hierarchy/partition/Cell {
+	public final fun getHeight ()F
+	public final fun getWidth ()F
+	public final fun getX0 ()F
+	public final fun getX1 ()F
+	public final fun getY0 ()F
+	public final fun getY1 ()F
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/juul/krayon/hierarchy/partition/Partition {
+	public fun <init> ()V
+	public fun <init> (FFFZ)V
+	public synthetic fun <init> (FFFZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getHeight ()F
+	public final fun getPadding ()F
+	public final fun getRound ()Z
+	public final fun getWidth ()F
+	public final fun layout (Lcom/juul/krayon/hierarchy/Node;)Lcom/juul/krayon/hierarchy/Node;
+	public final fun setHeight (F)V
+	public final fun setPadding (F)V
+	public final fun setRound (Z)V
+	public final fun setWidth (F)V
+}
+
+public final class com/juul/krayon/hierarchy/partition/PartitionKt {
+	public static final fun layoutWith (Lcom/juul/krayon/hierarchy/Node;Lcom/juul/krayon/hierarchy/partition/Partition;)Lcom/juul/krayon/hierarchy/Node;
+}
+
+public final class com/juul/krayon/hierarchy/tree/Tree {
+	public fun <init> ()V
+	public fun <init> (FFZLkotlin/jvm/functions/Function2;)V
+	public synthetic fun <init> (FFZLkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getHeight ()F
+	public final fun getNodeSize ()Z
+	public final fun getSeparation ()Lkotlin/jvm/functions/Function2;
+	public final fun getWidth ()F
+	public final fun layout (Lcom/juul/krayon/hierarchy/Node;)Lcom/juul/krayon/hierarchy/Node;
+	public final fun setHeight (F)V
+	public final fun setNodeSize (Z)V
+	public final fun setSeparation (Lkotlin/jvm/functions/Function2;)V
+	public final fun setWidth (F)V
+}
+
+public final class com/juul/krayon/hierarchy/tree/TreeKt {
+	public static final fun defaultSeparation ()Lkotlin/jvm/functions/Function2;
+	public static final fun layoutWith (Lcom/juul/krayon/hierarchy/Node;Lcom/juul/krayon/hierarchy/tree/Tree;)Lcom/juul/krayon/hierarchy/Node;
 }
 
 public final class com/juul/krayon/hierarchy/treemap/Dice : com/juul/krayon/hierarchy/treemap/TileMethod {

--- a/hierarchy/api/hierarchy.api
+++ b/hierarchy/api/hierarchy.api
@@ -3,6 +3,11 @@ public final class com/juul/krayon/hierarchy/HierarchyKt {
 	public static final fun hierarchy (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lcom/juul/krayon/hierarchy/Node;
 }
 
+public final class com/juul/krayon/hierarchy/Link {
+	public final fun getSource ()Lcom/juul/krayon/hierarchy/Node;
+	public final fun getTarget ()Lcom/juul/krayon/hierarchy/Node;
+}
+
 public final class com/juul/krayon/hierarchy/Node {
 	public final fun getChildren ()Ljava/util/List;
 	public final fun getData ()Ljava/lang/Object;
@@ -14,7 +19,9 @@ public final class com/juul/krayon/hierarchy/Node {
 
 public final class com/juul/krayon/hierarchy/NodeKt {
 	public static final fun ancestors (Lcom/juul/krayon/hierarchy/Node;)Lkotlin/sequences/Sequence;
+	public static final fun copy (Lcom/juul/krayon/hierarchy/Node;)Lcom/juul/krayon/hierarchy/Node;
 	public static final fun count (Lcom/juul/krayon/hierarchy/Node;)Lcom/juul/krayon/hierarchy/Node;
+	public static final fun descendants (Lcom/juul/krayon/hierarchy/Node;)Ljava/util/List;
 	public static final fun each (Lcom/juul/krayon/hierarchy/Node;Lkotlin/jvm/functions/Function1;)Lcom/juul/krayon/hierarchy/Node;
 	public static final fun eachAfter (Lcom/juul/krayon/hierarchy/Node;Lkotlin/jvm/functions/Function1;)Lcom/juul/krayon/hierarchy/Node;
 	public static final fun eachAfterIndexed (Lcom/juul/krayon/hierarchy/Node;Lkotlin/jvm/functions/Function2;)Lcom/juul/krayon/hierarchy/Node;
@@ -24,6 +31,9 @@ public final class com/juul/krayon/hierarchy/NodeKt {
 	public static final fun getDepth (Lcom/juul/krayon/hierarchy/Node;)I
 	public static final fun getHeight (Lcom/juul/krayon/hierarchy/Node;)I
 	public static final fun isLeaf (Lcom/juul/krayon/hierarchy/Node;)Z
+	public static final fun leaves (Lcom/juul/krayon/hierarchy/Node;)Ljava/util/List;
+	public static final fun links (Lcom/juul/krayon/hierarchy/Node;)Ljava/util/List;
+	public static final fun path (Lcom/juul/krayon/hierarchy/Node;Lcom/juul/krayon/hierarchy/Node;)Ljava/util/List;
 	public static final fun removeHierarchy (Lcom/juul/krayon/hierarchy/Node;)Lkotlin/sequences/Sequence;
 	public static final fun sort (Lcom/juul/krayon/hierarchy/Node;Ljava/util/Comparator;)Lcom/juul/krayon/hierarchy/Node;
 	public static final fun sum (Lcom/juul/krayon/hierarchy/Node;Lkotlin/jvm/functions/Function1;)Lcom/juul/krayon/hierarchy/Node;
@@ -32,8 +42,113 @@ public final class com/juul/krayon/hierarchy/NodeKt {
 	public static final fun traversePreOrder (Lcom/juul/krayon/hierarchy/Node;)Lkotlin/sequences/Sequence;
 }
 
+public final class com/juul/krayon/hierarchy/Point {
+	public final fun getX ()F
+	public final fun getY ()F
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/juul/krayon/hierarchy/StratifyKt {
+	public static final fun stratify (Ljava/lang/Iterable;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lcom/juul/krayon/hierarchy/Node;
+}
+
 public final class com/juul/krayon/hierarchy/SumOfKt {
 	public static final fun sumOf (Ljava/lang/Iterable;Lkotlin/jvm/functions/Function1;)F
+}
+
+public final class com/juul/krayon/hierarchy/cluster/Cluster {
+	public fun <init> ()V
+	public fun <init> (FFZLkotlin/jvm/functions/Function2;)V
+	public synthetic fun <init> (FFZLkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getHeight ()F
+	public final fun getNodeSize ()Z
+	public final fun getSeparation ()Lkotlin/jvm/functions/Function2;
+	public final fun getWidth ()F
+	public final fun layout (Lcom/juul/krayon/hierarchy/Node;)Lcom/juul/krayon/hierarchy/Node;
+	public final fun setHeight (F)V
+	public final fun setNodeSize (Z)V
+	public final fun setSeparation (Lkotlin/jvm/functions/Function2;)V
+	public final fun setWidth (F)V
+}
+
+public final class com/juul/krayon/hierarchy/cluster/ClusterKt {
+	public static final fun defaultSeparation ()Lkotlin/jvm/functions/Function2;
+	public static final fun layoutWith (Lcom/juul/krayon/hierarchy/Node;Lcom/juul/krayon/hierarchy/cluster/Cluster;)Lcom/juul/krayon/hierarchy/Node;
+}
+
+public final class com/juul/krayon/hierarchy/pack/Circle {
+	public final fun getRadius ()F
+	public final fun getX ()F
+	public final fun getY ()F
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/juul/krayon/hierarchy/pack/Pack {
+	public fun <init> ()V
+	public fun <init> (FFLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (FFLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getHeight ()F
+	public final fun getPadding ()Lkotlin/jvm/functions/Function1;
+	public final fun getRadius ()Lkotlin/jvm/functions/Function1;
+	public final fun getWidth ()F
+	public final fun layout (Lcom/juul/krayon/hierarchy/Node;)Lcom/juul/krayon/hierarchy/Node;
+	public final fun setHeight (F)V
+	public final fun setPadding (Lkotlin/jvm/functions/Function1;)V
+	public final fun setRadius (Lkotlin/jvm/functions/Function1;)V
+	public final fun setWidth (F)V
+}
+
+public final class com/juul/krayon/hierarchy/pack/PackKt {
+	public static final fun layoutWith (Lcom/juul/krayon/hierarchy/Node;Lcom/juul/krayon/hierarchy/pack/Pack;)Lcom/juul/krayon/hierarchy/Node;
+}
+
+public final class com/juul/krayon/hierarchy/partition/Cell {
+	public final fun getHeight ()F
+	public final fun getWidth ()F
+	public final fun getX0 ()F
+	public final fun getX1 ()F
+	public final fun getY0 ()F
+	public final fun getY1 ()F
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/juul/krayon/hierarchy/partition/Partition {
+	public fun <init> ()V
+	public fun <init> (FFFZ)V
+	public synthetic fun <init> (FFFZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getHeight ()F
+	public final fun getPadding ()F
+	public final fun getRound ()Z
+	public final fun getWidth ()F
+	public final fun layout (Lcom/juul/krayon/hierarchy/Node;)Lcom/juul/krayon/hierarchy/Node;
+	public final fun setHeight (F)V
+	public final fun setPadding (F)V
+	public final fun setRound (Z)V
+	public final fun setWidth (F)V
+}
+
+public final class com/juul/krayon/hierarchy/partition/PartitionKt {
+	public static final fun layoutWith (Lcom/juul/krayon/hierarchy/Node;Lcom/juul/krayon/hierarchy/partition/Partition;)Lcom/juul/krayon/hierarchy/Node;
+}
+
+public final class com/juul/krayon/hierarchy/tree/Tree {
+	public fun <init> ()V
+	public fun <init> (FFZLkotlin/jvm/functions/Function2;)V
+	public synthetic fun <init> (FFZLkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getHeight ()F
+	public final fun getNodeSize ()Z
+	public final fun getSeparation ()Lkotlin/jvm/functions/Function2;
+	public final fun getWidth ()F
+	public final fun layout (Lcom/juul/krayon/hierarchy/Node;)Lcom/juul/krayon/hierarchy/Node;
+	public final fun setHeight (F)V
+	public final fun setNodeSize (Z)V
+	public final fun setSeparation (Lkotlin/jvm/functions/Function2;)V
+	public final fun setWidth (F)V
+}
+
+public final class com/juul/krayon/hierarchy/tree/TreeKt {
+	public static final fun defaultSeparation ()Lkotlin/jvm/functions/Function2;
+	public static final fun layoutWith (Lcom/juul/krayon/hierarchy/Node;Lcom/juul/krayon/hierarchy/tree/Tree;)Lcom/juul/krayon/hierarchy/Node;
 }
 
 public final class com/juul/krayon/hierarchy/treemap/Dice : com/juul/krayon/hierarchy/treemap/TileMethod {

--- a/hierarchy/api/hierarchy.klib.api
+++ b/hierarchy/api/hierarchy.klib.api
@@ -10,6 +10,13 @@ abstract interface com.juul.krayon.hierarchy.treemap/TileMethod { // com.juul.kr
     abstract fun tile(com.juul.krayon.hierarchy/Node<*, com.juul.krayon.hierarchy.treemap/Tile>) // com.juul.krayon.hierarchy.treemap/TileMethod.tile|tile(com.juul.krayon.hierarchy.Node<*,com.juul.krayon.hierarchy.treemap.Tile>){}[0]
 }
 
+final class <#A: kotlin/Any?, #B: kotlin/Any?> com.juul.krayon.hierarchy/Link { // com.juul.krayon.hierarchy/Link|null[0]
+    final val source // com.juul.krayon.hierarchy/Link.source|{}source[0]
+        final fun <get-source>(): com.juul.krayon.hierarchy/Node<#A, #B> // com.juul.krayon.hierarchy/Link.source.<get-source>|<get-source>(){}[0]
+    final val target // com.juul.krayon.hierarchy/Link.target|{}target[0]
+        final fun <get-target>(): com.juul.krayon.hierarchy/Node<#A, #B> // com.juul.krayon.hierarchy/Link.target.<get-target>|<get-target>(){}[0]
+}
+
 final class <#A: kotlin/Any?, #B: kotlin/Any?> com.juul.krayon.hierarchy/Node { // com.juul.krayon.hierarchy/Node|null[0]
     final val data // com.juul.krayon.hierarchy/Node.data|{}data[0]
         final fun <get-data>(): #A // com.juul.krayon.hierarchy/Node.data.<get-data>|<get-data>(){}[0]
@@ -23,6 +30,82 @@ final class <#A: kotlin/Any?, #B: kotlin/Any?> com.juul.krayon.hierarchy/Node { 
     final var weight // com.juul.krayon.hierarchy/Node.weight|{}weight[0]
         final fun <get-weight>(): kotlin/Float // com.juul.krayon.hierarchy/Node.weight.<get-weight>|<get-weight>(){}[0]
         final fun <set-weight>(kotlin/Float) // com.juul.krayon.hierarchy/Node.weight.<set-weight>|<set-weight>(kotlin.Float){}[0]
+}
+
+final class <#A: kotlin/Any?> com.juul.krayon.hierarchy.cluster/Cluster { // com.juul.krayon.hierarchy.cluster/Cluster|null[0]
+    constructor <init>(kotlin/Float = ..., kotlin/Float = ..., kotlin/Boolean = ..., kotlin/Function2<com.juul.krayon.hierarchy/Node<#A, com.juul.krayon.hierarchy/Point>, com.juul.krayon.hierarchy/Node<#A, com.juul.krayon.hierarchy/Point>, kotlin/Float> = ...) // com.juul.krayon.hierarchy.cluster/Cluster.<init>|<init>(kotlin.Float;kotlin.Float;kotlin.Boolean;kotlin.Function2<com.juul.krayon.hierarchy.Node<1:0,com.juul.krayon.hierarchy.Point>,com.juul.krayon.hierarchy.Node<1:0,com.juul.krayon.hierarchy.Point>,kotlin.Float>){}[0]
+
+    final var height // com.juul.krayon.hierarchy.cluster/Cluster.height|{}height[0]
+        final fun <get-height>(): kotlin/Float // com.juul.krayon.hierarchy.cluster/Cluster.height.<get-height>|<get-height>(){}[0]
+        final fun <set-height>(kotlin/Float) // com.juul.krayon.hierarchy.cluster/Cluster.height.<set-height>|<set-height>(kotlin.Float){}[0]
+    final var nodeSize // com.juul.krayon.hierarchy.cluster/Cluster.nodeSize|{}nodeSize[0]
+        final fun <get-nodeSize>(): kotlin/Boolean // com.juul.krayon.hierarchy.cluster/Cluster.nodeSize.<get-nodeSize>|<get-nodeSize>(){}[0]
+        final fun <set-nodeSize>(kotlin/Boolean) // com.juul.krayon.hierarchy.cluster/Cluster.nodeSize.<set-nodeSize>|<set-nodeSize>(kotlin.Boolean){}[0]
+    final var separation // com.juul.krayon.hierarchy.cluster/Cluster.separation|{}separation[0]
+        final fun <get-separation>(): kotlin/Function2<com.juul.krayon.hierarchy/Node<#A, com.juul.krayon.hierarchy/Point>, com.juul.krayon.hierarchy/Node<#A, com.juul.krayon.hierarchy/Point>, kotlin/Float> // com.juul.krayon.hierarchy.cluster/Cluster.separation.<get-separation>|<get-separation>(){}[0]
+        final fun <set-separation>(kotlin/Function2<com.juul.krayon.hierarchy/Node<#A, com.juul.krayon.hierarchy/Point>, com.juul.krayon.hierarchy/Node<#A, com.juul.krayon.hierarchy/Point>, kotlin/Float>) // com.juul.krayon.hierarchy.cluster/Cluster.separation.<set-separation>|<set-separation>(kotlin.Function2<com.juul.krayon.hierarchy.Node<1:0,com.juul.krayon.hierarchy.Point>,com.juul.krayon.hierarchy.Node<1:0,com.juul.krayon.hierarchy.Point>,kotlin.Float>){}[0]
+    final var width // com.juul.krayon.hierarchy.cluster/Cluster.width|{}width[0]
+        final fun <get-width>(): kotlin/Float // com.juul.krayon.hierarchy.cluster/Cluster.width.<get-width>|<get-width>(){}[0]
+        final fun <set-width>(kotlin/Float) // com.juul.krayon.hierarchy.cluster/Cluster.width.<set-width>|<set-width>(kotlin.Float){}[0]
+
+    final fun layout(com.juul.krayon.hierarchy/Node<#A, *>): com.juul.krayon.hierarchy/Node<#A, com.juul.krayon.hierarchy/Point> // com.juul.krayon.hierarchy.cluster/Cluster.layout|layout(com.juul.krayon.hierarchy.Node<1:0,*>){}[0]
+}
+
+final class <#A: kotlin/Any?> com.juul.krayon.hierarchy.pack/Pack { // com.juul.krayon.hierarchy.pack/Pack|null[0]
+    constructor <init>(kotlin/Float = ..., kotlin/Float = ..., kotlin/Function1<com.juul.krayon.hierarchy/Node<#A, com.juul.krayon.hierarchy.pack/Circle>, kotlin/Float>? = ..., kotlin/Function1<com.juul.krayon.hierarchy/Node<#A, com.juul.krayon.hierarchy.pack/Circle>, kotlin/Float> = ...) // com.juul.krayon.hierarchy.pack/Pack.<init>|<init>(kotlin.Float;kotlin.Float;kotlin.Function1<com.juul.krayon.hierarchy.Node<1:0,com.juul.krayon.hierarchy.pack.Circle>,kotlin.Float>?;kotlin.Function1<com.juul.krayon.hierarchy.Node<1:0,com.juul.krayon.hierarchy.pack.Circle>,kotlin.Float>){}[0]
+
+    final var height // com.juul.krayon.hierarchy.pack/Pack.height|{}height[0]
+        final fun <get-height>(): kotlin/Float // com.juul.krayon.hierarchy.pack/Pack.height.<get-height>|<get-height>(){}[0]
+        final fun <set-height>(kotlin/Float) // com.juul.krayon.hierarchy.pack/Pack.height.<set-height>|<set-height>(kotlin.Float){}[0]
+    final var padding // com.juul.krayon.hierarchy.pack/Pack.padding|{}padding[0]
+        final fun <get-padding>(): kotlin/Function1<com.juul.krayon.hierarchy/Node<#A, com.juul.krayon.hierarchy.pack/Circle>, kotlin/Float> // com.juul.krayon.hierarchy.pack/Pack.padding.<get-padding>|<get-padding>(){}[0]
+        final fun <set-padding>(kotlin/Function1<com.juul.krayon.hierarchy/Node<#A, com.juul.krayon.hierarchy.pack/Circle>, kotlin/Float>) // com.juul.krayon.hierarchy.pack/Pack.padding.<set-padding>|<set-padding>(kotlin.Function1<com.juul.krayon.hierarchy.Node<1:0,com.juul.krayon.hierarchy.pack.Circle>,kotlin.Float>){}[0]
+    final var radius // com.juul.krayon.hierarchy.pack/Pack.radius|{}radius[0]
+        final fun <get-radius>(): kotlin/Function1<com.juul.krayon.hierarchy/Node<#A, com.juul.krayon.hierarchy.pack/Circle>, kotlin/Float>? // com.juul.krayon.hierarchy.pack/Pack.radius.<get-radius>|<get-radius>(){}[0]
+        final fun <set-radius>(kotlin/Function1<com.juul.krayon.hierarchy/Node<#A, com.juul.krayon.hierarchy.pack/Circle>, kotlin/Float>?) // com.juul.krayon.hierarchy.pack/Pack.radius.<set-radius>|<set-radius>(kotlin.Function1<com.juul.krayon.hierarchy.Node<1:0,com.juul.krayon.hierarchy.pack.Circle>,kotlin.Float>?){}[0]
+    final var width // com.juul.krayon.hierarchy.pack/Pack.width|{}width[0]
+        final fun <get-width>(): kotlin/Float // com.juul.krayon.hierarchy.pack/Pack.width.<get-width>|<get-width>(){}[0]
+        final fun <set-width>(kotlin/Float) // com.juul.krayon.hierarchy.pack/Pack.width.<set-width>|<set-width>(kotlin.Float){}[0]
+
+    final fun layout(com.juul.krayon.hierarchy/Node<#A, *>): com.juul.krayon.hierarchy/Node<#A, com.juul.krayon.hierarchy.pack/Circle> // com.juul.krayon.hierarchy.pack/Pack.layout|layout(com.juul.krayon.hierarchy.Node<1:0,*>){}[0]
+}
+
+final class <#A: kotlin/Any?> com.juul.krayon.hierarchy.partition/Partition { // com.juul.krayon.hierarchy.partition/Partition|null[0]
+    constructor <init>(kotlin/Float = ..., kotlin/Float = ..., kotlin/Float = ..., kotlin/Boolean = ...) // com.juul.krayon.hierarchy.partition/Partition.<init>|<init>(kotlin.Float;kotlin.Float;kotlin.Float;kotlin.Boolean){}[0]
+
+    final var height // com.juul.krayon.hierarchy.partition/Partition.height|{}height[0]
+        final fun <get-height>(): kotlin/Float // com.juul.krayon.hierarchy.partition/Partition.height.<get-height>|<get-height>(){}[0]
+        final fun <set-height>(kotlin/Float) // com.juul.krayon.hierarchy.partition/Partition.height.<set-height>|<set-height>(kotlin.Float){}[0]
+    final var padding // com.juul.krayon.hierarchy.partition/Partition.padding|{}padding[0]
+        final fun <get-padding>(): kotlin/Float // com.juul.krayon.hierarchy.partition/Partition.padding.<get-padding>|<get-padding>(){}[0]
+        final fun <set-padding>(kotlin/Float) // com.juul.krayon.hierarchy.partition/Partition.padding.<set-padding>|<set-padding>(kotlin.Float){}[0]
+    final var round // com.juul.krayon.hierarchy.partition/Partition.round|{}round[0]
+        final fun <get-round>(): kotlin/Boolean // com.juul.krayon.hierarchy.partition/Partition.round.<get-round>|<get-round>(){}[0]
+        final fun <set-round>(kotlin/Boolean) // com.juul.krayon.hierarchy.partition/Partition.round.<set-round>|<set-round>(kotlin.Boolean){}[0]
+    final var width // com.juul.krayon.hierarchy.partition/Partition.width|{}width[0]
+        final fun <get-width>(): kotlin/Float // com.juul.krayon.hierarchy.partition/Partition.width.<get-width>|<get-width>(){}[0]
+        final fun <set-width>(kotlin/Float) // com.juul.krayon.hierarchy.partition/Partition.width.<set-width>|<set-width>(kotlin.Float){}[0]
+
+    final fun layout(com.juul.krayon.hierarchy/Node<#A, *>): com.juul.krayon.hierarchy/Node<#A, com.juul.krayon.hierarchy.partition/Cell> // com.juul.krayon.hierarchy.partition/Partition.layout|layout(com.juul.krayon.hierarchy.Node<1:0,*>){}[0]
+}
+
+final class <#A: kotlin/Any?> com.juul.krayon.hierarchy.tree/Tree { // com.juul.krayon.hierarchy.tree/Tree|null[0]
+    constructor <init>(kotlin/Float = ..., kotlin/Float = ..., kotlin/Boolean = ..., kotlin/Function2<com.juul.krayon.hierarchy/Node<#A, com.juul.krayon.hierarchy/Point>, com.juul.krayon.hierarchy/Node<#A, com.juul.krayon.hierarchy/Point>, kotlin/Float> = ...) // com.juul.krayon.hierarchy.tree/Tree.<init>|<init>(kotlin.Float;kotlin.Float;kotlin.Boolean;kotlin.Function2<com.juul.krayon.hierarchy.Node<1:0,com.juul.krayon.hierarchy.Point>,com.juul.krayon.hierarchy.Node<1:0,com.juul.krayon.hierarchy.Point>,kotlin.Float>){}[0]
+
+    final var height // com.juul.krayon.hierarchy.tree/Tree.height|{}height[0]
+        final fun <get-height>(): kotlin/Float // com.juul.krayon.hierarchy.tree/Tree.height.<get-height>|<get-height>(){}[0]
+        final fun <set-height>(kotlin/Float) // com.juul.krayon.hierarchy.tree/Tree.height.<set-height>|<set-height>(kotlin.Float){}[0]
+    final var nodeSize // com.juul.krayon.hierarchy.tree/Tree.nodeSize|{}nodeSize[0]
+        final fun <get-nodeSize>(): kotlin/Boolean // com.juul.krayon.hierarchy.tree/Tree.nodeSize.<get-nodeSize>|<get-nodeSize>(){}[0]
+        final fun <set-nodeSize>(kotlin/Boolean) // com.juul.krayon.hierarchy.tree/Tree.nodeSize.<set-nodeSize>|<set-nodeSize>(kotlin.Boolean){}[0]
+    final var separation // com.juul.krayon.hierarchy.tree/Tree.separation|{}separation[0]
+        final fun <get-separation>(): kotlin/Function2<com.juul.krayon.hierarchy/Node<#A, com.juul.krayon.hierarchy/Point>, com.juul.krayon.hierarchy/Node<#A, com.juul.krayon.hierarchy/Point>, kotlin/Float> // com.juul.krayon.hierarchy.tree/Tree.separation.<get-separation>|<get-separation>(){}[0]
+        final fun <set-separation>(kotlin/Function2<com.juul.krayon.hierarchy/Node<#A, com.juul.krayon.hierarchy/Point>, com.juul.krayon.hierarchy/Node<#A, com.juul.krayon.hierarchy/Point>, kotlin/Float>) // com.juul.krayon.hierarchy.tree/Tree.separation.<set-separation>|<set-separation>(kotlin.Function2<com.juul.krayon.hierarchy.Node<1:0,com.juul.krayon.hierarchy.Point>,com.juul.krayon.hierarchy.Node<1:0,com.juul.krayon.hierarchy.Point>,kotlin.Float>){}[0]
+    final var width // com.juul.krayon.hierarchy.tree/Tree.width|{}width[0]
+        final fun <get-width>(): kotlin/Float // com.juul.krayon.hierarchy.tree/Tree.width.<get-width>|<get-width>(){}[0]
+        final fun <set-width>(kotlin/Float) // com.juul.krayon.hierarchy.tree/Tree.width.<set-width>|<set-width>(kotlin.Float){}[0]
+
+    final fun layout(com.juul.krayon.hierarchy/Node<#A, *>): com.juul.krayon.hierarchy/Node<#A, com.juul.krayon.hierarchy/Point> // com.juul.krayon.hierarchy.tree/Tree.layout|layout(com.juul.krayon.hierarchy.Node<1:0,*>){}[0]
 }
 
 final class <#A: kotlin/Any?> com.juul.krayon.hierarchy.treemap/Treemap { // com.juul.krayon.hierarchy.treemap/Treemap|null[0]
@@ -56,6 +139,34 @@ final class <#A: kotlin/Any?> com.juul.krayon.hierarchy.treemap/Treemap { // com
     final fun layout(com.juul.krayon.hierarchy/Node<#A, *>): com.juul.krayon.hierarchy/Node<#A, com.juul.krayon.hierarchy.treemap/Tile> // com.juul.krayon.hierarchy.treemap/Treemap.layout|layout(com.juul.krayon.hierarchy.Node<1:0,*>){}[0]
 }
 
+final class com.juul.krayon.hierarchy.pack/Circle { // com.juul.krayon.hierarchy.pack/Circle|null[0]
+    final val radius // com.juul.krayon.hierarchy.pack/Circle.radius|{}radius[0]
+        final fun <get-radius>(): kotlin/Float // com.juul.krayon.hierarchy.pack/Circle.radius.<get-radius>|<get-radius>(){}[0]
+    final val x // com.juul.krayon.hierarchy.pack/Circle.x|{}x[0]
+        final fun <get-x>(): kotlin/Float // com.juul.krayon.hierarchy.pack/Circle.x.<get-x>|<get-x>(){}[0]
+    final val y // com.juul.krayon.hierarchy.pack/Circle.y|{}y[0]
+        final fun <get-y>(): kotlin/Float // com.juul.krayon.hierarchy.pack/Circle.y.<get-y>|<get-y>(){}[0]
+
+    final fun toString(): kotlin/String // com.juul.krayon.hierarchy.pack/Circle.toString|toString(){}[0]
+}
+
+final class com.juul.krayon.hierarchy.partition/Cell { // com.juul.krayon.hierarchy.partition/Cell|null[0]
+    final val height // com.juul.krayon.hierarchy.partition/Cell.height|{}height[0]
+        final fun <get-height>(): kotlin/Float // com.juul.krayon.hierarchy.partition/Cell.height.<get-height>|<get-height>(){}[0]
+    final val width // com.juul.krayon.hierarchy.partition/Cell.width|{}width[0]
+        final fun <get-width>(): kotlin/Float // com.juul.krayon.hierarchy.partition/Cell.width.<get-width>|<get-width>(){}[0]
+    final val x0 // com.juul.krayon.hierarchy.partition/Cell.x0|{}x0[0]
+        final fun <get-x0>(): kotlin/Float // com.juul.krayon.hierarchy.partition/Cell.x0.<get-x0>|<get-x0>(){}[0]
+    final val x1 // com.juul.krayon.hierarchy.partition/Cell.x1|{}x1[0]
+        final fun <get-x1>(): kotlin/Float // com.juul.krayon.hierarchy.partition/Cell.x1.<get-x1>|<get-x1>(){}[0]
+    final val y0 // com.juul.krayon.hierarchy.partition/Cell.y0|{}y0[0]
+        final fun <get-y0>(): kotlin/Float // com.juul.krayon.hierarchy.partition/Cell.y0.<get-y0>|<get-y0>(){}[0]
+    final val y1 // com.juul.krayon.hierarchy.partition/Cell.y1|{}y1[0]
+        final fun <get-y1>(): kotlin/Float // com.juul.krayon.hierarchy.partition/Cell.y1.<get-y1>|<get-y1>(){}[0]
+
+    final fun toString(): kotlin/String // com.juul.krayon.hierarchy.partition/Cell.toString|toString(){}[0]
+}
+
 final class com.juul.krayon.hierarchy.treemap/Squarify : com.juul.krayon.hierarchy.treemap/TileMethod { // com.juul.krayon.hierarchy.treemap/Squarify|null[0]
     constructor <init>(kotlin/Float = ...) // com.juul.krayon.hierarchy.treemap/Squarify.<init>|<init>(kotlin.Float){}[0]
 
@@ -84,6 +195,15 @@ final class com.juul.krayon.hierarchy.treemap/Tile { // com.juul.krayon.hierarch
     final fun toString(): kotlin/String // com.juul.krayon.hierarchy.treemap/Tile.toString|toString(){}[0]
 }
 
+final class com.juul.krayon.hierarchy/Point { // com.juul.krayon.hierarchy/Point|null[0]
+    final val x // com.juul.krayon.hierarchy/Point.x|{}x[0]
+        final fun <get-x>(): kotlin/Float // com.juul.krayon.hierarchy/Point.x.<get-x>|<get-x>(){}[0]
+    final val y // com.juul.krayon.hierarchy/Point.y|{}y[0]
+        final fun <get-y>(): kotlin/Float // com.juul.krayon.hierarchy/Point.y.<get-y>|<get-y>(){}[0]
+
+    final fun toString(): kotlin/String // com.juul.krayon.hierarchy/Point.toString|toString(){}[0]
+}
+
 final object com.juul.krayon.hierarchy.treemap/Dice : com.juul.krayon.hierarchy.treemap/TileMethod { // com.juul.krayon.hierarchy.treemap/Dice|null[0]
     final fun tile(com.juul.krayon.hierarchy/Node<*, com.juul.krayon.hierarchy.treemap/Tile>) // com.juul.krayon.hierarchy.treemap/Dice.tile|tile(com.juul.krayon.hierarchy.Node<*,com.juul.krayon.hierarchy.treemap.Tile>){}[0]
 }
@@ -104,15 +224,27 @@ final val com.juul.krayon.hierarchy/isLeaf // com.juul.krayon.hierarchy/isLeaf|@
     final fun <#A1: kotlin/Any?, #B1: kotlin/Any?> (com.juul.krayon.hierarchy/Node<#A1, #B1>).<get-isLeaf>(): kotlin/Boolean // com.juul.krayon.hierarchy/isLeaf.<get-isLeaf>|<get-isLeaf>@com.juul.krayon.hierarchy.Node<0:0,0:1>(){0§<kotlin.Any?>;1§<kotlin.Any?>}[0]
 
 final fun <#A: kotlin/Any?, #B: kotlin/Any?> (com.juul.krayon.hierarchy/Node<#A, #B>).com.juul.krayon.hierarchy/ancestors(): kotlin.sequences/Sequence<com.juul.krayon.hierarchy/Node<#A, #B>> // com.juul.krayon.hierarchy/ancestors|ancestors@com.juul.krayon.hierarchy.Node<0:0,0:1>(){0§<kotlin.Any?>;1§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?, #B: kotlin/Any?> (com.juul.krayon.hierarchy/Node<#A, #B>).com.juul.krayon.hierarchy/copy(): com.juul.krayon.hierarchy/Node<#A, #B> // com.juul.krayon.hierarchy/copy|copy@com.juul.krayon.hierarchy.Node<0:0,0:1>(){0§<kotlin.Any?>;1§<kotlin.Any?>}[0]
 final fun <#A: kotlin/Any?, #B: kotlin/Any?> (com.juul.krayon.hierarchy/Node<#A, #B>).com.juul.krayon.hierarchy/count(): com.juul.krayon.hierarchy/Node<#A, #B> // com.juul.krayon.hierarchy/count|count@com.juul.krayon.hierarchy.Node<0:0,0:1>(){0§<kotlin.Any?>;1§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?, #B: kotlin/Any?> (com.juul.krayon.hierarchy/Node<#A, #B>).com.juul.krayon.hierarchy/descendants(): kotlin.collections/List<com.juul.krayon.hierarchy/Node<#A, #B>> // com.juul.krayon.hierarchy/descendants|descendants@com.juul.krayon.hierarchy.Node<0:0,0:1>(){0§<kotlin.Any?>;1§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?, #B: kotlin/Any?> (com.juul.krayon.hierarchy/Node<#A, #B>).com.juul.krayon.hierarchy/leaves(): kotlin.collections/List<com.juul.krayon.hierarchy/Node<#A, #B>> // com.juul.krayon.hierarchy/leaves|leaves@com.juul.krayon.hierarchy.Node<0:0,0:1>(){0§<kotlin.Any?>;1§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?, #B: kotlin/Any?> (com.juul.krayon.hierarchy/Node<#A, #B>).com.juul.krayon.hierarchy/links(): kotlin.collections/List<com.juul.krayon.hierarchy/Link<#A, #B>> // com.juul.krayon.hierarchy/links|links@com.juul.krayon.hierarchy.Node<0:0,0:1>(){0§<kotlin.Any?>;1§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?, #B: kotlin/Any?> (com.juul.krayon.hierarchy/Node<#A, #B>).com.juul.krayon.hierarchy/path(com.juul.krayon.hierarchy/Node<#A, #B>): kotlin.collections/List<com.juul.krayon.hierarchy/Node<#A, #B>> // com.juul.krayon.hierarchy/path|path@com.juul.krayon.hierarchy.Node<0:0,0:1>(com.juul.krayon.hierarchy.Node<0:0,0:1>){0§<kotlin.Any?>;1§<kotlin.Any?>}[0]
 final fun <#A: kotlin/Any?, #B: kotlin/Any?> (com.juul.krayon.hierarchy/Node<#A, #B>).com.juul.krayon.hierarchy/sort(kotlin/Comparator<#A>): com.juul.krayon.hierarchy/Node<#A, #B> // com.juul.krayon.hierarchy/sort|sort@com.juul.krayon.hierarchy.Node<0:0,0:1>(kotlin.Comparator<0:0>){0§<kotlin.Any?>;1§<kotlin.Any?>}[0]
 final fun <#A: kotlin/Any?, #B: kotlin/Any?> (com.juul.krayon.hierarchy/Node<#A, #B>).com.juul.krayon.hierarchy/traverseBreadthFirst(): kotlin.sequences/Sequence<com.juul.krayon.hierarchy/Node<#A, #B>> // com.juul.krayon.hierarchy/traverseBreadthFirst|traverseBreadthFirst@com.juul.krayon.hierarchy.Node<0:0,0:1>(){0§<kotlin.Any?>;1§<kotlin.Any?>}[0]
 final fun <#A: kotlin/Any?, #B: kotlin/Any?> (com.juul.krayon.hierarchy/Node<#A, #B>).com.juul.krayon.hierarchy/traversePostOrder(): kotlin.sequences/Sequence<com.juul.krayon.hierarchy/Node<#A, #B>> // com.juul.krayon.hierarchy/traversePostOrder|traversePostOrder@com.juul.krayon.hierarchy.Node<0:0,0:1>(){0§<kotlin.Any?>;1§<kotlin.Any?>}[0]
 final fun <#A: kotlin/Any?, #B: kotlin/Any?> (com.juul.krayon.hierarchy/Node<#A, #B>).com.juul.krayon.hierarchy/traversePreOrder(): kotlin.sequences/Sequence<com.juul.krayon.hierarchy/Node<#A, #B>> // com.juul.krayon.hierarchy/traversePreOrder|traversePreOrder@com.juul.krayon.hierarchy.Node<0:0,0:1>(){0§<kotlin.Any?>;1§<kotlin.Any?>}[0]
 final fun <#A: kotlin/Any?, #B: kotlin/Any?> (com.juul.krayon.hierarchy/Node<#A?, #B>).com.juul.krayon.hierarchy/removeHierarchy(): kotlin.sequences/Sequence<kotlin/Pair<#A, #B>> // com.juul.krayon.hierarchy/removeHierarchy|removeHierarchy@com.juul.krayon.hierarchy.Node<0:0?,0:1>(){0§<kotlin.Any?>;1§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?> (com.juul.krayon.hierarchy/Node<#A, *>).com.juul.krayon.hierarchy.cluster/layoutWith(com.juul.krayon.hierarchy.cluster/Cluster<#A>): com.juul.krayon.hierarchy/Node<#A, com.juul.krayon.hierarchy/Point> // com.juul.krayon.hierarchy.cluster/layoutWith|layoutWith@com.juul.krayon.hierarchy.Node<0:0,*>(com.juul.krayon.hierarchy.cluster.Cluster<0:0>){0§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?> (com.juul.krayon.hierarchy/Node<#A, *>).com.juul.krayon.hierarchy.pack/layoutWith(com.juul.krayon.hierarchy.pack/Pack<#A>): com.juul.krayon.hierarchy/Node<#A, com.juul.krayon.hierarchy.pack/Circle> // com.juul.krayon.hierarchy.pack/layoutWith|layoutWith@com.juul.krayon.hierarchy.Node<0:0,*>(com.juul.krayon.hierarchy.pack.Pack<0:0>){0§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?> (com.juul.krayon.hierarchy/Node<#A, *>).com.juul.krayon.hierarchy.partition/layoutWith(com.juul.krayon.hierarchy.partition/Partition<#A>): com.juul.krayon.hierarchy/Node<#A, com.juul.krayon.hierarchy.partition/Cell> // com.juul.krayon.hierarchy.partition/layoutWith|layoutWith@com.juul.krayon.hierarchy.Node<0:0,*>(com.juul.krayon.hierarchy.partition.Partition<0:0>){0§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?> (com.juul.krayon.hierarchy/Node<#A, *>).com.juul.krayon.hierarchy.tree/layoutWith(com.juul.krayon.hierarchy.tree/Tree<#A>): com.juul.krayon.hierarchy/Node<#A, com.juul.krayon.hierarchy/Point> // com.juul.krayon.hierarchy.tree/layoutWith|layoutWith@com.juul.krayon.hierarchy.Node<0:0,*>(com.juul.krayon.hierarchy.tree.Tree<0:0>){0§<kotlin.Any?>}[0]
 final fun <#A: kotlin/Any?> (com.juul.krayon.hierarchy/Node<#A, *>).com.juul.krayon.hierarchy.treemap/layoutWith(com.juul.krayon.hierarchy.treemap/Treemap<#A>): com.juul.krayon.hierarchy/Node<#A, com.juul.krayon.hierarchy.treemap/Tile> // com.juul.krayon.hierarchy.treemap/layoutWith|layoutWith@com.juul.krayon.hierarchy.Node<0:0,*>(com.juul.krayon.hierarchy.treemap.Treemap<0:0>){0§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?> com.juul.krayon.hierarchy.cluster/defaultSeparation(): kotlin/Function2<com.juul.krayon.hierarchy/Node<#A, com.juul.krayon.hierarchy/Point>, com.juul.krayon.hierarchy/Node<#A, com.juul.krayon.hierarchy/Point>, kotlin/Float> // com.juul.krayon.hierarchy.cluster/defaultSeparation|defaultSeparation(){0§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?> com.juul.krayon.hierarchy.tree/defaultSeparation(): kotlin/Function2<com.juul.krayon.hierarchy/Node<#A, com.juul.krayon.hierarchy/Point>, com.juul.krayon.hierarchy/Node<#A, com.juul.krayon.hierarchy/Point>, kotlin/Float> // com.juul.krayon.hierarchy.tree/defaultSeparation|defaultSeparation(){0§<kotlin.Any?>}[0]
 final fun <#A: kotlin/Any?> com.juul.krayon.hierarchy/flatHierarchy(kotlin.collections/Iterable<#A>): com.juul.krayon.hierarchy/Node<#A?, kotlin/Nothing?> // com.juul.krayon.hierarchy/flatHierarchy|flatHierarchy(kotlin.collections.Iterable<0:0>){0§<kotlin.Any?>}[0]
 final fun <#A: kotlin/Any?> com.juul.krayon.hierarchy/hierarchy(#A, kotlin/Function1<#A, kotlin.collections/List<#A>>): com.juul.krayon.hierarchy/Node<#A, kotlin/Nothing?> // com.juul.krayon.hierarchy/hierarchy|hierarchy(0:0;kotlin.Function1<0:0,kotlin.collections.List<0:0>>){0§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?> com.juul.krayon.hierarchy/stratify(kotlin.collections/Iterable<#A>, kotlin/Function1<#A, kotlin/String?>, kotlin/Function1<#A, kotlin/String?>): com.juul.krayon.hierarchy/Node<#A, kotlin/Nothing?> // com.juul.krayon.hierarchy/stratify|stratify(kotlin.collections.Iterable<0:0>;kotlin.Function1<0:0,kotlin.String?>;kotlin.Function1<0:0,kotlin.String?>){0§<kotlin.Any?>}[0]
 final fun com.juul.krayon.hierarchy.treemap/tile(kotlin/Float, kotlin/Float, kotlin/Float, kotlin/Float): com.juul.krayon.hierarchy.treemap/Tile // com.juul.krayon.hierarchy.treemap/tile|tile(kotlin.Float;kotlin.Float;kotlin.Float;kotlin.Float){}[0]
 final inline fun <#A: kotlin/Any?, #B: kotlin/Any?> (com.juul.krayon.hierarchy/Node<#A, #B>).com.juul.krayon.hierarchy/each(crossinline kotlin/Function1<com.juul.krayon.hierarchy/Node<#A, #B>, kotlin/Unit>): com.juul.krayon.hierarchy/Node<#A, #B> // com.juul.krayon.hierarchy/each|each@com.juul.krayon.hierarchy.Node<0:0,0:1>(kotlin.Function1<com.juul.krayon.hierarchy.Node<0:0,0:1>,kotlin.Unit>){0§<kotlin.Any?>;1§<kotlin.Any?>}[0]
 final inline fun <#A: kotlin/Any?, #B: kotlin/Any?> (com.juul.krayon.hierarchy/Node<#A, #B>).com.juul.krayon.hierarchy/eachAfter(crossinline kotlin/Function1<com.juul.krayon.hierarchy/Node<#A, #B>, kotlin/Unit>): com.juul.krayon.hierarchy/Node<#A, #B> // com.juul.krayon.hierarchy/eachAfter|eachAfter@com.juul.krayon.hierarchy.Node<0:0,0:1>(kotlin.Function1<com.juul.krayon.hierarchy.Node<0:0,0:1>,kotlin.Unit>){0§<kotlin.Any?>;1§<kotlin.Any?>}[0]

--- a/hierarchy/api/jvm/hierarchy.api
+++ b/hierarchy/api/jvm/hierarchy.api
@@ -3,6 +3,11 @@ public final class com/juul/krayon/hierarchy/HierarchyKt {
 	public static final fun hierarchy (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lcom/juul/krayon/hierarchy/Node;
 }
 
+public final class com/juul/krayon/hierarchy/Link {
+	public final fun getSource ()Lcom/juul/krayon/hierarchy/Node;
+	public final fun getTarget ()Lcom/juul/krayon/hierarchy/Node;
+}
+
 public final class com/juul/krayon/hierarchy/Node {
 	public final fun getChildren ()Ljava/util/List;
 	public final fun getData ()Ljava/lang/Object;
@@ -14,7 +19,9 @@ public final class com/juul/krayon/hierarchy/Node {
 
 public final class com/juul/krayon/hierarchy/NodeKt {
 	public static final fun ancestors (Lcom/juul/krayon/hierarchy/Node;)Lkotlin/sequences/Sequence;
+	public static final fun copy (Lcom/juul/krayon/hierarchy/Node;)Lcom/juul/krayon/hierarchy/Node;
 	public static final fun count (Lcom/juul/krayon/hierarchy/Node;)Lcom/juul/krayon/hierarchy/Node;
+	public static final fun descendants (Lcom/juul/krayon/hierarchy/Node;)Ljava/util/List;
 	public static final fun each (Lcom/juul/krayon/hierarchy/Node;Lkotlin/jvm/functions/Function1;)Lcom/juul/krayon/hierarchy/Node;
 	public static final fun eachAfter (Lcom/juul/krayon/hierarchy/Node;Lkotlin/jvm/functions/Function1;)Lcom/juul/krayon/hierarchy/Node;
 	public static final fun eachAfterIndexed (Lcom/juul/krayon/hierarchy/Node;Lkotlin/jvm/functions/Function2;)Lcom/juul/krayon/hierarchy/Node;
@@ -24,6 +31,9 @@ public final class com/juul/krayon/hierarchy/NodeKt {
 	public static final fun getDepth (Lcom/juul/krayon/hierarchy/Node;)I
 	public static final fun getHeight (Lcom/juul/krayon/hierarchy/Node;)I
 	public static final fun isLeaf (Lcom/juul/krayon/hierarchy/Node;)Z
+	public static final fun leaves (Lcom/juul/krayon/hierarchy/Node;)Ljava/util/List;
+	public static final fun links (Lcom/juul/krayon/hierarchy/Node;)Ljava/util/List;
+	public static final fun path (Lcom/juul/krayon/hierarchy/Node;Lcom/juul/krayon/hierarchy/Node;)Ljava/util/List;
 	public static final fun removeHierarchy (Lcom/juul/krayon/hierarchy/Node;)Lkotlin/sequences/Sequence;
 	public static final fun sort (Lcom/juul/krayon/hierarchy/Node;Ljava/util/Comparator;)Lcom/juul/krayon/hierarchy/Node;
 	public static final fun sum (Lcom/juul/krayon/hierarchy/Node;Lkotlin/jvm/functions/Function1;)Lcom/juul/krayon/hierarchy/Node;
@@ -32,8 +42,113 @@ public final class com/juul/krayon/hierarchy/NodeKt {
 	public static final fun traversePreOrder (Lcom/juul/krayon/hierarchy/Node;)Lkotlin/sequences/Sequence;
 }
 
+public final class com/juul/krayon/hierarchy/Point {
+	public final fun getX ()F
+	public final fun getY ()F
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/juul/krayon/hierarchy/StratifyKt {
+	public static final fun stratify (Ljava/lang/Iterable;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lcom/juul/krayon/hierarchy/Node;
+}
+
 public final class com/juul/krayon/hierarchy/SumOfKt {
 	public static final fun sumOf (Ljava/lang/Iterable;Lkotlin/jvm/functions/Function1;)F
+}
+
+public final class com/juul/krayon/hierarchy/cluster/Cluster {
+	public fun <init> ()V
+	public fun <init> (FFZLkotlin/jvm/functions/Function2;)V
+	public synthetic fun <init> (FFZLkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getHeight ()F
+	public final fun getNodeSize ()Z
+	public final fun getSeparation ()Lkotlin/jvm/functions/Function2;
+	public final fun getWidth ()F
+	public final fun layout (Lcom/juul/krayon/hierarchy/Node;)Lcom/juul/krayon/hierarchy/Node;
+	public final fun setHeight (F)V
+	public final fun setNodeSize (Z)V
+	public final fun setSeparation (Lkotlin/jvm/functions/Function2;)V
+	public final fun setWidth (F)V
+}
+
+public final class com/juul/krayon/hierarchy/cluster/ClusterKt {
+	public static final fun defaultSeparation ()Lkotlin/jvm/functions/Function2;
+	public static final fun layoutWith (Lcom/juul/krayon/hierarchy/Node;Lcom/juul/krayon/hierarchy/cluster/Cluster;)Lcom/juul/krayon/hierarchy/Node;
+}
+
+public final class com/juul/krayon/hierarchy/pack/Circle {
+	public final fun getRadius ()F
+	public final fun getX ()F
+	public final fun getY ()F
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/juul/krayon/hierarchy/pack/Pack {
+	public fun <init> ()V
+	public fun <init> (FFLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (FFLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getHeight ()F
+	public final fun getPadding ()Lkotlin/jvm/functions/Function1;
+	public final fun getRadius ()Lkotlin/jvm/functions/Function1;
+	public final fun getWidth ()F
+	public final fun layout (Lcom/juul/krayon/hierarchy/Node;)Lcom/juul/krayon/hierarchy/Node;
+	public final fun setHeight (F)V
+	public final fun setPadding (Lkotlin/jvm/functions/Function1;)V
+	public final fun setRadius (Lkotlin/jvm/functions/Function1;)V
+	public final fun setWidth (F)V
+}
+
+public final class com/juul/krayon/hierarchy/pack/PackKt {
+	public static final fun layoutWith (Lcom/juul/krayon/hierarchy/Node;Lcom/juul/krayon/hierarchy/pack/Pack;)Lcom/juul/krayon/hierarchy/Node;
+}
+
+public final class com/juul/krayon/hierarchy/partition/Cell {
+	public final fun getHeight ()F
+	public final fun getWidth ()F
+	public final fun getX0 ()F
+	public final fun getX1 ()F
+	public final fun getY0 ()F
+	public final fun getY1 ()F
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/juul/krayon/hierarchy/partition/Partition {
+	public fun <init> ()V
+	public fun <init> (FFFZ)V
+	public synthetic fun <init> (FFFZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getHeight ()F
+	public final fun getPadding ()F
+	public final fun getRound ()Z
+	public final fun getWidth ()F
+	public final fun layout (Lcom/juul/krayon/hierarchy/Node;)Lcom/juul/krayon/hierarchy/Node;
+	public final fun setHeight (F)V
+	public final fun setPadding (F)V
+	public final fun setRound (Z)V
+	public final fun setWidth (F)V
+}
+
+public final class com/juul/krayon/hierarchy/partition/PartitionKt {
+	public static final fun layoutWith (Lcom/juul/krayon/hierarchy/Node;Lcom/juul/krayon/hierarchy/partition/Partition;)Lcom/juul/krayon/hierarchy/Node;
+}
+
+public final class com/juul/krayon/hierarchy/tree/Tree {
+	public fun <init> ()V
+	public fun <init> (FFZLkotlin/jvm/functions/Function2;)V
+	public synthetic fun <init> (FFZLkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getHeight ()F
+	public final fun getNodeSize ()Z
+	public final fun getSeparation ()Lkotlin/jvm/functions/Function2;
+	public final fun getWidth ()F
+	public final fun layout (Lcom/juul/krayon/hierarchy/Node;)Lcom/juul/krayon/hierarchy/Node;
+	public final fun setHeight (F)V
+	public final fun setNodeSize (Z)V
+	public final fun setSeparation (Lkotlin/jvm/functions/Function2;)V
+	public final fun setWidth (F)V
+}
+
+public final class com/juul/krayon/hierarchy/tree/TreeKt {
+	public static final fun defaultSeparation ()Lkotlin/jvm/functions/Function2;
+	public static final fun layoutWith (Lcom/juul/krayon/hierarchy/Node;Lcom/juul/krayon/hierarchy/tree/Tree;)Lcom/juul/krayon/hierarchy/Node;
 }
 
 public final class com/juul/krayon/hierarchy/treemap/Dice : com/juul/krayon/hierarchy/treemap/TileMethod {

--- a/hierarchy/src/commonMain/kotlin/Node.kt
+++ b/hierarchy/src/commonMain/kotlin/Node.kt
@@ -40,7 +40,7 @@ public fun <T, L> Node<T, L>.ancestors(): Sequence<Node<T, L>> = sequence {
     var current: Node<T, L>? = this@ancestors
     while (current != null) {
         yield(current)
-        current = parent
+        current = current.parent
     }
 }
 
@@ -120,3 +120,69 @@ public fun <T, L> Node<T?, L>.removeHierarchy(): Sequence<Pair<T, L>> =
     traverseBreadthFirst()
         .filter { it.data != null }
         .map { checkNotNull(it.data) to it.layout }
+
+/** A directed edge from a parent [source] node to a child [target] node, as returned by [links]. */
+public class Link<T, L> internal constructor(
+    public val source: Node<T, L>,
+    public val target: Node<T, L>,
+)
+
+/** Returns all descendant nodes in breadth-first order, starting with `this`. */
+public fun <T, L> Node<T, L>.descendants(): List<Node<T, L>> = traverseBreadthFirst().toList()
+
+/** Returns all leaf nodes (those with no children) in pre-order. */
+public fun <T, L> Node<T, L>.leaves(): List<Node<T, L>> = traversePreOrder().filter { it.isLeaf }.toList()
+
+/** Returns a [Link] from each node's parent to that node, for every descendant except `this`, in breadth-first order. */
+public fun <T, L> Node<T, L>.links(): List<Link<T, L>> {
+    val root = this
+    val result = mutableListOf<Link<T, L>>()
+    traverseBreadthFirst().forEach { node ->
+        if (node !== root) result += Link(checkNotNull(node.parent), node)
+    }
+    return result
+}
+
+/** Returns the shortest path of nodes from `this` to [target], passing through their least common ancestor. */
+public fun <T, L> Node<T, L>.path(target: Node<T, L>): List<Node<T, L>> {
+    val ancestor = leastCommonAncestor(this, target)
+    val nodes = mutableListOf(this)
+    var start: Node<T, L> = this
+    while (start !== ancestor) {
+        start = checkNotNull(start.parent)
+        nodes.add(start)
+    }
+    val split = nodes.size
+    var end: Node<T, L> = target
+    while (end !== ancestor) {
+        nodes.add(split, end)
+        end = checkNotNull(end.parent)
+    }
+    return nodes
+}
+
+private fun <T, L> leastCommonAncestor(a: Node<T, L>, b: Node<T, L>): Node<T, L>? {
+    if (a === b) return a
+    val aNodes = a.ancestors().toMutableList()
+    val bNodes = b.ancestors().toMutableList()
+    var common: Node<T, L>? = null
+    var x = aNodes.removeLastOrNull()
+    var y = bNodes.removeLastOrNull()
+    while (x === y && x != null) {
+        common = x
+        x = aNodes.removeLastOrNull()
+        y = bNodes.removeLastOrNull()
+    }
+    return common
+}
+
+/** Returns a deep copy of the subtree rooted at `this`, detached from any parent. Data and layout references are shared. */
+public fun <T, L> Node<T, L>.copy(): Node<T, L> {
+    fun copyNode(source: Node<T, L>, parent: Node<T, L>?): Node<T, L> {
+        val node = Node(source.data, source.layout, parent)
+        node.weight = source.weight
+        node.children = source.children.map { copyNode(it, node) }
+        return node
+    }
+    return copyNode(this, null)
+}

--- a/hierarchy/src/commonMain/kotlin/Point.kt
+++ b/hierarchy/src/commonMain/kotlin/Point.kt
@@ -1,0 +1,9 @@
+package com.juul.krayon.hierarchy
+
+/** Cartesian coordinate attached as a layout by [com.juul.krayon.hierarchy.tree.Tree] and [com.juul.krayon.hierarchy.cluster.Cluster]. */
+public class Point internal constructor(
+    public val x: Float,
+    public val y: Float,
+) {
+    override fun toString(): String = "Point(x=$x, y=$y)"
+}

--- a/hierarchy/src/commonMain/kotlin/Stratify.kt
+++ b/hierarchy/src/commonMain/kotlin/Stratify.kt
@@ -1,0 +1,51 @@
+package com.juul.krayon.hierarchy
+
+/**
+ * Builds a hierarchy from a flat [data] collection, linking each element to its parent by matching the id returned by
+ * [id] with the parent id returned by [parentId]. The element whose [parentId] is `null` or empty becomes the root.
+ *
+ * Throws [IllegalArgumentException] if there is no single root, if a referenced parent id is missing or ambiguous, or
+ * if the links form a cycle.
+ */
+public fun <T> stratify(
+    data: Iterable<T>,
+    id: (T) -> String?,
+    parentId: (T) -> String?,
+): Node<T, Nothing?> {
+    val elements = data.toList()
+
+    val byId = HashMap<String, T>()
+    for (element in elements) {
+        val key = id(element)?.takeIf { it.isNotEmpty() } ?: continue
+        require(key !in byId) { "ambiguous: $key" }
+        byId[key] = element
+    }
+
+    val childrenByParent = HashMap<String, MutableList<T>>()
+    var root: T? = null
+    var rootCount = 0
+    for (element in elements) {
+        val parent = parentId(element)?.takeIf { it.isNotEmpty() }
+        if (parent != null) {
+            require(parent in byId) { "missing: $parent" }
+            childrenByParent.getOrPut(parent) { mutableListOf() }.add(element)
+        } else {
+            root = element
+            rootCount += 1
+        }
+    }
+    require(rootCount != 0) { "no root" }
+    require(rootCount == 1) { "multiple roots" }
+
+    fun build(element: T, parent: Node<T, Nothing?>?): Node<T, Nothing?> {
+        val node = Node(element, null, parent)
+        val key = id(element)?.takeIf { it.isNotEmpty() }
+        val children = key?.let { childrenByParent[it] }.orEmpty()
+        node.children = children.map { build(it, node) }
+        return node
+    }
+
+    val rootNode = build(checkNotNull(root), null)
+    require(rootNode.traversePreOrder().count() == elements.size) { "cycle" }
+    return rootNode
+}

--- a/hierarchy/src/commonMain/kotlin/cluster/Cluster.kt
+++ b/hierarchy/src/commonMain/kotlin/cluster/Cluster.kt
@@ -1,0 +1,81 @@
+package com.juul.krayon.hierarchy.cluster
+
+import com.juul.krayon.hierarchy.Node
+import com.juul.krayon.hierarchy.Point
+import com.juul.krayon.hierarchy.traversePostOrder
+
+/** Applies [cluster] to `this`, attaching a [Point] layout to every node. */
+public fun <T> Node<T, *>.layoutWith(cluster: Cluster<T>): Node<T, Point> = cluster.layout(this)
+
+/**
+ * Dendrogram (cluster) layout that places every leaf at the same depth.
+ *
+ * When [nodeSize] is `false`, [width] and [height] are the extent of the layout; otherwise they are the
+ * per-node spacing along the x and y axes.
+ */
+public class Cluster<T>(
+    public var width: Float = 1f,
+    public var height: Float = 1f,
+    public var nodeSize: Boolean = false,
+    public var separation: (Node<T, Point>, Node<T, Point>) -> Float = defaultSeparation(),
+) {
+    public fun layout(root: Node<T, *>): Node<T, Point> {
+        @Suppress("UNCHECKED_CAST")
+        val typedRoot = root as Node<T, Point>
+        val xs = HashMap<Node<T, Point>, Float>()
+        val ys = HashMap<Node<T, Point>, Float>()
+
+        var previousNode: Node<T, Point>? = null
+        var x = 0f
+        typedRoot.traversePostOrder().forEach { node ->
+            val children = node.children
+            if (children.isNotEmpty()) {
+                xs[node] = children.sumOf { xs.getValue(it).toDouble() }.toFloat() / children.size
+                ys[node] = 1f + children.fold(0f) { max, child -> maxOf(max, ys.getValue(child)) }
+            } else {
+                val previous = previousNode
+                xs[node] = if (previous != null) {
+                    x += separation(node, previous)
+                    x
+                } else {
+                    0f
+                }
+                ys[node] = 0f
+                previousNode = node
+            }
+        }
+
+        val left = leafLeft(typedRoot)
+        val right = leafRight(typedRoot)
+        val x0 = xs.getValue(left) - separation(left, right) / 2f
+        val x1 = xs.getValue(right) + separation(right, left) / 2f
+        val rootX = xs.getValue(typedRoot)
+        val rootY = ys.getValue(typedRoot)
+
+        typedRoot.traversePostOrder().forEach { node ->
+            node.layout = if (nodeSize) {
+                Point((xs.getValue(node) - rootX) * width, (rootY - ys.getValue(node)) * height)
+            } else {
+                val normalizedY = if (rootY != 0f) ys.getValue(node) / rootY else 1f
+                Point((xs.getValue(node) - x0) / (x1 - x0) * width, (1f - normalizedY) * height)
+            }
+        }
+        return typedRoot
+    }
+}
+
+/** Default node separation: `1` between siblings, `2` between nodes with different parents. */
+public fun <T> defaultSeparation(): (Node<T, Point>, Node<T, Point>) -> Float =
+    { a, b -> if (a.parent === b.parent) 1f else 2f }
+
+private fun <T> leafLeft(node: Node<T, Point>): Node<T, Point> {
+    var current = node
+    while (current.children.isNotEmpty()) current = current.children.first()
+    return current
+}
+
+private fun <T> leafRight(node: Node<T, Point>): Node<T, Point> {
+    var current = node
+    while (current.children.isNotEmpty()) current = current.children.last()
+    return current
+}

--- a/hierarchy/src/commonMain/kotlin/pack/Pack.kt
+++ b/hierarchy/src/commonMain/kotlin/pack/Pack.kt
@@ -1,0 +1,403 @@
+package com.juul.krayon.hierarchy.pack
+
+import com.juul.krayon.hierarchy.Node
+import com.juul.krayon.hierarchy.isLeaf
+import com.juul.krayon.hierarchy.traversePostOrder
+import com.juul.krayon.hierarchy.traversePreOrder
+import kotlin.math.abs
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.sqrt
+
+/** Circle attached as a layout by [Pack]. */
+public class Circle internal constructor(
+    public val x: Float,
+    public val y: Float,
+    public val radius: Float,
+) {
+    override fun toString(): String = "Circle(x=$x, y=$y, radius=$radius)"
+}
+
+/** Applies [pack] to `this`, attaching a [Circle] layout to every node. */
+public fun <T> Node<T, *>.layoutWith(pack: Pack<T>): Node<T, Circle> = pack.layout(this)
+
+/**
+ * Circle-packing layout. Leaves are sized by [radius] (defaulting to the square root of the node weight set via
+ * `sum`/`count`), packed among siblings, and enclosed within their parent. Results are scaled to fit [width] by
+ * [height]. [padding] separates adjacent circles.
+ */
+public class Pack<T>(
+    public var width: Float = 1f,
+    public var height: Float = 1f,
+    public var radius: ((Node<T, Circle>) -> Float)? = null,
+    public var padding: (Node<T, Circle>) -> Float = { 0f },
+) {
+    public fun layout(root: Node<T, *>): Node<T, Circle> {
+        @Suppress("UNCHECKED_CAST")
+        val typedRoot = root as Node<T, Circle>
+        val circles = HashMap<Node<T, Circle>, PackCircle>()
+
+        fun circleOf(node: Node<T, Circle>) = circles.getOrPut(node) { PackCircle() }
+
+        val random = lcg()
+        circleOf(typedRoot).apply {
+            x = width / 2.0
+            y = height / 2.0
+        }
+
+        val radiusFn = radius
+        if (radiusFn != null) {
+            typedRoot.traversePreOrder().forEach { node ->
+                if (node.isLeaf) circleOf(node).r = max(0.0, radiusFn(node).toDouble())
+            }
+            typedRoot.traversePostOrder().forEach { node -> packChildren(node, padding, 0.5, random, ::circleOf) }
+            typedRoot.traversePreOrder().forEach { node -> translateChild(node, 1.0, ::circleOf) }
+        } else {
+            typedRoot.traversePreOrder().forEach { node ->
+                if (node.isLeaf) circleOf(node).r = max(0.0, sqrt(node.weight.toDouble()))
+            }
+            typedRoot.traversePostOrder().forEach { node -> packChildren(node, { 0f }, 1.0, random, ::circleOf) }
+            val k = circleOf(typedRoot).r / min(width, height)
+            typedRoot.traversePostOrder().forEach { node -> packChildren(node, padding, k, random, ::circleOf) }
+            val translation = min(width, height) / (2.0 * circleOf(typedRoot).r)
+            typedRoot.traversePreOrder().forEach { node -> translateChild(node, translation, ::circleOf) }
+        }
+
+        typedRoot.traversePreOrder().forEach { node ->
+            val circle = circleOf(node)
+            node.layout = Circle(circle.x.toFloat(), circle.y.toFloat(), circle.r.toFloat())
+        }
+        return typedRoot
+    }
+
+    private fun packChildren(
+        node: Node<T, Circle>,
+        padding: (Node<T, Circle>) -> Float,
+        k: Double,
+        random: () -> Double,
+        circleOf: (Node<T, Circle>) -> PackCircle,
+    ) {
+        val children = node.children
+        if (children.isEmpty()) return
+        val r = (padding(node) * k).let { if (it.isNaN()) 0.0 else it }
+        val childCircles = children.map(circleOf)
+        if (r != 0.0) childCircles.forEach { it.r += r }
+        val enclosingRadius = packSiblingsRandom(childCircles, random)
+        if (r != 0.0) childCircles.forEach { it.r -= r }
+        circleOf(node).r = enclosingRadius + r
+    }
+
+    private fun translateChild(
+        node: Node<T, Circle>,
+        k: Double,
+        circleOf: (Node<T, Circle>) -> PackCircle,
+    ) {
+        val circle = circleOf(node)
+        circle.r *= k
+        val parent = node.parent
+        if (parent != null) {
+            val parentCircle = circleOf(parent)
+            circle.x = parentCircle.x + k * circle.x
+            circle.y = parentCircle.y + k * circle.y
+        }
+    }
+}
+
+internal class PackCircle {
+    var x: Double = 0.0
+    var y: Double = 0.0
+    var r: Double = 0.0
+}
+
+private class ChainNode(val circle: PackCircle) {
+    var next: ChainNode? = null
+    var previous: ChainNode? = null
+}
+
+private fun place(b: PackCircle, a: PackCircle, c: PackCircle) {
+    val dx = b.x - a.x
+    val dy = b.y - a.y
+    val d2 = dx * dx + dy * dy
+    if (d2 != 0.0) {
+        val a2 = (a.r + c.r).let { it * it }
+        val b2 = (b.r + c.r).let { it * it }
+        if (a2 > b2) {
+            val x = (d2 + b2 - a2) / (2.0 * d2)
+            val y = sqrt(max(0.0, b2 / d2 - x * x))
+            c.x = b.x - x * dx - y * dy
+            c.y = b.y - x * dy + y * dx
+        } else {
+            val x = (d2 + a2 - b2) / (2.0 * d2)
+            val y = sqrt(max(0.0, a2 / d2 - x * x))
+            c.x = a.x + x * dx - y * dy
+            c.y = a.y + x * dy + y * dx
+        }
+    } else {
+        c.x = a.x + c.r
+        c.y = a.y
+    }
+}
+
+private fun intersects(a: PackCircle, b: PackCircle): Boolean {
+    val dr = a.r + b.r - 1e-6
+    val dx = b.x - a.x
+    val dy = b.y - a.y
+    return dr > 0.0 && dr * dr > dx * dx + dy * dy
+}
+
+private fun score(node: ChainNode): Double {
+    val a = node.circle
+    val b = checkNotNull(node.next).circle
+    val ab = a.r + b.r
+    val dx = (a.x * b.r + b.x * a.r) / ab
+    val dy = (a.y * b.r + b.y * a.r) / ab
+    return dx * dx + dy * dy
+}
+
+internal fun packSiblingsRandom(circles: List<PackCircle>, random: () -> Double): Double {
+    val n = circles.size
+    if (n == 0) return 0.0
+
+    val first = circles[0]
+    first.x = 0.0
+    first.y = 0.0
+    if (n == 1) return first.r
+
+    val second = circles[1]
+    first.x = -second.r
+    second.x = first.r
+    second.y = 0.0
+    if (n == 2) return first.r + second.r
+
+    place(second, first, circles[2])
+
+    var a = ChainNode(first)
+    var b = ChainNode(second)
+    var c = ChainNode(circles[2])
+    a.next = b
+    c.previous = b
+    b.next = c
+    a.previous = c
+    c.next = a
+    b.previous = a
+
+    var i = 3
+    while (i < n) {
+        place(a.circle, b.circle, circles[i])
+        c = ChainNode(circles[i])
+
+        var j = checkNotNull(b.next)
+        var k = checkNotNull(a.previous)
+        var sj = b.circle.r
+        var sk = a.circle.r
+        var collided = false
+        do {
+            if (sj <= sk) {
+                if (intersects(j.circle, c.circle)) {
+                    b = j
+                    a.next = b
+                    b.previous = a
+                    collided = true
+                    break
+                }
+                sj += j.circle.r
+                j = checkNotNull(j.next)
+            } else {
+                if (intersects(k.circle, c.circle)) {
+                    a = k
+                    a.next = b
+                    b.previous = a
+                    collided = true
+                    break
+                }
+                sk += k.circle.r
+                k = checkNotNull(k.previous)
+            }
+        } while (j !== k.next)
+
+        if (collided) continue
+
+        val oldB = b
+        c.previous = a
+        c.next = oldB
+        a.next = c
+        oldB.previous = c
+        b = c
+
+        var aa = score(a)
+        var scan = c
+        while (true) {
+            scan = checkNotNull(scan.next)
+            if (scan === b) break
+            val ca = score(scan)
+            if (ca < aa) {
+                a = scan
+                aa = ca
+            }
+        }
+        b = checkNotNull(a.next)
+        i++
+    }
+
+    val chain = mutableListOf(b.circle)
+    var scan = checkNotNull(b.next)
+    while (scan !== b) {
+        chain.add(scan.circle)
+        scan = checkNotNull(scan.next)
+    }
+    val enclosing = packEncloseRandom(chain, random)
+    for (circle in circles) {
+        circle.x -= enclosing.x
+        circle.y -= enclosing.y
+    }
+    return enclosing.r
+}
+
+private fun packEncloseRandom(circles: List<PackCircle>, random: () -> Double): PackCircle {
+    val shuffled = circles.toMutableList()
+    shuffle(shuffled, random)
+    val n = shuffled.size
+    var i = 0
+    var basis = emptyList<PackCircle>()
+    var enclosing: PackCircle? = null
+    while (i < n) {
+        val p = shuffled[i]
+        val e = enclosing
+        if (e != null && enclosesWeak(e, p)) {
+            i++
+        } else {
+            basis = extendBasis(basis, p)
+            enclosing = encloseBasis(basis)
+            i = 0
+        }
+    }
+    return checkNotNull(enclosing)
+}
+
+private fun shuffle(array: MutableList<PackCircle>, random: () -> Double) {
+    var m = array.size
+    while (m != 0) {
+        val i = (random() * m).toInt()
+        m -= 1
+        val t = array[m]
+        array[m] = array[i]
+        array[i] = t
+    }
+}
+
+private fun extendBasis(basis: List<PackCircle>, p: PackCircle): List<PackCircle> {
+    if (enclosesWeakAll(p, basis)) return listOf(p)
+
+    for (i in basis.indices) {
+        if (enclosesNot(p, basis[i]) && enclosesWeakAll(encloseBasis2(basis[i], p), basis)) {
+            return listOf(basis[i], p)
+        }
+    }
+
+    for (i in 0 until basis.size - 1) {
+        for (j in i + 1 until basis.size) {
+            if (enclosesNot(encloseBasis2(basis[i], basis[j]), p) &&
+                enclosesNot(encloseBasis2(basis[i], p), basis[j]) &&
+                enclosesNot(encloseBasis2(basis[j], p), basis[i]) &&
+                enclosesWeakAll(encloseBasis3(basis[i], basis[j], p), basis)
+            ) {
+                return listOf(basis[i], basis[j], p)
+            }
+        }
+    }
+
+    error("Unable to extend enclosing basis")
+}
+
+private fun enclosesNot(a: PackCircle, b: PackCircle): Boolean {
+    val dr = a.r - b.r
+    val dx = b.x - a.x
+    val dy = b.y - a.y
+    return dr < 0.0 || dr * dr < dx * dx + dy * dy
+}
+
+private fun enclosesWeak(a: PackCircle, b: PackCircle): Boolean {
+    val dr = a.r - b.r + max(max(a.r, b.r), 1.0) * 1e-9
+    val dx = b.x - a.x
+    val dy = b.y - a.y
+    return dr > 0.0 && dr * dr > dx * dx + dy * dy
+}
+
+private fun enclosesWeakAll(a: PackCircle, basis: List<PackCircle>): Boolean =
+    basis.all { enclosesWeak(a, it) }
+
+private fun encloseBasis(basis: List<PackCircle>): PackCircle = when (basis.size) {
+    1 -> encloseBasis1(basis[0])
+    2 -> encloseBasis2(basis[0], basis[1])
+    else -> encloseBasis3(basis[0], basis[1], basis[2])
+}
+
+private fun encloseBasis1(a: PackCircle): PackCircle = PackCircle().apply {
+    x = a.x
+    y = a.y
+    r = a.r
+}
+
+private fun encloseBasis2(a: PackCircle, b: PackCircle): PackCircle {
+    val x1 = a.x
+    val y1 = a.y
+    val r1 = a.r
+    val x2 = b.x
+    val y2 = b.y
+    val r2 = b.r
+    val x21 = x2 - x1
+    val y21 = y2 - y1
+    val r21 = r2 - r1
+    val l = sqrt(x21 * x21 + y21 * y21)
+    return PackCircle().apply {
+        x = (x1 + x2 + x21 / l * r21) / 2.0
+        y = (y1 + y2 + y21 / l * r21) / 2.0
+        r = (l + r1 + r2) / 2.0
+    }
+}
+
+private fun encloseBasis3(a: PackCircle, b: PackCircle, c: PackCircle): PackCircle {
+    val x1 = a.x
+    val y1 = a.y
+    val r1 = a.r
+    val x2 = b.x
+    val y2 = b.y
+    val r2 = b.r
+    val x3 = c.x
+    val y3 = c.y
+    val r3 = c.r
+    val a2 = x1 - x2
+    val a3 = x1 - x3
+    val b2 = y1 - y2
+    val b3 = y1 - y3
+    val c2 = r2 - r1
+    val c3 = r3 - r1
+    val d1 = x1 * x1 + y1 * y1 - r1 * r1
+    val d2 = d1 - x2 * x2 - y2 * y2 + r2 * r2
+    val d3 = d1 - x3 * x3 - y3 * y3 + r3 * r3
+    val ab = a3 * b2 - a2 * b3
+    val xa = (b2 * d3 - b3 * d2) / (ab * 2.0) - x1
+    val xb = (b3 * c2 - b2 * c3) / ab
+    val ya = (a3 * d2 - a2 * d3) / (ab * 2.0) - y1
+    val yb = (a2 * c3 - a3 * c2) / ab
+    val bigA = xb * xb + yb * yb - 1.0
+    val bigB = 2.0 * (r1 + xa * xb + ya * yb)
+    val bigC = xa * xa + ya * ya - r1 * r1
+    val r = -(if (abs(bigA) > 1e-6) (bigB + sqrt(bigB * bigB - 4.0 * bigA * bigC)) / (2.0 * bigA) else bigC / bigB)
+    return PackCircle().apply {
+        x = x1 + xa + xb * r
+        y = y1 + ya + yb * r
+        this.r = r
+    }
+}
+
+private fun lcg(): () -> Double {
+    val a = 1664525.0
+    val c = 1013904223.0
+    val m = 4294967296.0
+    var s = 1.0
+    return {
+        s = (a * s + c) % m
+        s / m
+    }
+}

--- a/hierarchy/src/commonMain/kotlin/partition/Partition.kt
+++ b/hierarchy/src/commonMain/kotlin/partition/Partition.kt
@@ -1,0 +1,127 @@
+package com.juul.krayon.hierarchy.partition
+
+import com.juul.krayon.hierarchy.Node
+import com.juul.krayon.hierarchy.depth
+import com.juul.krayon.hierarchy.height
+import com.juul.krayon.hierarchy.traversePreOrder
+import kotlin.math.floor
+
+/** Rectangle attached as a layout by [Partition], spanning `[x0, x1]` horizontally and `[y0, y1]` vertically. */
+public class Cell internal constructor(
+    public val x0: Float,
+    public val y0: Float,
+    public val x1: Float,
+    public val y1: Float,
+) {
+    public val width: Float get() = x1 - x0
+    public val height: Float get() = y1 - y0
+
+    override fun toString(): String = "Cell(x0=$x0, y0=$y0, x1=$x1, y1=$y1)"
+}
+
+/** Applies [partition] to `this`, attaching a [Cell] layout to every node. */
+public fun <T> Node<T, *>.layoutWith(partition: Partition<T>): Node<T, Cell> = partition.layout(this)
+
+/**
+ * Adjacency (icicle/sunburst) layout. Subdivides [width] by [height] into rectangles sized by node weight (set via
+ * `sum`/`count`), with each depth occupying a horizontal band. [padding] insets each cell; [round] snaps coordinates
+ * to integers.
+ */
+public class Partition<T>(
+    public var width: Float = 1f,
+    public var height: Float = 1f,
+    public var padding: Float = 0f,
+    public var round: Boolean = false,
+) {
+    public fun layout(root: Node<T, *>): Node<T, Cell> {
+        @Suppress("UNCHECKED_CAST")
+        val typedRoot = root as Node<T, Cell>
+        val rectangles = HashMap<Node<T, Cell>, Rectangle>()
+
+        fun rectOf(node: Node<T, Cell>) = rectangles.getOrPut(node) { Rectangle() }
+
+        val n = typedRoot.height + 1
+        rectOf(typedRoot).apply {
+            x0 = padding
+            y0 = padding
+            x1 = width
+            y1 = height / n
+        }
+        typedRoot.traversePreOrder().forEach { node -> positionNode(node, n, ::rectOf) }
+        if (round) {
+            typedRoot.traversePreOrder().forEach { node ->
+                rectOf(node).apply {
+                    x0 = roundHalfUp(x0)
+                    y0 = roundHalfUp(y0)
+                    x1 = roundHalfUp(x1)
+                    y1 = roundHalfUp(y1)
+                }
+            }
+        }
+        typedRoot.traversePreOrder().forEach { node ->
+            val rectangle = rectOf(node)
+            node.layout = Cell(rectangle.x0, rectangle.y0, rectangle.x1, rectangle.y1)
+        }
+        return typedRoot
+    }
+
+    private fun positionNode(node: Node<T, Cell>, n: Int, rectOf: (Node<T, Cell>) -> Rectangle) {
+        val rectangle = rectOf(node)
+        if (node.children.isNotEmpty()) {
+            dice(
+                node,
+                rectangle.x0,
+                height * (node.depth + 1) / n,
+                rectangle.x1,
+                height * (node.depth + 2) / n,
+                rectOf,
+            )
+        }
+        var x0 = rectangle.x0
+        var y0 = rectangle.y0
+        var x1 = rectangle.x1 - padding
+        var y1 = rectangle.y1 - padding
+        if (x1 < x0) {
+            x0 = (x0 + x1) / 2f
+            x1 = x0
+        }
+        if (y1 < y0) {
+            y0 = (y0 + y1) / 2f
+            y1 = y0
+        }
+        rectangle.x0 = x0
+        rectangle.y0 = y0
+        rectangle.x1 = x1
+        rectangle.y1 = y1
+    }
+
+    private fun dice(
+        parent: Node<T, Cell>,
+        x0: Float,
+        y0: Float,
+        x1: Float,
+        y1: Float,
+        rectOf: (Node<T, Cell>) -> Rectangle,
+    ) {
+        val k = if (parent.weight != 0f) (x1 - x0) / parent.weight else 0f
+        var x = x0
+        for (child in parent.children) {
+            rectOf(child).apply {
+                this.y0 = y0
+                this.y1 = y1
+                this.x0 = x
+                x += child.weight * k
+                this.x1 = x
+            }
+        }
+    }
+}
+
+private fun roundHalfUp(value: Float): Float = floor(value + 0.5f)
+
+private class Rectangle {
+    var x0: Float = 0f
+    var y0: Float = 0f
+    var x1: Float = 0f
+    var y1: Float = 0f
+}

--- a/hierarchy/src/commonMain/kotlin/tree/Tree.kt
+++ b/hierarchy/src/commonMain/kotlin/tree/Tree.kt
@@ -1,0 +1,217 @@
+package com.juul.krayon.hierarchy.tree
+
+import com.juul.krayon.hierarchy.Node
+import com.juul.krayon.hierarchy.Point
+import com.juul.krayon.hierarchy.depth
+import com.juul.krayon.hierarchy.traversePreOrder
+
+/** Applies [tree] to `this`, attaching a [Point] layout to every node. */
+public fun <T> Node<T, *>.layoutWith(tree: Tree<T>): Node<T, Point> = tree.layout(this)
+
+/**
+ * Node-link tree diagram using the Reingold–Tilford "tidy" algorithm, as improved by Buchheim et al.
+ *
+ * When [nodeSize] is `false`, [width] and [height] are the extent of the layout; otherwise they are the
+ * per-node spacing along the x and y axes.
+ */
+public class Tree<T>(
+    public var width: Float = 1f,
+    public var height: Float = 1f,
+    public var nodeSize: Boolean = false,
+    public var separation: (Node<T, Point>, Node<T, Point>) -> Float = defaultSeparation(),
+) {
+    public fun layout(root: Node<T, *>): Node<T, Point> {
+        @Suppress("UNCHECKED_CAST")
+        val typedRoot = root as Node<T, Point>
+        val x = HashMap<Node<T, Point>, Float>()
+
+        val t = wrapTree(typedRoot)
+        t.eachAfter(::firstWalk)
+        checkNotNull(t.parent).mod = -t.prelim
+        t.eachBefore { v -> secondWalk(v, x) }
+
+        if (nodeSize) {
+            typedRoot.traversePreOrder().forEach { node ->
+                node.layout = Point(x.getValue(node) * width, node.depth * height)
+            }
+        } else {
+            var left = typedRoot
+            var right = typedRoot
+            var bottom = typedRoot
+            typedRoot.traversePreOrder().forEach { node ->
+                if (x.getValue(node) < x.getValue(left)) left = node
+                if (x.getValue(node) > x.getValue(right)) right = node
+                if (node.depth > bottom.depth) bottom = node
+            }
+            val s = if (left === right) 1f else separation(left, right) / 2f
+            val tx = s - x.getValue(left)
+            val kx = width / (x.getValue(right) + s + tx)
+            val ky = height / (if (bottom.depth != 0) bottom.depth.toFloat() else 1f)
+            typedRoot.traversePreOrder().forEach { node ->
+                node.layout = Point((x.getValue(node) + tx) * kx, node.depth * ky)
+            }
+        }
+        return typedRoot
+    }
+
+    private fun nextLeft(v: TreeNode<T>): TreeNode<T>? = v.children?.first() ?: v.thread
+
+    private fun nextRight(v: TreeNode<T>): TreeNode<T>? = v.children?.last() ?: v.thread
+
+    private fun moveSubtree(wm: TreeNode<T>, wp: TreeNode<T>, shift: Float) {
+        val change = shift / (wp.number - wm.number)
+        wp.change -= change
+        wp.shift += shift
+        wm.change += change
+        wp.prelim += shift
+        wp.mod += shift
+    }
+
+    private fun executeShifts(v: TreeNode<T>) {
+        val children = v.children ?: return
+        var shift = 0f
+        var change = 0f
+        for (i in children.indices.reversed()) {
+            val w = children[i]
+            w.prelim += shift
+            w.mod += shift
+            change += w.change
+            shift += w.shift + change
+        }
+    }
+
+    private fun nextAncestor(vim: TreeNode<T>, v: TreeNode<T>, ancestor: TreeNode<T>): TreeNode<T> =
+        if (vim.ancestor.parent === v.parent) vim.ancestor else ancestor
+
+    private fun apportion(v: TreeNode<T>, w: TreeNode<T>?, ancestorIn: TreeNode<T>): TreeNode<T> {
+        var ancestor = ancestorIn
+        if (w == null) return ancestor
+
+        var vip = v
+        var vop = v
+        var vim = w
+        var vom = checkNotNull(vip.parent).children!!.first()
+        var sip = vip.mod
+        var sop = vop.mod
+        var sim = vim.mod
+        var som = vom.mod
+
+        var nextVim = nextRight(vim)
+        var nextVip = nextLeft(vip)
+        while (nextVim != null && nextVip != null) {
+            vim = nextVim
+            vip = nextVip
+            vom = checkNotNull(nextLeft(vom))
+            vop = checkNotNull(nextRight(vop))
+            vop.ancestor = v
+            val shift = (vim.prelim + sim) - (vip.prelim + sip) + separation(vim.node, vip.node)
+            if (shift > 0f) {
+                moveSubtree(nextAncestor(vim, v, ancestor), v, shift)
+                sip += shift
+                sop += shift
+            }
+            sim += vim.mod
+            sip += vip.mod
+            som += vom.mod
+            sop += vop.mod
+            nextVim = nextRight(vim)
+            nextVip = nextLeft(vip)
+        }
+        if (nextVim != null && nextRight(vop) == null) {
+            vop.thread = nextVim
+            vop.mod += sim - sop
+        }
+        if (nextVip != null && nextLeft(vom) == null) {
+            vom.thread = nextVip
+            vom.mod += sip - som
+            ancestor = v
+        }
+        return ancestor
+    }
+
+    private fun firstWalk(v: TreeNode<T>) {
+        val children = v.children
+        val siblings = checkNotNull(v.parent).children!!
+        val w = if (v.number != 0) siblings[v.number - 1] else null
+        if (children != null) {
+            executeShifts(v)
+            val midpoint = (children.first().prelim + children.last().prelim) / 2f
+            if (w != null) {
+                v.prelim = w.prelim + separation(v.node, w.node)
+                v.mod = v.prelim - midpoint
+            } else {
+                v.prelim = midpoint
+            }
+        } else if (w != null) {
+            v.prelim = w.prelim + separation(v.node, w.node)
+        }
+        val parent = checkNotNull(v.parent)
+        parent.ancestor2 = apportion(v, w, parent.ancestor2 ?: siblings.first())
+    }
+
+    private fun secondWalk(v: TreeNode<T>, x: HashMap<Node<T, Point>, Float>) {
+        val parent = checkNotNull(v.parent)
+        x[v.node] = v.prelim + parent.mod
+        v.mod += parent.mod
+    }
+
+    private fun wrapTree(root: Node<T, Point>): TreeNode<T> {
+        fun wrap(node: Node<T, Point>, index: Int, parent: TreeNode<T>?): TreeNode<T> {
+            val wrapped = treeNode(node, index)
+            wrapped.parent = parent
+            val children = node.children
+            if (children.isNotEmpty()) {
+                wrapped.children = children.mapIndexed { i, child -> wrap(child, i, wrapped) }
+            }
+            return wrapped
+        }
+        val wrapped = wrap(root, 0, null)
+        val superRoot = TreeNode<T>(null, 0)
+        superRoot.ancestor = superRoot
+        superRoot.children = listOf(wrapped)
+        wrapped.parent = superRoot
+        return wrapped
+    }
+}
+
+/** Default node separation: `1` between siblings, `2` between nodes with different parents. */
+public fun <T> defaultSeparation(): (Node<T, Point>, Node<T, Point>) -> Float =
+    { a, b -> if (a.parent === b.parent) 1f else 2f }
+
+private class TreeNode<T>(
+    node: Node<T, Point>?,
+    val number: Int,
+) {
+    private val backing: Node<T, Point>? = node
+
+    /** The wrapped hierarchy node. Never accessed for the synthetic super-root. */
+    val node: Node<T, Point> get() = checkNotNull(backing)
+
+    var parent: TreeNode<T>? = null
+    var children: List<TreeNode<T>>? = null
+
+    /** Default ancestor (`A` in the paper). */
+    var ancestor2: TreeNode<T>? = null
+
+    /** Ancestor (`a` in the paper); defaults to itself. */
+    lateinit var ancestor: TreeNode<T>
+
+    var prelim: Float = 0f
+    var mod: Float = 0f
+    var change: Float = 0f
+    var shift: Float = 0f
+    var thread: TreeNode<T>? = null
+}
+
+private fun <T> treeNode(node: Node<T, Point>?, index: Int): TreeNode<T> =
+    TreeNode(node, index).apply { ancestor = this }
+
+private fun <T> TreeNode<T>.eachAfter(action: (TreeNode<T>) -> Unit) {
+    children?.forEach { it.eachAfter(action) }
+    action(this)
+}
+
+private fun <T> TreeNode<T>.eachBefore(action: (TreeNode<T>) -> Unit) {
+    action(this)
+    children?.forEach { it.eachBefore(action) }
+}

--- a/hierarchy/src/commonTest/kotlin/Datum.kt
+++ b/hierarchy/src/commonTest/kotlin/Datum.kt
@@ -1,0 +1,57 @@
+package com.juul.krayon.hierarchy
+
+internal data class Datum(
+    val name: String,
+    val value: Float = 0f,
+    val children: List<Datum> = emptyList(),
+)
+
+/** root -> [a -> [a1, a2], b -> [b1]] */
+internal fun fixtureA(): Node<Datum, Nothing?> = hierarchy(
+    Datum(
+        "root",
+        children = listOf(
+            Datum("a", children = listOf(Datum("a1"), Datum("a2"))),
+            Datum("b", children = listOf(Datum("b1"))),
+        ),
+    ),
+) { it.children }
+
+/** Uneven depth: root -> [a -> [a1 -> [a1x]], b] */
+internal fun fixtureB(): Node<Datum, Nothing?> = hierarchy(
+    Datum(
+        "root",
+        children = listOf(
+            Datum("a", children = listOf(Datum("a1", children = listOf(Datum("a1x"))))),
+            Datum("b"),
+        ),
+    ),
+) { it.children }
+
+/** Nested weighted leaves: root -> [a -> [a1=1, a2=2], b -> [b1=3]] */
+internal fun fixtureNested(): Node<Datum, Nothing?> = hierarchy(
+    Datum(
+        "root",
+        children = listOf(
+            Datum("a", children = listOf(Datum("a1", value = 1f), Datum("a2", value = 2f))),
+            Datum("b", children = listOf(Datum("b1", value = 3f))),
+        ),
+    ),
+) { it.children }
+
+/** root -> [a=1, b=2, c=3, d=4, e=5] weighted leaves. */
+internal fun fixtureWeighted(): Node<Datum, Nothing?> = hierarchy(
+    Datum(
+        "root",
+        children = listOf(
+            Datum("a", value = 1f),
+            Datum("b", value = 2f),
+            Datum("c", value = 3f),
+            Datum("d", value = 4f),
+            Datum("e", value = 5f),
+        ),
+    ),
+) { it.children }
+
+internal fun <L> Node<Datum, L>.layoutByName(): Map<String, L> =
+    traverseBreadthFirst().associate { it.data.name to it.layout }

--- a/hierarchy/src/commonTest/kotlin/NodeHelpersTests.kt
+++ b/hierarchy/src/commonTest/kotlin/NodeHelpersTests.kt
@@ -1,0 +1,64 @@
+package com.juul.krayon.hierarchy
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotSame
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+
+class NodeHelpersTests {
+
+    private fun Node<Datum, Nothing?>.byName() = traverseBreadthFirst().associateBy { it.data.name }
+
+    @Test
+    fun descendants_areBreadthFirst() {
+        val names = fixtureA().descendants().map { it.data.name }
+        assertEquals(listOf("root", "a", "b", "a1", "a2", "b1"), names)
+    }
+
+    @Test
+    fun leaves_arePreOrderLeaves() {
+        val names = fixtureA().leaves().map { it.data.name }
+        assertEquals(listOf("a1", "a2", "b1"), names)
+    }
+
+    @Test
+    fun links_connectParentToChildBreadthFirst() {
+        val edges = fixtureA().links().map { it.source.data.name to it.target.data.name }
+        assertEquals(
+            listOf("root" to "a", "root" to "b", "a" to "a1", "a" to "a2", "b" to "b1"),
+            edges,
+        )
+    }
+
+    @Test
+    fun path_passesThroughLeastCommonAncestor() {
+        val root = fixtureA()
+        val byName = root.byName()
+        val names = byName.getValue("a1").path(byName.getValue("b1")).map { it.data.name }
+        assertEquals(listOf("a1", "a", "root", "b", "b1"), names)
+    }
+
+    @Test
+    fun path_toSelfIsSingleton() {
+        val root = fixtureA()
+        val a1 = root.byName().getValue("a1")
+        assertEquals(listOf("a1"), a1.path(a1).map { it.data.name })
+    }
+
+    @Test
+    fun copy_deepCopiesStructureSharingData() {
+        val root = fixtureA().count()
+        val copy = root.copy()
+        assertNotSame(root, copy)
+        assertNull(copy.parent)
+        assertEquals(6f, copy.weight)
+        assertEquals(
+            root.descendants().map { it.data.name },
+            copy.descendants().map { it.data.name },
+        )
+        assertSame(root.data, copy.data)
+        assertSame(root.children.first().data, copy.children.first().data)
+        assertSame(copy, copy.children.first().parent)
+    }
+}

--- a/hierarchy/src/commonTest/kotlin/StratifyTests.kt
+++ b/hierarchy/src/commonTest/kotlin/StratifyTests.kt
@@ -1,0 +1,66 @@
+package com.juul.krayon.hierarchy
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+
+private data class Row(val id: String, val parentId: String? = null)
+
+class StratifyTests {
+
+    private val table = listOf(
+        Row("root"),
+        Row("a", "root"),
+        Row("b", "root"),
+        Row("a1", "a"),
+    )
+
+    private fun stratifyTable(rows: List<Row>) =
+        stratify(rows, id = { it.id }, parentId = { it.parentId })
+
+    @Test
+    fun stratify_buildsExpectedStructure() {
+        val root = stratifyTable(table)
+        assertEquals("root", root.data.id)
+        assertNull(root.parent)
+        assertEquals(0, root.depth)
+        assertEquals(2, root.height)
+
+        val byName = root.traverseBreadthFirst().associateBy { it.data.id }
+        assertEquals("root", byName.getValue("a").parent?.data?.id)
+        assertEquals("a", byName.getValue("a1").parent?.data?.id)
+        assertEquals(1, byName.getValue("a").height)
+        assertEquals(0, byName.getValue("b").height)
+        assertEquals(2, byName.getValue("a1").depth)
+        assertEquals(listOf("a", "b"), root.children.map { it.data.id })
+    }
+
+    @Test
+    fun stratify_missingParent_fails() {
+        assertFailsWith<IllegalArgumentException> {
+            stratifyTable(listOf(Row("root"), Row("a", "missing")))
+        }
+    }
+
+    @Test
+    fun stratify_multipleRoots_fails() {
+        assertFailsWith<IllegalArgumentException> {
+            stratifyTable(listOf(Row("root"), Row("other")))
+        }
+    }
+
+    @Test
+    fun stratify_ambiguousId_fails() {
+        assertFailsWith<IllegalArgumentException> {
+            stratifyTable(listOf(Row("root"), Row("a", "root"), Row("a", "root")))
+        }
+    }
+
+    @Test
+    fun stratify_noRoot_fails() {
+        assertFailsWith<IllegalArgumentException> {
+            stratifyTable(listOf(Row("a", "b"), Row("b", "a")))
+        }
+    }
+}

--- a/hierarchy/src/commonTest/kotlin/cluster/ClusterTests.kt
+++ b/hierarchy/src/commonTest/kotlin/cluster/ClusterTests.kt
@@ -1,0 +1,50 @@
+package com.juul.krayon.hierarchy.cluster
+
+import com.juul.krayon.hierarchy.Point
+import com.juul.krayon.hierarchy.fixtureA
+import com.juul.krayon.hierarchy.fixtureB
+import com.juul.krayon.hierarchy.layoutByName
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+private const val TOLERANCE = 1e-4f
+
+private fun assertPoint(expectedX: Float, expectedY: Float, actual: Point) {
+    assertEquals(expectedX, actual.x, TOLERANCE)
+    assertEquals(expectedY, actual.y, TOLERANCE)
+}
+
+class ClusterTests {
+
+    @Test
+    fun cluster_size_matchesD3() {
+        val layout = fixtureA().layoutWith(Cluster(width = 1f, height = 1f)).layoutByName()
+        assertPoint(0.55f, 0f, layout.getValue("root"))
+        assertPoint(0.3f, 0.5f, layout.getValue("a"))
+        assertPoint(0.8f, 0.5f, layout.getValue("b"))
+        assertPoint(0.2f, 1f, layout.getValue("a1"))
+        assertPoint(0.4f, 1f, layout.getValue("a2"))
+        assertPoint(0.8f, 1f, layout.getValue("b1"))
+    }
+
+    @Test
+    fun cluster_nodeSize_matchesD3() {
+        val layout = fixtureA().layoutWith(Cluster(width = 2f, height = 3f, nodeSize = true)).layoutByName()
+        assertPoint(0f, 0f, layout.getValue("root"))
+        assertPoint(-2.5f, 3f, layout.getValue("a"))
+        assertPoint(2.5f, 3f, layout.getValue("b"))
+        assertPoint(-3.5f, 6f, layout.getValue("a1"))
+        assertPoint(-1.5f, 6f, layout.getValue("a2"))
+        assertPoint(2.5f, 6f, layout.getValue("b1"))
+    }
+
+    @Test
+    fun cluster_unevenDepth_alignsLeavesToBottom() {
+        val layout = fixtureB().layoutWith(Cluster(width = 1f, height = 1f)).layoutByName()
+        assertPoint(0.5f, 0f, layout.getValue("root"))
+        assertPoint(0.25f, 0.333333f, layout.getValue("a"))
+        assertPoint(0.75f, 1f, layout.getValue("b"))
+        assertPoint(0.25f, 0.666667f, layout.getValue("a1"))
+        assertPoint(0.25f, 1f, layout.getValue("a1x"))
+    }
+}

--- a/hierarchy/src/commonTest/kotlin/pack/PackTests.kt
+++ b/hierarchy/src/commonTest/kotlin/pack/PackTests.kt
@@ -1,0 +1,72 @@
+package com.juul.krayon.hierarchy.pack
+
+import com.juul.krayon.hierarchy.Node
+import com.juul.krayon.hierarchy.fixtureWeighted
+import com.juul.krayon.hierarchy.layoutByName
+import com.juul.krayon.hierarchy.sum
+import com.juul.krayon.hierarchy.traversePreOrder
+import kotlin.math.sqrt
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+private const val TOLERANCE = 1e-3f
+
+private fun assertCircle(x: Float, y: Float, radius: Float, actual: Circle) {
+    assertEquals(x, actual.x, TOLERANCE)
+    assertEquals(y, actual.y, TOLERANCE)
+    assertEquals(radius, actual.radius, TOLERANCE)
+}
+
+class PackTests {
+
+    @Test
+    fun pack_size_matchesD3() {
+        val layout = fixtureWeighted().sum { it.value }
+            .layoutWith(Pack(width = 100f, height = 100f))
+            .layoutByName()
+        assertCircle(50f, 50f, 50f, layout.getValue("root"))
+        assertCircle(25.835198f, 49.372877f, 8.859644f, layout.getValue("a"))
+        assertCircle(47.224271f, 49.372877f, 12.529429f, layout.getValue("b"))
+        assertCircle(32.061995f, 72.763237f, 15.345354f, layout.getValue("c"))
+        assertCircle(31.654693f, 23.438862f, 17.719288f, layout.getValue("d"))
+        assertCircle(67.156709f, 74.840233f, 19.810767f, layout.getValue("e"))
+    }
+
+    @Test
+    fun pack_padding_matchesD3() {
+        val layout = fixtureWeighted().sum { it.value }
+            .layoutWith(Pack(width = 100f, height = 100f, padding = { 3f }))
+            .layoutByName()
+        assertCircle(50f, 50f, 50f, layout.getValue("root"))
+        assertCircle(25.635218f, 49.497577f, 7.910929f, layout.getValue("a"))
+        assertCircle(47.412643f, 49.497577f, 11.187744f, layout.getValue("b"))
+        assertCircle(32.622252f, 72.762863f, 13.702132f, layout.getValue("c"))
+        assertCircle(32.3033f, 23.941636f, 15.821859f, layout.getValue("d"))
+        assertCircle(66.647509f, 74.513431f, 17.689376f, layout.getValue("e"))
+    }
+
+    @Test
+    fun pack_childrenAreContainedWithinRoot() {
+        val root: Node<*, Circle> = fixtureWeighted().sum { it.value }
+            .layoutWith(Pack(width = 100f, height = 100f))
+        val enclosing = root.layout
+        root.traversePreOrder().forEach { node ->
+            val circle = node.layout
+            val distance = sqrt(
+                (circle.x - enclosing.x) * (circle.x - enclosing.x) +
+                    (circle.y - enclosing.y) * (circle.y - enclosing.y),
+            )
+            assertTrue(distance + circle.radius <= enclosing.radius + 1e-2f, "node ${'$'}circle escapes enclosing circle")
+        }
+    }
+
+    @Test
+    fun pack_leafRadiiScaleWithSqrtOfWeight() {
+        val layout = fixtureWeighted().sum { it.value }
+            .layoutWith(Pack(width = 100f, height = 100f))
+            .layoutByName()
+        val ratio = layout.getValue("e").radius / layout.getValue("a").radius
+        assertEquals(sqrt(5f) / sqrt(1f), ratio, 1e-2f)
+    }
+}

--- a/hierarchy/src/commonTest/kotlin/partition/PartitionTests.kt
+++ b/hierarchy/src/commonTest/kotlin/partition/PartitionTests.kt
@@ -1,0 +1,58 @@
+package com.juul.krayon.hierarchy.partition
+
+import com.juul.krayon.hierarchy.fixtureNested
+import com.juul.krayon.hierarchy.layoutByName
+import com.juul.krayon.hierarchy.sum
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+private const val TOLERANCE = 1e-4f
+
+private fun assertCell(x0: Float, y0: Float, x1: Float, y1: Float, actual: Cell) {
+    assertEquals(x0, actual.x0, TOLERANCE)
+    assertEquals(y0, actual.y0, TOLERANCE)
+    assertEquals(x1, actual.x1, TOLERANCE)
+    assertEquals(y1, actual.y1, TOLERANCE)
+}
+
+class PartitionTests {
+
+    @Test
+    fun partition_size_matchesD3() {
+        val layout = fixtureNested().sum { it.value }
+            .layoutWith(Partition(width = 6f, height = 4f))
+            .layoutByName()
+        assertCell(0f, 0f, 6f, 1.333333f, layout.getValue("root"))
+        assertCell(0f, 1.333333f, 3f, 2.666667f, layout.getValue("a"))
+        assertCell(3f, 1.333333f, 6f, 2.666667f, layout.getValue("b"))
+        assertCell(0f, 2.666667f, 1f, 4f, layout.getValue("a1"))
+        assertCell(1f, 2.666667f, 3f, 4f, layout.getValue("a2"))
+        assertCell(3f, 2.666667f, 6f, 4f, layout.getValue("b1"))
+    }
+
+    @Test
+    fun partition_padding_matchesD3() {
+        val layout = fixtureNested().sum { it.value }
+            .layoutWith(Partition(width = 6f, height = 4f, padding = 0.5f))
+            .layoutByName()
+        assertCell(0.5f, 0.5f, 5.5f, 0.833333f, layout.getValue("root"))
+        assertCell(0.5f, 1.333333f, 2.75f, 2.166667f, layout.getValue("a"))
+        assertCell(3.25f, 1.333333f, 5.5f, 2.166667f, layout.getValue("b"))
+        assertCell(0.5f, 2.666667f, 0.916667f, 3.5f, layout.getValue("a1"))
+        assertCell(1.416667f, 2.666667f, 2.75f, 3.5f, layout.getValue("a2"))
+        assertCell(3.25f, 2.666667f, 5.5f, 3.5f, layout.getValue("b1"))
+    }
+
+    @Test
+    fun partition_round_snapsToIntegers() {
+        val layout = fixtureNested().sum { it.value }
+            .layoutWith(Partition(width = 6f, height = 4f, round = true))
+            .layoutByName()
+        assertCell(0f, 0f, 6f, 1f, layout.getValue("root"))
+        assertCell(0f, 1f, 3f, 3f, layout.getValue("a"))
+        assertCell(3f, 1f, 6f, 3f, layout.getValue("b"))
+        assertCell(0f, 3f, 1f, 4f, layout.getValue("a1"))
+        assertCell(1f, 3f, 3f, 4f, layout.getValue("a2"))
+        assertCell(3f, 3f, 6f, 4f, layout.getValue("b1"))
+    }
+}

--- a/hierarchy/src/commonTest/kotlin/tree/TreeTests.kt
+++ b/hierarchy/src/commonTest/kotlin/tree/TreeTests.kt
@@ -1,0 +1,50 @@
+package com.juul.krayon.hierarchy.tree
+
+import com.juul.krayon.hierarchy.Point
+import com.juul.krayon.hierarchy.fixtureA
+import com.juul.krayon.hierarchy.fixtureB
+import com.juul.krayon.hierarchy.layoutByName
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+private const val TOLERANCE = 1e-4f
+
+private fun assertPoint(expectedX: Float, expectedY: Float, actual: Point) {
+    assertEquals(expectedX, actual.x, TOLERANCE)
+    assertEquals(expectedY, actual.y, TOLERANCE)
+}
+
+class TreeTests {
+
+    @Test
+    fun tree_size_matchesD3() {
+        val layout = fixtureA().layoutWith(Tree(width = 1f, height = 1f)).layoutByName()
+        assertPoint(0.55f, 0f, layout.getValue("root"))
+        assertPoint(0.3f, 0.5f, layout.getValue("a"))
+        assertPoint(0.8f, 0.5f, layout.getValue("b"))
+        assertPoint(0.2f, 1f, layout.getValue("a1"))
+        assertPoint(0.4f, 1f, layout.getValue("a2"))
+        assertPoint(0.8f, 1f, layout.getValue("b1"))
+    }
+
+    @Test
+    fun tree_nodeSize_matchesD3() {
+        val layout = fixtureA().layoutWith(Tree(width = 2f, height = 3f, nodeSize = true)).layoutByName()
+        assertPoint(0f, 0f, layout.getValue("root"))
+        assertPoint(-2.5f, 3f, layout.getValue("a"))
+        assertPoint(2.5f, 3f, layout.getValue("b"))
+        assertPoint(-3.5f, 6f, layout.getValue("a1"))
+        assertPoint(-1.5f, 6f, layout.getValue("a2"))
+        assertPoint(2.5f, 6f, layout.getValue("b1"))
+    }
+
+    @Test
+    fun tree_unevenDepth_alignsToDepth() {
+        val layout = fixtureB().layoutWith(Tree(width = 1f, height = 1f)).layoutByName()
+        assertPoint(0.5f, 0f, layout.getValue("root"))
+        assertPoint(0.25f, 0.333333f, layout.getValue("a"))
+        assertPoint(0.75f, 0.333333f, layout.getValue("b"))
+        assertPoint(0.25f, 0.666667f, layout.getValue("a1"))
+        assertPoint(0.25f, 1f, layout.getValue("a1x"))
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Expands the `hierarchy` module with the remaining `d3-hierarchy` layouts, following the existing generic-layout (`Node<T, L>`) style used by `treemap`. Only the `hierarchy` module is touched.

New capabilities:

- **tree** (`com.juul.krayon.hierarchy.tree`) — Reingold–Tilford "tidy" tree via Buchheim et al.'s linear-time algorithm. Configurable `size`/`nodeSize` and `separation`; attaches a `Point(x, y)` layout.
- **cluster** (`…hierarchy.cluster`) — dendrogram with leaves aligned at equal depth. `size`/`nodeSize`/`separation`; attaches `Point`.
- **pack** (`…hierarchy.pack`) — circle packing (front-chain sibling packing + Welzl enclosing circle). `radius`/`size`/`padding`; attaches `Circle(x, y, radius)`.
- **partition** (`…hierarchy.partition`) — icicle/sunburst rectangles. `size`/`padding`/`round`; attaches `Cell(x0, y0, x1, y1)`.
- **stratify** (`…hierarchy.stratify`) — builds a hierarchy from a flat list via `id`/`parentId` accessors, with validation (single root, missing/ambiguous parents, cycles).
- **Node helpers** — `leaves()`, `links()` (+ `Link`), `path(target)`, `descendants()`, `copy()`, added additively alongside existing traversals. A shared `Point` type is introduced for tree/cluster.

Layouts follow the treemap convention: a configurable layout class plus a `Node<T, *>.layoutWith(...)` extension that mutates and returns the same nodes with the layout attached.

## Notes

- **`Double` for pack geometry:** circle packing is ported using `Double` internally (public `Circle` remains `Float`). `Float` precision caused the Welzl enclose-basis search to fail (`Unable to extend enclosing basis`); `Double` also reproduces d3's exact coordinates.
- **`ancestors()` bug fix:** the existing `ancestors()` advanced the chain with `current = parent` (always the receiver's parent) instead of `current = current.parent`, yielding an infinite sequence for depth > 1. `path()` depends on a correct ancestor walk, so this one-line bug is fixed.
- **`count()` semantics:** Krayon's `count()` weights every node (not only leaves as d3 does), so partition/pack fixtures use `sum { value }` with explicit leaf weights, which is identical between Krayon and d3.

## Testing

Common tests (`kotlin.test`) verify each layout against exact `d3-hierarchy@3` values on small fixtures (tree/cluster coordinates, pack radii + containment, partition cells, stratify structure, node helpers).

- `./gradlew :hierarchy:jvmTest` — 24 tests pass.
- `./gradlew :hierarchy:lintKotlin` — clean.
- `./gradlew :hierarchy:jvmApiCheck :hierarchy:klibApiCheck` — pass; API dumps regenerated and committed.

> The sandbox lacks the Android SDK, so Android host tests / android API dumps could not be run here. The android API dump was kept in sync with the (identical) JVM dump.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-81248e6d-27c5-40d7-9476-e6f81cea25a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-81248e6d-27c5-40d7-9476-e6f81cea25a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

