### PR TITLE
Relax consumer Android SDK requirement

### DIFF
--- a/build-logic/src/main/kotlin/library-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/library-conventions.gradle.kts
@@ -22,6 +22,9 @@ kotlin {
         namespace = "com.juul.krayon.${project.name.replace("-", ".")}"
         compileSdk = libs.versions.android.compile.get().toInt()
         minSdk = libs.versions.android.min.get().toInt()
+        aarMetadata {
+            minCompileSdk = libs.versions.android.min.get().toInt()
+        }
 
         androidResources { enable = true }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Mirrors [JuulLabs/kable#1211](https://github.com/JuulLabs/kable/pull/1211) (see [JuulLabs/kable#1206](https://github.com/JuulLabs/kable/issues/1206)).

Under AGP 9, published AAR metadata defaults `minCompileSdk` to the library's `compileSdk` (currently 37), unintentionally requiring consumers to raise their Android compile SDK — and effectively requiring AGP 9.x — just to depend on Krayon.

This sets `aarMetadata.minCompileSdk` to `libs.versions.android.min` (23) in the shared `library-conventions` plugin, which applies to all published Krayon modules. The `sample` modules are not published, so no changes are needed there.

Verified by publishing `:core` to Maven Local and inspecting `META-INF/com/android/build/gradle/aar-metadata.properties` in the AAR:

- Before: `minCompileSdk=37`
- After: `minCompileSdk=23`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-30b882cb-886a-4ff0-9147-bba1bc0bec39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-30b882cb-886a-4ff0-9147-bba1bc0bec39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

